### PR TITLE
Config and data service improvements

### DIFF
--- a/cdisc_rules_engine/config/config.py
+++ b/cdisc_rules_engine/config/config.py
@@ -2,10 +2,12 @@ import os
 
 from dotenv import load_dotenv
 
+from cdisc_rules_engine.interfaces import ConfigInterface
+
 load_dotenv()
 
 
-class ConfigService:
+class ConfigService(ConfigInterface):
 
     _config_keys = []
     _instance = None

--- a/cdisc_rules_engine/interfaces/__init__.py
+++ b/cdisc_rules_engine/interfaces/__init__.py
@@ -1,5 +1,6 @@
 from .cache_service_interface import CacheServiceInterface
 from .condition_interface import ConditionInterface
+from .config_interface import ConfigInterface
 from .data_reader_interface import DataReaderInterface
 from .data_service_interface import DataServiceInterface
 from .factory_interface import FactoryInterface
@@ -10,6 +11,7 @@ from .terms_factory_interface import TermsFactoryInterface
 __all__ = [
     "CacheServiceInterface",
     "ConditionInterface",
+    "ConfigInterface",
     "DataReaderInterface",
     "DataServiceInterface",
     "FactoryInterface",

--- a/cdisc_rules_engine/interfaces/config_interface.py
+++ b/cdisc_rules_engine/interfaces/config_interface.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+
+
+class ConfigInterface(ABC):
+    """
+    The interface defines a set of methods
+    that must be implemented by all custom configuration
+    classes.
+    """
+
+    @abstractmethod
+    def getValue(self, key: str, default=None):
+        """
+        Returns value of a configuration parameter.
+        """

--- a/cdisc_rules_engine/interfaces/data_service_interface.py
+++ b/cdisc_rules_engine/interfaces/data_service_interface.py
@@ -35,6 +35,12 @@ class DataServiceInterface(ABC):
         """
 
     @abstractmethod
+    def get_variables_metadata(self, dataset_name: str, **params) -> pd.DataFrame:
+        """
+        Gets variables metadata of a dataset.
+        """
+
+    @abstractmethod
     def get_dataset_by_type(
         self, dataset_name: str, dataset_type: str, **params
     ) -> pd.DataFrame:
@@ -48,6 +54,12 @@ class DataServiceInterface(ABC):
         """
         Accepts a list of split dataset filenames,
         downloads all of them and merges into a single DataFrame.
+        """
+
+    @abstractmethod
+    def get_define_xml_contents(self, dataset_name: str) -> bytes:
+        """
+        Returns contents of define.xml file.
         """
 
     @abstractmethod

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -29,10 +29,7 @@ from cdisc_rules_engine.models.validation_error_container import (
     ValidationErrorContainer,
 )
 from cdisc_rules_engine.services import logger
-from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
-from cdisc_rules_engine.services.cache.in_memory_cache_service import (
-    InMemoryCacheService,
-)
+from cdisc_rules_engine.services.cache import CacheServiceFactory, InMemoryCacheService
 from cdisc_rules_engine.services.data_services import DataServiceFactory
 from cdisc_rules_engine.services.define_xml_reader import DefineXMLReader
 from cdisc_rules_engine.utilities.data_processor import DataProcessor

--- a/cdisc_rules_engine/services/cache/redis_cache_service.py
+++ b/cdisc_rules_engine/services/cache/redis_cache_service.py
@@ -3,10 +3,10 @@ from typing import List
 
 import redis
 
-from cdisc_rules_engine.config import ConfigService
 from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.interfaces import (
     CacheServiceInterface,
+    ConfigInterface,
 )
 
 
@@ -14,7 +14,7 @@ class RedisCacheService(CacheServiceInterface):
     _instance = None
 
     @classmethod
-    def get_instance(cls, config: ConfigService, **kwargs):
+    def get_instance(cls, config: ConfigInterface, **kwargs):
         if cls._instance is None:
             instance = cls(
                 config.getValue("REDIS_HOST_NAME"), config.getValue("REDIS_ACCESS_KEY")

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Optional, Iterable
 import numpy as np
 import pandas as pd
 
+from cdisc_rules_engine.config import ConfigService
 from cdisc_rules_engine.constants.domains import AP_DOMAIN_LENGTH
 from cdisc_rules_engine.interfaces import DataServiceInterface, CacheServiceInterface
 from cdisc_rules_engine.models.dataset_types import DatasetTypes
@@ -67,10 +68,15 @@ class BaseDataService(DataServiceInterface, ABC):
     """
 
     def __init__(
-        self, cache_service: CacheServiceInterface, reader_factory: DataReaderFactory
+        self,
+        cache_service: CacheServiceInterface,
+        reader_factory: DataReaderFactory,
+        config: ConfigService,
+        **kwargs,
     ):
         self.cache_service = cache_service
-        self.reader_factory = reader_factory
+        self._reader_factory = reader_factory
+        self._config = config
 
     def get_dataset_by_type(
         self, dataset_name: str, dataset_type: str, **params
@@ -197,7 +203,7 @@ class BaseDataService(DataServiceInterface, ABC):
             lambda x: x.replace({np.nan: None})
         )
 
-    def _async_get_dataset(
+    async def _async_get_dataset(
         self, function_to_call: Callable, dataset_name: str, **kwargs
     ) -> pd.DataFrame:
         """

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -6,9 +6,12 @@ from typing import Callable, List, Optional, Iterable
 import numpy as np
 import pandas as pd
 
-from cdisc_rules_engine.config import ConfigService
 from cdisc_rules_engine.constants.domains import AP_DOMAIN_LENGTH
-from cdisc_rules_engine.interfaces import DataServiceInterface, CacheServiceInterface
+from cdisc_rules_engine.interfaces import (
+    CacheServiceInterface,
+    ConfigInterface,
+    DataServiceInterface,
+)
 from cdisc_rules_engine.models.dataset_types import DatasetTypes
 from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.services.data_readers import DataReaderFactory
@@ -71,7 +74,7 @@ class BaseDataService(DataServiceInterface, ABC):
         self,
         cache_service: CacheServiceInterface,
         reader_factory: DataReaderFactory,
-        config: ConfigService,
+        config: ConfigInterface,
         **kwargs,
     ):
         self.cache_service = cache_service

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -1,14 +1,16 @@
+import asyncio
 from abc import ABC
-from functools import wraps
-from typing import Callable, List, Optional
+from functools import wraps, partial
+from typing import Callable, List, Optional, Iterable
 
 import numpy as np
 import pandas as pd
 
 from cdisc_rules_engine.constants.domains import AP_DOMAIN_LENGTH
-from cdisc_rules_engine.interfaces import DataServiceInterface
+from cdisc_rules_engine.interfaces import DataServiceInterface, CacheServiceInterface
 from cdisc_rules_engine.models.dataset_types import DatasetTypes
 from cdisc_rules_engine.services import logger
+from cdisc_rules_engine.services.data_readers import DataReaderFactory
 from cdisc_rules_engine.utilities.utils import (
     get_dataset_cache_key_from_path,
     get_directory_path,
@@ -57,10 +59,66 @@ def cached_dataset(dataset_type: str):
 
 
 class BaseDataService(DataServiceInterface, ABC):
-    def __init__(self, **params):
-        self.blob_service = None
-        self.cache_service = None
-        self.reader_factory = None
+    """
+    An abstract base class for all data services that implement
+    data service interface. The class implements some methods
+    whose implementation stays the same regardless of the service.
+    It is not necessary to inherit from this class.
+    """
+
+    def __init__(
+        self, cache_service: CacheServiceInterface, reader_factory: DataReaderFactory
+    ):
+        self.cache_service = cache_service
+        self.reader_factory = reader_factory
+
+    def get_dataset_by_type(
+        self, dataset_name: str, dataset_type: str, **params
+    ) -> pd.DataFrame:
+        """
+        Generic function to return dataset based on the type.
+        dataset_type param can be: contents, metadata, variables_metadata.
+        """
+        dataset_type_to_function_map: dict = {
+            DatasetTypes.CONTENTS.value: self.get_dataset,
+            DatasetTypes.METADATA.value: self.get_dataset_metadata,
+            DatasetTypes.VARIABLES_METADATA.value: self.get_variables_metadata,
+        }
+        return dataset_type_to_function_map[dataset_type](
+            dataset_name=dataset_name, **params
+        )
+
+    def join_split_datasets(
+        self, func_to_call: Callable, dataset_names: List[str], **kwargs
+    ) -> pd.DataFrame:
+        """
+        Accepts a list of split dataset filenames, asynchronously downloads
+        all of them and merges into a single DataFrame.
+
+        function_to_call must accept dataset_name and kwargs
+        as input parameters and return pandas DataFrame.
+        """
+        # pop drop_duplicates param at the beginning to avoid passing it to func_to_call
+        drop_duplicates: bool = kwargs.pop("drop_duplicates", False)
+
+        # download datasets asynchronously
+        coroutines = [
+            self._async_get_dataset(func_to_call, name, **kwargs)
+            for name in dataset_names
+        ]
+        loop = asyncio.get_event_loop()
+        datasets: Iterable[pd.DataFrame] = loop.run_until_complete(
+            asyncio.gather(*coroutines)
+        )
+
+        # join datasets
+        joined_dataset: pd.DataFrame = pd.concat(
+            [dataset for dataset in datasets],
+            ignore_index=True,
+        )
+        if drop_duplicates:
+            joined_dataset.drop_duplicates()
+        return joined_dataset
 
     def get_dataset_class(
         self, dataset: pd.DataFrame, file_path: str, datasets: List[dict]
@@ -137,4 +195,15 @@ class BaseDataService(DataServiceInterface, ABC):
         numeric_columns = dataset.select_dtypes(include=np.number).columns
         dataset[numeric_columns] = dataset[numeric_columns].apply(
             lambda x: x.replace({np.nan: None})
+        )
+
+    def _async_get_dataset(
+        self, function_to_call: Callable, dataset_name: str, **kwargs
+    ) -> pd.DataFrame:
+        """
+        Asynchronously executes passed function_to_call.
+        """
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, partial(function_to_call, dataset_name=dataset_name, **kwargs)
         )

--- a/cdisc_rules_engine/services/data_services/data_service_factory.py
+++ b/cdisc_rules_engine/services/data_services/data_service_factory.py
@@ -1,9 +1,9 @@
 from typing import List, Type
 
-from cdisc_rules_engine.config import ConfigService
 from cdisc_rules_engine.dummy_models.dummy_dataset import DummyDataset
 from cdisc_rules_engine.interfaces import (
     CacheServiceInterface,
+    ConfigInterface,
     DataServiceInterface,
     FactoryInterface,
 )
@@ -14,7 +14,7 @@ from . import DummyDataService, LocalDataService
 class DataServiceFactory(FactoryInterface):
     _registered_services_map = {"local": LocalDataService, "dummy": DummyDataService}
 
-    def __init__(self, config: ConfigService, cache_service: CacheServiceInterface):
+    def __init__(self, config: ConfigInterface, cache_service: CacheServiceInterface):
         self.data_service_name = config.getValue("DATA_SERVICE_TYPE") or "local"
         self.config = config
         self.cache_service = cache_service

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -7,6 +7,7 @@ from cdisc_rules_engine.dummy_models.dummy_dataset import DummyDataset
 from cdisc_rules_engine.exceptions.custom_exceptions import DatasetNotFoundError
 from cdisc_rules_engine.interfaces import CacheServiceInterface
 from cdisc_rules_engine.models.dataset_types import DatasetTypes
+from cdisc_rules_engine.services.data_readers import DataReaderFactory
 from cdisc_rules_engine.services.data_services import BaseDataService
 
 
@@ -15,16 +16,26 @@ class DummyDataService(BaseDataService):
     The class returns datasets from provided mock data.
     """
 
-    def __init__(self, data: List[DummyDataset]):
-        self.data = data
-        super().__init__()
+    def __init__(
+        self,
+        cache_service: CacheServiceInterface,
+        reader_factory: DataReaderFactory,
+        config: ConfigService,
+        **kwargs,
+    ):
+        super(DummyDataService, self).__init__(cache_service, reader_factory, config)
+        self.data = kwargs.get("data")
 
     @classmethod
     def get_instance(
         cls, cache_service: CacheServiceInterface, config: ConfigService, **kwargs
     ):
-        data = kwargs.get("data")
-        return cls(data)
+        return cls(
+            cache_service=cache_service,
+            reader_factory=DataReaderFactory(),
+            config=config,
+            **kwargs,
+        )
 
     def check_dataset_exists(self, dataset_name):
         dataset_name = dataset_name.replace("/", "")
@@ -94,6 +105,9 @@ class DummyDataService(BaseDataService):
         return dataset_type_to_function_map[dataset_type](
             dataset_name=dataset_name, **params
         )
+
+    def get_define_xml_contents(self, dataset_name: str) -> bytes:
+        pass
 
     def has_all_files(self, prefix: str, file_names: List[str]) -> bool:
         return True

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -24,7 +24,7 @@ class DummyDataService(BaseDataService):
         **kwargs,
     ):
         super(DummyDataService, self).__init__(cache_service, reader_factory, config)
-        self.data = kwargs.get("data")
+        self.data: List[DummyDataset] = kwargs.get("data")
 
     @classmethod
     def get_instance(

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -2,10 +2,9 @@ from typing import List, Optional, Callable, TextIO
 
 import pandas as pd
 
-from cdisc_rules_engine.config import ConfigService
 from cdisc_rules_engine.dummy_models.dummy_dataset import DummyDataset
 from cdisc_rules_engine.exceptions.custom_exceptions import DatasetNotFoundError
-from cdisc_rules_engine.interfaces import CacheServiceInterface
+from cdisc_rules_engine.interfaces import CacheServiceInterface, ConfigInterface
 from cdisc_rules_engine.models.dataset_types import DatasetTypes
 from cdisc_rules_engine.services.data_readers import DataReaderFactory
 from cdisc_rules_engine.services.data_services import BaseDataService
@@ -20,7 +19,7 @@ class DummyDataService(BaseDataService):
         self,
         cache_service: CacheServiceInterface,
         reader_factory: DataReaderFactory,
-        config: ConfigService,
+        config: ConfigInterface,
         **kwargs,
     ):
         super(DummyDataService, self).__init__(cache_service, reader_factory, config)
@@ -28,7 +27,7 @@ class DummyDataService(BaseDataService):
 
     @classmethod
     def get_instance(
-        cls, cache_service: CacheServiceInterface, config: ConfigService, **kwargs
+        cls, cache_service: CacheServiceInterface, config: ConfigInterface, **kwargs
     ):
         return cls(
             cache_service=cache_service,

--- a/cdisc_rules_engine/services/data_services/local_data_service.py
+++ b/cdisc_rules_engine/services/data_services/local_data_service.py
@@ -25,11 +25,6 @@ from cdisc_rules_engine.config import ConfigService
 class LocalDataService(BaseDataService):
     _instance = None
 
-    def __init__(self, **params):
-        super(LocalDataService, self).__init__(**params)
-        self.cache_service = None
-        self.reader_factory = DataReaderFactory()
-
     @classmethod
     def get_instance(
         cls,
@@ -38,8 +33,12 @@ class LocalDataService(BaseDataService):
         **kwargs
     ):
         if cls._instance is None:
-            service = cls()
-            service.cache_service = cache_service
+            service = cls(
+                cache_service=cache_service,
+                reader_factory=DataReaderFactory(),
+                config=config,
+                **kwargs
+            )
             cls._instance = service
         return cls._instance
 
@@ -51,7 +50,7 @@ class LocalDataService(BaseDataService):
 
     @cached_dataset(DatasetTypes.CONTENTS.value)
     def get_dataset(self, dataset_name: str, **params) -> pandas.DataFrame:
-        reader = self.reader_factory.get_service()
+        reader = self._reader_factory.get_service()
         df = reader.from_file(dataset_name)
         self._replace_nans_in_numeric_cols_with_none(df)
         return df

--- a/cdisc_rules_engine/services/data_services/local_data_service.py
+++ b/cdisc_rules_engine/services/data_services/local_data_service.py
@@ -8,7 +8,7 @@ from cdisc_rules_engine.models.dataset_types import DatasetTypes
 from cdisc_rules_engine.models.variable_metadata_container import (
     VariableMetadataContainer,
 )
-from cdisc_rules_engine.interfaces import CacheServiceInterface
+from cdisc_rules_engine.interfaces import CacheServiceInterface, ConfigInterface
 from cdisc_rules_engine.services.data_readers.data_reader_factory import (
     DataReaderFactory,
 )
@@ -19,7 +19,6 @@ from cdisc_rules_engine.utilities.utils import (
 )
 
 from .base_data_service import BaseDataService, cached_dataset
-from cdisc_rules_engine.config import ConfigService
 
 
 class LocalDataService(BaseDataService):
@@ -29,7 +28,7 @@ class LocalDataService(BaseDataService):
     def get_instance(
         cls,
         cache_service: CacheServiceInterface,
-        config: ConfigService = None,
+        config: ConfigInterface = None,
         **kwargs
     ):
         if cls._instance is None:

--- a/cdisc_rules_engine/services/logging_service_factory.py
+++ b/cdisc_rules_engine/services/logging_service_factory.py
@@ -1,7 +1,7 @@
 import logging
 
-from cdisc_rules_engine.config import ConfigService
 from cdisc_rules_engine.constants import LOG_FORMAT
+from cdisc_rules_engine.interfaces import ConfigInterface
 
 logging.getLogger("asyncio").disabled = True
 logging.getLogger("xmlschema").disabled = True
@@ -11,7 +11,7 @@ class LoggingServiceFactory:
     _instance = None
 
     @classmethod
-    def get_logger(cls, config: ConfigService):
+    def get_logger(cls, config: ConfigInterface):
         # TODO: Expand this function as more logging services are available.
         if cls._instance is None:
             logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.3.6.3",
+    version="0.4.1",
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.4",
+    version="0.4.1",
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.4.1",
+    version="0.3.6.3",
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.3.6.4",  # TODO change to 0.4.1 before merging
+    version="0.4.1",
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.4.1",
+    version="0.3.6.4",  # TODO change to 0.4.1 before merging
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.4.1",
+    version="0.4.2",
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -1,5 +1,5 @@
 from typing import List
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import pandas as pd
 import pytest
@@ -35,7 +35,7 @@ from cdisc_rules_engine.utilities.utils import get_dataset_cache_key_from_path
 )
 def test_get_dataset_class(dataset, data, expected_class, filename):
     dataset = pd.DataFrame.from_dict(data)
-    data_service = LocalDataService()
+    data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     class_name = data_service.get_dataset_class(dataset, filename, dataset)
     assert class_name == expected_class
 
@@ -57,7 +57,7 @@ def test_get_dataset_class_associated_domains():
         return_value=ap_dataset,
         side_effect=lambda dataset_name: path_to_dataset_map[dataset_name],
     ):
