### PR TITLE
Updates to DY operation

### DIFF
--- a/cdisc_rules_engine/operations/day_data_validator.py
+++ b/cdisc_rules_engine/operations/day_data_validator.py
@@ -1,16 +1,40 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 from datetime import datetime
+import numpy as np
 
 
 class DayDataValidator(BaseOperation):
     def _execute_operation(self):
-        dtc_value = self.params.dataframe[self.params.target].map(
-            datetime.fromisoformat
-        )
-        rfstdtc_value = self.params.dataframe["RFSTDTC"].map(datetime.fromisoformat)
+        dtc_value = self.params.dataframe[self.params.target].map(self.parse_timestamp)
 
-        # + 1 if --DTC is on or after RFSTDTC
-        delta = (dtc_value - rfstdtc_value).map(
-            lambda x: x.days if x.days < 0 else x.days + 1
-        )
-        return delta
+        # Always get RFSTDTC column from DM dataset.
+        dm_datasets = [
+            dataset for dataset in self.params.datasets if dataset["domain"] == "DM"
+        ]
+        if not dm_datasets:
+            # Return none for all values if dm is not provided.
+            return [0] * len(self.params.dataframe[self.params.target])
+        if len(dm_datasets) > 1:
+            files = [dataset["filename"] for dataset in dm_datasets]
+            dm_data = self.data_service.join_split_datasets(files)
+        else:
+            dm_data = self.data_service.get_dataset(dm_datasets[0]["filename"])
+
+        rfstdtc_value = dm_data["RFSTDTC"].map(self.parse_timestamp)
+
+        delta = (dtc_value - rfstdtc_value).map(self.get_day_difference)
+        return delta.replace(np.nan, 0)
+
+    def parse_timestamp(self, timestamp: str) -> datetime:
+        try:
+            return datetime.fromisoformat(timestamp)
+        except TypeError:
+            # Null date time
+            return None
+        except ValueError:
+            # Value is not iso format
+            return None
+
+    def get_day_difference(self, delta: datetime) -> int:
+        # Return 1 if the --DTC value is the same as the DY
+        return delta.days if delta.days < 0 else delta.days + 1

--- a/tests/unit/test_operations/test_day_data_validtor.py
+++ b/tests/unit/test_operations/test_day_data_validtor.py
@@ -1,0 +1,62 @@
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.operations.day_data_validator import DayDataValidator
+from cdisc_rules_engine.models.operation_params import OperationParams
+import pandas as pd
+import pytest
+
+from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            pd.DataFrame.from_dict(
+                {
+                    "values": [
+                        "1997-07-19T19:20:30",
+                        "1997-08-16T19:20:30",
+                        "1997-07-16T19:20",
+                        "2022-05-20T13:44",
+                        "2022-05-20T13:44",
+                        None,
+                    ]
+                }
+            ),
+            [4, 32, 1, 13, 0, 0],
+        ),
+    ],
+)
+def test_minimum(data, expected, mock_data_service, operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    datasets_map = {
+        "dm.xpt": pd.DataFrame.from_dict(
+            {
+                "RFSTDTC": [
+                    "1997-07-16T19:20:30",
+                    "1997-07-16T19:20:30",
+                    "1997-07-16T19:20",
+                    "2022-05-08T13:44",
+                    "TEST",
+                    "2022-05-20T13:44",
+                ]
+            }
+        )
+    }
+    datasets = [
+        {"domain": "DM", "filename": "dm.xpt"},
+    ]
+    mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
+        name.split("/")[-1]
+    )
+    operation_params.datasets = datasets
+    operation_params.dataframe = data
+    operation_params.target = "values"
+    result = DayDataValidator(
+        operation_params, pd.DataFrame(), cache, mock_data_service
+    ).execute()
+    print(result)
+    assert operation_params.operation_id in result
+    for i, val in enumerate(result[operation_params.operation_id]):
+        assert val == expected[i]


### PR DESCRIPTION
This PR updates the DY operation to apply the following logic:
Get the RFSTDTC values from DM
Get the date portion of whatever DTC variable is given to the operation
Calculate Study Day: --DY = (date portion of --DTC) - (date portion of RFSTDTC) + 1 if --DTC is on or after RFSTDTC, --DY = (date portion of --DTC) - (date portion of RFSTDTC) if --DTC precedes RFSTDTC.

note: This function returns 0 for invalid dates instead of None to support operations comparing an integer to the result of this operation.