### PR TITLE
There needs to be a way to execute Rule CG0664

### DIFF
--- a/engine/enums/rule_types.py
+++ b/engine/enums/rule_types.py
@@ -8,6 +8,9 @@ class RuleTypes(BaseEnum):
     RANGE_CHECK = "Range & Limit"
     DATASET_METADATA_CHECK = "Dataset Metadata Check"
     DATASET_METADATA_CHECK_AGAINST_DEFINE = "Dataset Metadata Check against Define XML"
+    VARIABLE_ORDER_AGAINST_LIBRARY_METADATA_CHECK = (
+        "VARIABLE_ORDER_AGAINST_LIBRARY_METADATA_CHECK"
+    )
     VARIABLE_METADATA_CHECK_AGAINST_DEFINE = (
         "Variable Metadata Check against Define XML"
     )

--- a/engine/models/actions.py
+++ b/engine/models/actions.py
@@ -22,6 +22,7 @@ class COREActions(BaseActions):
         domain: str,
         rule: dict,
         value_level_metadata: list = None,
+        report_seq: bool = True,
     ):
         if value_level_metadata is None:
             value_level_metadata = []
@@ -31,6 +32,7 @@ class COREActions(BaseActions):
         self.domain = domain
         self.rule = rule
         self.value_level_metadata = value_level_metadata
+        self.report_seq = report_seq
 
     @rule_action(params={"message": FIELD_TEXT, "target": FIELD_TEXT})
     def generate_record_message(self, message, target=None):
@@ -148,7 +150,7 @@ class COREActions(BaseActions):
             if isinstance(usubjid, pd.Series)
             else None,
             sequence=int(sequence[df_row.name])
-            if isinstance(sequence, pd.Series)
+            if isinstance(sequence, pd.Series) and self.report_seq
             else None,
         )
         return error_object

--- a/engine/rules_engine.py
+++ b/engine/rules_engine.py
@@ -447,7 +447,9 @@ class RulesEngine:
         df_to_validate = pd.DataFrame()
         for index, col in enumerate(dataset):
             df_to_validate[col] = [index + 1]
-        return self.execute_rule(rule, df_to_validate, dataset_path, datasets, domain)
+        return self.execute_rule(
+            rule, df_to_validate, dataset_path, datasets, domain, report_seq=False
+        )
 
     def validate_variables_metadata(
         self, rule: dict, dataset_path: str, datasets: List[dict], domain: str, **kwargs
@@ -527,6 +529,7 @@ class RulesEngine:
         value_level_metadata: List[dict] = None,
         variable_codelist_map: dict = None,
         codelist_term_maps: list = None,
+        report_seq: bool = True,
     ) -> List[str]:
         """
         Executes the given rule on a given dataset.
@@ -578,6 +581,7 @@ class RulesEngine:
                 domain=domain,
                 rule=rule,
                 value_level_metadata=value_level_metadata,
+                report_seq=report_seq,
             ),
         )
         return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1319,6 +1319,36 @@ def rule_dataset_references_invalid_whodrug_terms() -> dict:
     }
 
 
+@pytest.fixture
+def rule_validate_columns_order_against_library_metadata() -> dict:
+    """
+    Rule that can be used to validate columns order against library metadata.
+    """
+    return {
+        "core_id": "MockRule",
+        "standards": [{"Name": "SDTMIG", "Version": "3.3"}],
+        "classes": {"Include": ["Events"]},
+        "domains": {"Include": ["AE"]},
+        "rule_type": RuleTypes.VARIABLE_ORDER_AGAINST_LIBRARY_METADATA_CHECK.value,
+        "conditions": ConditionCompositeFactory.get_condition_composite(
+            {
+                "any": [
+                    {
+                        "name": "get_dataset",
+                        "operator": "not_equal_to",
+                    },
+                ]
+            }
+        ),
+        "actions": [
+            {
+                "name": "generate_dataset_error_objects",
+                "params": {"message": "Order of variables is invalid"},
+            }
+        ],
+    }
+
+
 @pytest.fixture(scope="function")
 def installed_whodrug_dictionaries(request) -> dict:
     """

--- a/tests/unit/test_rules_engine.py
+++ b/tests/unit/test_rules_engine.py
@@ -2337,7 +2337,6 @@ def test_validate_variables_order(
             "errors": [
                 {
                     "row": 1,
-                    "seq": 2,
                     "value": {
                         "DOMAIN": 1,
                         "AESEQ": 2,


### PR DESCRIPTION
The idea of this PR is to make it possible validate the variables order against the library metadata. The suggested approach is to use a new rule type (implementing it as an operation might be too complex).

From the validation perspective the algorithm is:
1. Create a df that has one row and maps the column name to its order.
2. Expect that a rule contains only one condition holding the operator without a target and comparator.
3. Request metadata from the library knowing the dataset class and domain.
4. Create a list of rule conditions for each variable, use variable name as a target and "ordinal" as a comparator.
5. Validate the resulting rule against the df from step 1.