-        data_service = LocalDataService()
+        data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
         filepath = f"{data_bundle_path}/ce.xpt"
         class_name = data_service.get_dataset_class(ap_dataset, filepath, datasets)
         assert class_name == "Events"

--- a/tests/unit/test_dataset_preprocessor.py
+++ b/tests/unit/test_dataset_preprocessor.py
@@ -27,8 +27,9 @@ def test_preprocess_no_datasets_in_rule(dataset_rule_equal_to_error_objects: dic
         }
     )
     datasets: List[dict] = [{"domain": "AE", "filename": "ae.xpt"}]
+    data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     preprocessor = DatasetPreprocessor(
-        dataset, "AE", "path", LocalDataService(), InMemoryCacheService()
+        dataset, "AE", "path", data_service, InMemoryCacheService()
     )
     preprocessed_dataset: pd.DataFrame = preprocessor.preprocess(
         dataset_rule_equal_to_error_objects, datasets
@@ -142,8 +143,10 @@ def test_preprocess(mock_get_dataset: MagicMock, dataset_rule_equal_to: dict):
         {"domain": "AE", "filename": "ae.xpt"},
         {"domain": "TS", "filename": "ts.xpt"},
     ]
+
+    data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     preprocessor = DatasetPreprocessor(
-        ec_dataset, "EC", "path/ec.xpt", LocalDataService(), InMemoryCacheService()
+        ec_dataset, "EC", "path/ec.xpt", data_service, InMemoryCacheService()
     )
     preprocessed_dataset: pd.DataFrame = preprocessor.preprocess(
         dataset_rule_equal_to, datasets
@@ -274,8 +277,10 @@ def test_preprocess_relationship_dataset(
             "filename": "suppec.xpt",
         },
     ]
