### PR TITLE
Properly get dataset metadata from dummy dataset

### DIFF
--- a/cdisc_rules_engine/dummy_models/dummy_dataset.py
+++ b/cdisc_rules_engine/dummy_models/dummy_dataset.py
@@ -21,7 +21,7 @@ class DummyDataset:
     def get_metadata(self):
         return {
             "dataset_size": [self.filesize or 1000],
-            "dataset_name": [self.name or "test"],
+            "dataset_name": [self.domain or "test"],
             "dataset_label": [self.label or "test"],
         }
 

--- a/tests/unit/test_dummy_data_service.py
+++ b/tests/unit/test_dummy_data_service.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import pytest
 
 from cdisc_rules_engine.dummy_models.dummy_dataset import DummyDataset
 from cdisc_rules_engine.services.data_services import DummyDataService
@@ -86,7 +85,6 @@ def test_get_dataset():
 def test_get_dataset_metadata():
     dataset_data = [
         {
-            "name": "AE",
             "filesize": 2000,
             "filename": "ae.xpt",
             "label": "ADVERSE EVENTS",

--- a/tests/unit/test_dummy_dataset.py
+++ b/tests/unit/test_dummy_dataset.py
@@ -15,3 +15,32 @@ def test_invalid_dataset_data():
     ]
     with pytest.raises(InvalidDatasetFormat):
         DummyDataset(dataset_data)
+
+
+def test_valid_dataset_data():
+    dataset_data = [
+        {
+            "domain": "AE",
+            "filename": "ae.xpt",
+            "label": "Adverse Events",
+            "records": {"AESEQ": [1, 2, 3, 4]},
+        }
+    ]
+    dataset = DummyDataset(dataset_data[0])
+    assert dataset.domain == "AE"
+
+
+def test_get_dataset_metadata():
+    dataset_data = [
+        {
+            "domain": "AE",
+            "filename": "ae.xpt",
+            "label": "Adverse Events",
+            "records": {"AESEQ": [1, 2, 3, 4]},
+        }
+    ]
+    dataset = DummyDataset(dataset_data[0])
+    metadata = dataset.get_metadata()
+    assert "dataset_name" in metadata
+    assert metadata["dataset_name"] == ["AE"]
+    assert metadata["dataset_label"] == ["Adverse Events"]


### PR DESCRIPTION
This PR updates the dummy dataset to get the domain name properly, and return the correct metadata