### PR TITLE
Add -r argument for selecting individual rules to run

### DIFF
--- a/cdisc_rules_engine/interfaces/cache_service_interface.py
+++ b/cdisc_rules_engine/interfaces/cache_service_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Iterable
+from typing import Iterable, List
 
 
 class CacheServiceInterface(ABC):
@@ -29,6 +29,9 @@ class CacheServiceInterface(ABC):
         raise NotImplementedError
 
     def get(self, cache_key):
+        raise NotImplementedError
+
+    def get_all(self, cache_keys: List[str]):
         raise NotImplementedError
 
     def get_all_by_prefix(self, prefix):

--- a/cdisc_rules_engine/models/validation_args.py
+++ b/cdisc_rules_engine/models/validation_args.py
@@ -18,5 +18,6 @@ Validation_args = namedtuple(
         "whodrug",
         "meddra",
         "disable_progressbar",
+        "rules",
     ],
 )

--- a/cdisc_rules_engine/services/cache/in_memory_cache_service.py
+++ b/cdisc_rules_engine/services/cache/in_memory_cache_service.py
@@ -38,6 +38,9 @@ class InMemoryCacheService(CacheServiceInterface):
     def get(self, cache_key):
         return self.cache.get(cache_key, None)
 
+    def get_all(self, cache_keys: List[str]):
+        return [self.cache.get(key) for key in cache_keys]
+
     def get_all_by_prefix(self, prefix):
         items = []
         for key in self.cache:

--- a/cdisc_rules_engine/services/cache/redis_cache_service.py
+++ b/cdisc_rules_engine/services/cache/redis_cache_service.py
@@ -60,9 +60,14 @@ class RedisCacheService(CacheServiceInterface):
         else:
             return None
 
+    def get_all(self, cache_keys: List[str]):
+        return [
+            pickle.loads(cached_data) for cached_data in self.client.mget(cache_keys)
+        ]
+
     def get_all_by_prefix(self, prefix):
         keys = [key for key in self.client.scan_iter(match=f"{prefix}*")]
-        return [pickle.loads(cached_data) for cached_data in self.client.mget(keys)]
+        return self.get_all(keys)
 
     def exists(self, cache_key):
         return self.client.exists(cache_key)

--- a/core.py
+++ b/core.py
@@ -42,7 +42,7 @@ def cli():
     "-l",
     "--log-level",
     default="disabled",
-    type=click.Choice(["info", "debug", "error", "critical", "disabled"]),
+    type=click.Choice(["info", "debug", "error", "critical", "disabled", "warn"]),
     help="Sets log level for engine logs, logs are disabled by default",
 )
 @click.option(

--- a/core.py
+++ b/core.py
@@ -103,6 +103,7 @@ def cli():
     show_default=True,
     help="Disable progress bar",
 )
+@click.option("--rules", "-r", multiple=True)
 @click.pass_context
 def validate(
     ctx,
@@ -121,6 +122,7 @@ def validate(
     whodrug,
     meddra,
     disable_progressbar,
+    rules,
 ):
     """
     Validate data using CDISC Rules Engine
@@ -153,6 +155,7 @@ def validate(
             whodrug,
             meddra,
             disable_progressbar,
+            rules,
         )
     )
 

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -7,7 +7,7 @@ import click
 from functools import partial
 from multiprocessing import Pool
 from multiprocessing.managers import SyncManager
-
+from typing import List
 from cdisc_rules_engine.config import config
 from cdisc_rules_engine.constants.define_xml_constants import DEFINE_XML_FILE_NAME
 from cdisc_rules_engine.interfaces import CacheServiceInterface, DataServiceInterface
@@ -119,6 +119,7 @@ def set_log_level(level: str):
         "debug": logging.DEBUG,
         "error": logging.ERROR,
         "critical": logging.CRITICAL,
+        "warn": logging.WARNING,
     }
 
     if level == "disabled":
@@ -137,6 +138,24 @@ def get_cache_service(manager):
         return manager.InMemoryCacheService()
 
 
+def get_rules(cache: CacheServiceInterface, args) -> List[dict]:
+    if args.rules:
+        keys = [
+            get_rules_cache_key(args.standard, args.version.replace(".", "-"), rule)
+            for rule in args.rules
+        ]
+        rules = cache.get_all(keys)
+    else:
+        engine_logger.warn(
+            f"No rules specified. Running all rules for {args.standard}"
+            + f" version {args.version}"
+        )
+        rules = cache.get_all_by_prefix(
+            get_rules_cache_key(args.standard, args.version.replace(".", "-"))
+        )
+    return rules
+
+
 def run_validation(args: Validation_args):
     set_log_level(args.log_level.lower())
     cache_path: str = f"{os.path.dirname(__file__)}/../{args.cache}"
@@ -152,26 +171,12 @@ def run_validation(args: Validation_args):
 
     # install dictionaries if needed
     fill_cache_with_dictionaries(shared_cache, args)
-    rules = [
-        shared_cache.get(
-            get_rules_cache_key(args.standard, args.version.replace(".", "-"), rule)
-        )
-        for rule in args.rules
-    ]
-    if not args.rules:
-        engine_logger.info(
-            f"No rules specified. Running all rules for {args.standard} \
-                version {args.version}"
-        )
-        rules = shared_cache.get_all_by_prefix(
-            get_rules_cache_key(args.standard, args.version.replace(".", "-"))
-        )
+    rules = get_rules(shared_cache, args)
     data_service = DataServiceFactory(config, shared_cache).get_data_service()
     datasets = get_datasets(data_service, data_path)
 
     start = time.time()
     results = []
-
     # run each rule in a separate process
     with Pool(args.pool_size) as pool:
         if args.disable_progressbar is True:


### PR DESCRIPTION
This PR adds the -r flag for specifying individual rules to run:

`python core.py validate -d XPT/ -s sdtmig -v 3-4 -l info -r CDISC.SDTMIG.CG0344`

The -r flag can be used more than once to specify multiple rules