+
+    data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     preprocessor = DatasetPreprocessor(
-        ec_dataset, "EC", "path/ec.xpt", LocalDataService(), InMemoryCacheService()
+        ec_dataset, "EC", "path/ec.xpt", data_service, InMemoryCacheService()
     )
     preprocessed_dataset: pd.DataFrame = preprocessor.preprocess(
         dataset_rule_record_in_parent_domain_equal_to, datasets
@@ -367,11 +372,13 @@ def test_preprocess_with_merge_comparison(
     mock_get_dataset.side_effect = lambda dataset_name: path_to_dataset_map[
         dataset_name
     ]
+
+    data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     preprocessor = DatasetPreprocessor(
         target_dataset,
         "EC",
         "study_id/data_bundle_id/ec.xpt",
-        LocalDataService(),
+        data_service,
         InMemoryCacheService(),
     )
     result: pd.DataFrame = preprocessor.preprocess(

--- a/tests/unit/test_dummy_data_service.py
+++ b/tests/unit/test_dummy_data_service.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import numpy as np
 import pandas as pd
 
@@ -46,7 +48,9 @@ def test_get_dataset():
         }
     ]
     datasets = [DummyDataset(dataset) for dataset in dataset_data]
-    data_service = DummyDataService(datasets)
+    data_service = DummyDataService(
+        MagicMock(), MagicMock(), MagicMock(), data=datasets
+    )
     dataset = data_service.get_dataset("ae.xpt")
     assert isinstance(dataset, pd.DataFrame)
     assert dataset["AESEQ"].to_list() == [
@@ -93,7 +97,9 @@ def test_get_dataset_metadata():
         }
     ]
     datasets = [DummyDataset(dataset) for dataset in dataset_data]
