### PR TITLE
Set log level for each validation process

### DIFF
--- a/cdisc_rules_engine/services/logging/console_logger.py
+++ b/cdisc_rules_engine/services/logging/console_logger.py
@@ -28,7 +28,7 @@ class ConsoleLogger(LoggerInterface):
             "error": logging.ERROR,
             "critical": logging.CRITICAL,
             "warn": logging.WARNING,
-            "verbose": 100,
+            "verbose": logging.CRITICAL + 1,
         }
         self._logger.setLevel(levels.get(level, logging.ERROR))
 
@@ -51,4 +51,4 @@ class ConsoleLogger(LoggerInterface):
         self._logger.critical(msg, *args, **kwargs)
 
     def log(self, msg: str, *args, **kwargs):
-        self._logger.log(100, msg, *args, **kwargs)
+        self._logger.log(logging.CRITICAL + 1, msg, *args, **kwargs)

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -43,6 +43,7 @@ def validate_single_rule(cache, datasets, args, rule: dict = None):
     rule["conditions"] = ConditionCompositeFactory.get_condition_composite(
         rule["conditions"]
     )
+    set_log_level(args)
     # call rule engine
     engine = RulesEngine(
         cache=cache,
@@ -118,12 +119,13 @@ def get_datasets(
 
 
 def set_log_level(args):
-    if args.verbose_output:
-        engine_logger.setLevel("verbose")
-    elif args.log_level.lower() == "disabled":
+    if args.log_level.lower() == "disabled":
         engine_logger.disabled = True
     else:
         engine_logger.setLevel(args.log_level.lower())
+    if args.verbose_output:
+        engine_logger.disabled = False
+        engine_logger.setLevel("verbose")
 
 
 def get_cache_service(manager):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.5",
+    version="0.5.1",
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",


### PR DESCRIPTION
In windows each validation process gets its own logger. We were previously only setting the log level for the first process. This PR updates the logger to set log level for each validation.