### PR TITLE
Add steps for building windows and linux distributions and releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
           pip install -r requirements.txt
       - name: Build Binary
         run: pyinstaller core.py --dist ./dist/output/linux --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: "core-linux"
+          path: dist/output/linux
   build-windows:
     runs-on: windows-latest
     steps:
@@ -38,6 +43,11 @@ jobs:
           pip install -r requirements.txt
       - name: Build Binary
         run: pyinstaller core.py --dist ./dist/output/windows --add-data=$pythonLocation/Lib/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates
+      - name: Archive Windows Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: "core-windows"
+          path: dist/output/windows
   deploy-package:
     runs-on: ubuntu-latest
     steps:
@@ -57,16 +67,6 @@ jobs:
       runs-on: ubuntu-latest
       needs: [build-linux, build-windows]
       steps:
-      - name: Archive Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: "core-linux"
-          path: dist/output/linux/*
-      - name: Archive Windows Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: "core-windows"
-          path: dist/output/windows/*
       - name: Release
         uses: softprops/action-gh-release@master
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This PR adds a workflow to release binaries for windows and linux and a python package.

The pipeline works as follows:
1. Build linux binary
2. Build windows binary
3. Deploy  package to PYPI
(Steps 1-3 are run in parallel)
4. Archive artifacts and upload them to github releases

It is difficult to test github actions locally, but I was able to ensure the build linux step was successful and the build windows step is similar, just on a different container image. Additional testing will need to be done for the archiving step