-    data_service = DummyDataService(datasets)
+    data_service = DummyDataService(
+        MagicMock(), MagicMock(), MagicMock(), data=datasets
+    )
     metadata = data_service.get_dataset_metadata("ae.xpt")
     assert isinstance(metadata, pd.DataFrame)
     assert metadata["dataset_label"].iloc[0] == "ADVERSE EVENTS"
@@ -121,7 +127,9 @@ def test_get_variables_metadata():
         }
     ]
     datasets = [DummyDataset(dataset) for dataset in dataset_data]
-    data_service = DummyDataService(datasets)
+    data_service = DummyDataService(
+        MagicMock(), MagicMock(), MagicMock(), data=datasets
+    )
     metadata = data_service.get_variables_metadata("/ae.xpt")
     assert isinstance(metadata, pd.DataFrame)
     assert metadata["variable_name"].iloc[0] == "AESEQ"

--- a/tests/unit/test_local_data_service.py
+++ b/tests/unit/test_local_data_service.py
@@ -12,7 +12,7 @@ def test_read_metadata():
     Unit test for read_data method.
     """
     dataset_path = f"{os.path.dirname(__file__)}/../resources/test_dataset.xpt"
-    data_service = LocalDataService()
+    data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     metadata = data_service.read_metadata(dataset_path)
     assert "file_metadata" in metadata
     assert metadata["file_metadata"].get("name") == "test_dataset.xpt"
@@ -36,7 +36,7 @@ def test_read_metadata():
 )
 def test_has_all_files(files, expected_result):
     directory = f"{os.path.dirname(__file__)}/../resources"
-    data_service = LocalDataService()
+    data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     assert data_service.has_all_files(directory, files) == expected_result
 
 


### PR DESCRIPTION
Recently I have been trying to extend the engine with a plugin that implements AWS data service and figured out that data service interface and base class can be improved in the following ways:

1. Some obligatory to implement methods like `get_variables_metadata` and `get_define_xml_contents` have not been listed in the interface. Added them.
2. Methods `join_split_datasets` and `get_dataset_by_type` do not really depend on the concrete implementation and can be the same for all concrete data services, so I have moved them to the base class.
3. `_async_get_dataset` was refactored to use asyncio instead of multithreading since we try to follow asyncio approach.

Besides, I have noticed a couple of things that can help make the engine configurable from outside:

1. Added `ConfigInterface` to remove the dependency from `ConfigService` class and allow external apps like plugins implement the configuration as they wish.
2. Parametrized `RulesEngine` class to accept config object that implements the interface.