### PR TITLE
Add rule-blocking issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/rule-blocking-bug.md
+++ b/.github/ISSUE_TEMPLATE/rule-blocking-bug.md
@@ -1,0 +1,35 @@
+---
+name: Rule-Blocking Bug
+about: For bug reports that block a rule
+title: 'Rule blocked: CORERULES-###'
+labels: bug
+assignees: ''
+
+---
+
+- Attach a .txt file with the JSON containing the full request. This can be copied from the Rule Editor under Test->Results->Request.
+- Replace the "###" in the issue title with the primary JIRA ticket number for the rule. 
+- Fill in the following information
+
+**Links to related JIRA Tickets**
+- https://jira.cdisc.org/projects/CORERULES/issues/CORERULES-
+- https://jira.cdisc.org/projects/CORERULES/issues/CORERULES-
+
+**Rule Information**
+- **Standard**:
+- **Rule ID**:
+- **Rule Description**:
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Error returned from Rule Engine**
+```json
+Replace this with the contents from the Rule Editor under Test->Results->Result. If there are no results, provide the error message
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/rule-blocking-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/rule-blocking-enhancement.md
@@ -1,0 +1,35 @@
+---
+name: Rule-Blocking Enhancement
+about: For feature requests that block a rule
+title: 'Rule blocked: CORERULES-###'
+labels: enhancement
+assignees: ''
+
+---
+
+- Attach test dataset files that can be used to test the new feature
+- Replace the "###" in the issue title with the primary JIRA ticket number for the rule. 
+- Fill in the following information
+
+**Links to related JIRA Tickets**
+- https://jira.cdisc.org/projects/CORERULES/issues/CORERULES-
+- https://jira.cdisc.org/projects/CORERULES/issues/CORERULES-
+
+**Rule Information**
+- **Standard**:
+- **Rule ID**:
+- **Rule Description**:
+
+**Describe the problem**
+A clear and concise description of the problem.
+
+**Describe the solution**
+A clear and concise description of how this problem could be solved.
+
+**Proposed rule logic**
+```yaml
+Give an example of how the new solution could be written as a rule
+```
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem and solution.

--- a/.github/ISSUE_TEMPLATE/rule-blocking-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/rule-blocking-enhancement.md
@@ -28,7 +28,7 @@ A clear and concise description of how this problem could be solved.
 
 **Proposed rule logic**
 ```yaml
-Give an example of how the new solution could be written as a rule
+Replace this with an example of how the new solution could be written as a rule
 ```
 
 **Screenshots**


### PR DESCRIPTION
These templates are intended to assist the Rule Authors in submitting new bugs or feature requests when their rules are blocked.