### PR TITLE
Lower required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["scripts", "tests"]),
     license="MIT",
     include_package_data=True,
-    python_requires=">=3.9",
+    python_requires=">=3.8",
     install_requires=[
         "pytest==7.1.2",
         "pandas==1.3.5",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.3.1",
+    version="0.3.2",
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",


### PR DESCRIPTION
The Azure version uses Python 3.8 whereas the setup.py states the required version is 3.9. This causes the issue with the package installation from PyPi:

```
ERROR: Ignored the following versions that require a different python version: 0.1.0 Requires-Python >=3.9; 0.2.0 Requires-Python >=3.9; 0.3.0 Requires-Python >=3.9; 0.3.1 Requires-Python >=3.9
ERROR: Could not find a version that satisfies the requirement cdisc-rules-engine==0.3.1 (from versions: none)
```
