### PR TITLE
Cross Domain Variable Presence

### DIFF
--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -29,6 +29,7 @@ from cdisc_rules_engine.operations.whodrug_references_validator import (
     WhodrugReferencesValidator,
 )
 from cdisc_rules_engine.operations.variable_permissibility import VariablePermissibility
+from cdisc_rules_engine.operations.variable_count import VariableCount
 
 
 class OperationsFactory(FactoryInterface):
@@ -52,6 +53,7 @@ class OperationsFactory(FactoryInterface):
         "variable_names": VariableNames,
         "variable_permissibilities": VariablePermissibility,
         "variable_value_count": VariableValueCount,
+        "variable_count": VariableCount,
     }
 
     @classmethod

--- a/cdisc_rules_engine/operations/variable_count.py
+++ b/cdisc_rules_engine/operations/variable_count.py
@@ -1,0 +1,44 @@
+import pandas as pd
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+import asyncio
+from collections import Counter
+from typing import List, Set
+
+
+class VariableCount(BaseOperation):
+    """
+    Counts the number of times the value of the target
+    column appears as a variable in the study.
+    """
+
+    def _execute_operation(self):
+        # get metadata
+        variable_count = asyncio.run(self._get_all_study_variable_counts())
+        return variable_count
+
+    async def _get_all_study_variable_counts(self) -> dict:
+        """
+        Returns a mapping of target values to the number
+        of times that value appears as a variable in the study.
+        """
+        datasets_with_unique_domains = list(
+            {dataset["domain"]: dataset for dataset in self.params.datasets}.values()
+        )
+        target_variable = self.params.target.replace("--", self.params.domain, 1)
+        values = set(self.params.dataframe[target_variable].unique())
+        coroutines = [
+            self._get_dataset_variable_count(dataset, values)
+            for dataset in datasets_with_unique_domains
+        ]
+        dataset_variable_value_counts: List[Counter] = await asyncio.gather(*coroutines)
+        counts = dict(sum(dataset_variable_value_counts, Counter()))
+        return self.params.dataframe[target_variable].map(counts)
+
+    async def _get_dataset_variable_count(
+        self, dataset: dict, values: Set[str]
+    ) -> Counter:
+        data: pd.DataFrame = self.data_service.get_dataset(
+            f"{self.params.directory_path}/{dataset.get('filename')}"
+        )
+        column_value_intersection = values and set(data.columns)
+        return Counter(column_value_intersection)

--- a/tests/unit/test_operations/test_variable_count.py
+++ b/tests/unit/test_operations/test_variable_count.py
@@ -1,0 +1,46 @@
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.operations.variable_count import VariableCount
+from cdisc_rules_engine.models.operation_params import OperationParams
+import pandas as pd
+from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+
+
+def test_variable_count(mock_data_service, operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    dataset_path = "study/bundle/blah"
+    datasets_map = {
+        "AE": pd.DataFrame.from_dict(
+            {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
+        ),
+        "EX": pd.DataFrame.from_dict(
+            {"STUDYID": [4, 8, 12], "EXSEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
+        ),
+        "AE2": pd.DataFrame.from_dict(
+            {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
+        ),
+        "RELREC": pd.DataFrame.from_dict({"LNKGRP": ["DOMAIN", "EXSEQ", "AESEQ"]}),
+    }
+
+    datasets = [
+        {"domain": "AE", "filename": "AE"},
+        {"domain": "EX", "filename": "EX"},
+        {"domain": "AE", "filename": "AE2"},
+        {"domain": "RELREC", "filename": "RELREC"},
+    ]
+    mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
+        name.split("/")[-1]
+    )
+    mock_data_service.join_split_datasets.side_effect = lambda func, files: pd.concat(
+        [func(f) for f in files]
+    )
+    operation_params.domain = "RELREC"
+    operation_params.dataframe = datasets_map["RELREC"]
+    operation_params.datasets = datasets
+    operation_params.target = "LNKGRP"
+    operation_params.dataset_path = dataset_path
+    result = VariableCount(
+        operation_params, pd.DataFrame(), cache, mock_data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    assert result[operation_params.operation_id].equals(pd.Series([2, 1, 1]))

--- a/tests/unit/test_operations/test_variable_count.py
+++ b/tests/unit/test_operations/test_variable_count.py
@@ -3,9 +3,16 @@ from cdisc_rules_engine.operations.variable_count import VariableCount
 from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+import pytest
 
 
-def test_variable_count(mock_data_service, operation_params: OperationParams):
+@pytest.mark.parametrize(
+    "target, expected",
+    [("DOMAIN", 2), ("--SEQ", 2), ("SPECIALVAR", 1)],
+)
+def test_variable_count(
+    target, expected, mock_data_service, operation_params: OperationParams
+):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     dataset_path = "study/bundle/blah"
@@ -14,7 +21,12 @@ def test_variable_count(mock_data_service, operation_params: OperationParams):
             {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
         ),
         "EX": pd.DataFrame.from_dict(
-            {"STUDYID": [4, 8, 12], "EXSEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
+            {
+                "STUDYID": [4, 8, 12],
+                "EXSEQ": [1, 2, 3],
+                "DOMAIN": [12, 6, 1],
+                "SPECIALVAR": ["A", "B", "C"],
+            }
         ),
         "AE2": pd.DataFrame.from_dict(
             {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
@@ -26,7 +38,6 @@ def test_variable_count(mock_data_service, operation_params: OperationParams):
         {"domain": "AE", "filename": "AE"},
         {"domain": "EX", "filename": "EX"},
         {"domain": "AE", "filename": "AE2"},
-        {"domain": "RELREC", "filename": "RELREC"},
     ]
     mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
         name.split("/")[-1]
@@ -34,13 +45,12 @@ def test_variable_count(mock_data_service, operation_params: OperationParams):
     mock_data_service.join_split_datasets.side_effect = lambda func, files: pd.concat(
         [func(f) for f in files]
     )
-    operation_params.domain = "RELREC"
-    operation_params.dataframe = datasets_map["RELREC"]
     operation_params.datasets = datasets
-    operation_params.target = "LNKGRP"
+    operation_params.target = target
     operation_params.dataset_path = dataset_path
     result = VariableCount(
         operation_params, pd.DataFrame(), cache, mock_data_service
     ).execute()
     assert operation_params.operation_id in result
-    assert result[operation_params.operation_id].equals(pd.Series([2, 1, 1]))
+    for val in result[operation_params.operation_id]:
+        assert val == expected


### PR DESCRIPTION
This PR creates a new operator "variable_count" which counts the number of times a value in the target column of the target dataset appears as a variable in the study. For example if there is a LNKGRP column with values like ["DOMAIN", "AESEQ", ...] The operator will return a series containing the number of times each value appears in the study