### PR TITLE
Parametrize progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ From the root of the project run the following command:
 Clone the repository and run `core.py --help` to see the full list of commands.
 
 Run `core.py validate --help` to see the list of validation options.
-
 ```
   -ca, --cache TEXT               Relative path to cache files containing pre
                                   loaded metadata and rules
@@ -57,8 +56,12 @@ Run `core.py validate --help` to see the list of validation options.
   -r, --rules TEXT
   -vo, --verbose-output           Specify this option to print rules as they
                                   are completed
+  -p, --progress [bar|disabled|percents]
+                                  Defines how to display the validation
+                                  progress. By default a progress bar like
+                                  "[████████████████████████████--------]
+                                  78%"is printed.
   --help                          Show this message and exit.
-
 ```
 
 #### Validate folder

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Run `core.py validate --help` to see the list of validation options.
                                   files
   --meddra TEXT                   Path to directory with MedDRA dictionary
                                   files
-  --disable-progressbar           Disable progress bar
   -r, --rules TEXT
   -vo, --verbose-output           Specify this option to print rules as they
                                   are completed

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Run `core.py validate --help` to see the list of validation options.
   -r, --rules TEXT
   -vo, --verbose-output           Specify this option to print rules as they
                                   are completed
-  -p, --progress [bar|disabled|percents]
+  -p, --progress [verbose_output|disabled|percents|bar]
                                   Defines how to display the validation
                                   progress. By default a progress bar like
                                   "[████████████████████████████--------]

--- a/cdisc_rules_engine/enums/progress_parameter_options.py
+++ b/cdisc_rules_engine/enums/progress_parameter_options.py
@@ -5,3 +5,4 @@ class ProgressParameterOptions(BaseEnum):
     BAR = "bar"
     PERCENTS = "percents"
     DISABLED = "disabled"
+    VERBOSE_OUTPUT = "verbose_output"

--- a/cdisc_rules_engine/enums/progress_parameter_options.py
+++ b/cdisc_rules_engine/enums/progress_parameter_options.py
@@ -1,0 +1,7 @@
+from .base_enum import BaseEnum
+
+
+class ProgressParameterOptions(BaseEnum):
+    BAR = "bar"
+    PERCENTS = "percents"
+    DISABLED = "disabled"

--- a/cdisc_rules_engine/models/validation_args.py
+++ b/cdisc_rules_engine/models/validation_args.py
@@ -17,7 +17,6 @@ Validation_args = namedtuple(
         "define_version",
         "whodrug",
         "meddra",
-        "disable_progressbar",
         "rules",
         "verbose_output",
         "progress",

--- a/cdisc_rules_engine/models/validation_args.py
+++ b/cdisc_rules_engine/models/validation_args.py
@@ -20,5 +20,6 @@ Validation_args = namedtuple(
         "disable_progressbar",
         "rules",
         "verbose_output",
+        "progress",
     ],
 )

--- a/cdisc_rules_engine/models/validation_args.py
+++ b/cdisc_rules_engine/models/validation_args.py
@@ -18,7 +18,6 @@ Validation_args = namedtuple(
         "whodrug",
         "meddra",
         "rules",
-        "verbose_output",
         "progress",
     ],
 )

--- a/cdisc_rules_engine/utilities/progress_displayers.py
+++ b/cdisc_rules_engine/utilities/progress_displayers.py
@@ -1,0 +1,78 @@
+import sys
+from typing import List, Iterable, Callable, Dict
+
+import click
+
+from cdisc_rules_engine.enums.progress_parameter_options import ProgressParameterOptions
+from cdisc_rules_engine.models.rule_validation_result import RuleValidationResult
+from cdisc_rules_engine.models.validation_args import Validation_args
+
+
+def _disabled_progress_displayer(
+    rules: List[dict],
+    validation_results: Iterable[RuleValidationResult],
+    results: List[RuleValidationResult],
+) -> List[RuleValidationResult]:
+    """
+    Doesn't display any progress.
+    """
+    for rule_result in validation_results:
+        results.append(rule_result)
+    return results
+
+
+def _percents_progress_displayer(
+    rules: List[dict],
+    validation_results: Iterable[RuleValidationResult],
+    results: List[RuleValidationResult],
+) -> List[RuleValidationResult]:
+    """
+    Prints validation progress like:
+    5
+    8
+    10
+    ...
+    """
+    counter = 0
+    rules_len = len(rules)
+    for rule_result in validation_results:
+        counter += 1
+        current_progress: int = int(counter / rules_len * 100)
+        sys.stdout.write(f"{current_progress}\n")
+        sys.stdout.flush()
+        results.append(rule_result)
+    return results
+
+
+def _bar_progress_displayer(
+    rules: List[dict],
+    validation_results: Iterable[RuleValidationResult],
+    results: List[RuleValidationResult],
+) -> List[RuleValidationResult]:
+    """
+    Prints a progress bar like:
+    [████████████████████████████--------]   78%
+    """
+    with click.progressbar(
+        length=len(rules),
+        fill_char=click.style("\u2588", fg="green"),
+        empty_char=click.style("-", fg="white", dim=True),
+        show_eta=False,
+    ) as bar:
+        for rule_result in validation_results:
+            results.append(rule_result)
+            bar.update(1)
+    return results
+
+
+def get_progress_displayer(args: Validation_args) -> Callable:
+    """
+    Returns corresponding progress handler (bar, percents or disabled)
+    based on the input parameters.
+    By default, a progress bar is returned.
+    """
+    handlers_map: Dict[str, Callable] = {
+        ProgressParameterOptions.DISABLED.value: _disabled_progress_displayer,
+        ProgressParameterOptions.PERCENTS.value: _percents_progress_displayer,
+    }
+    return handlers_map.get(args.progress, _bar_progress_displayer)

--- a/core.py
+++ b/core.py
@@ -128,6 +128,23 @@ def cli():
     default=False,
     help="Specify this option to print rules as they are completed",
 )
+@click.option(
+    "-p",
+    "--progress",
+    default="bar",
+    type=click.Choice(
+        [
+            "bar",
+            "percents",
+            "disabled",
+        ]
+    ),
+    help=(
+        "Defines how to display the validation progress. "
+        'By default a progress bar like "[████████████████████████████--------]   78%"'
+        "is printed."
+    ),
+)
 @click.pass_context
 def validate(
     ctx,
@@ -149,6 +166,7 @@ def validate(
     disable_progressbar: bool,
     rules: Tuple[str],
     verbose_output: bool,
+    progress: str,
 ):
     """
     Validate data using CDISC Rules Engine

--- a/core.py
+++ b/core.py
@@ -114,13 +114,6 @@ def cli():
 )
 @click.option("--whodrug", help="Path to directory with WHODrug dictionary files")
 @click.option("--meddra", help="Path to directory with MedDRA dictionary files")
-@click.option(
-    "--disable-progressbar",
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help="Disable progress bar",
-)
 @click.option("--rules", "-r", multiple=True)
 @click.option(
     "-vo",
@@ -158,7 +151,6 @@ def validate(
     define_version: str,
     whodrug: str,
     meddra: str,
-    disable_progressbar: bool,
     rules: Tuple[str],
     verbose_output: bool,
     progress: str,
@@ -223,7 +215,6 @@ def validate(
             define_version,
             whodrug,
             meddra,
-            disable_progressbar,
             rules,
             verbose_output,
             progress,

--- a/core.py
+++ b/core.py
@@ -119,13 +119,6 @@ def cli():
 @click.option("--meddra", help="Path to directory with MedDRA dictionary files")
 @click.option("--rules", "-r", multiple=True)
 @click.option(
-    "-vo",
-    "--verbose-output",
-    is_flag=True,
-    default=False,
-    help="Specify this option to print rules as they are completed",
-)
-@click.option(
     "-p",
     "--progress",
     default=ProgressParameterOptions.BAR.value,
@@ -155,7 +148,6 @@ def validate(
     whodrug: str,
     meddra: str,
     rules: Tuple[str],
-    verbose_output: bool,
     progress: str,
 ):
     """
@@ -219,7 +211,6 @@ def validate(
             whodrug,
             meddra,
             rules,
-            verbose_output,
             progress,
         )
     )

--- a/core.py
+++ b/core.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from multiprocessing import freeze_support
 
 from cdisc_rules_engine.constants.define_xml_constants import DEFINE_XML_FILE_NAME
+from cdisc_rules_engine.enums.progress_parameter_options import ProgressParameterOptions
 from cdisc_rules_engine.enums.report_types import ReportTypes
 from cdisc_rules_engine.models.validation_args import Validation_args
 from scripts.run_validation import run_validation
@@ -131,14 +132,8 @@ def cli():
 @click.option(
     "-p",
     "--progress",
-    default="bar",
-    type=click.Choice(
-        [
-            "bar",
-            "percents",
-            "disabled",
-        ]
-    ),
+    default=ProgressParameterOptions.BAR.value,
+    type=click.Choice(ProgressParameterOptions.values()),
     help=(
         "Defines how to display the validation progress. "
         'By default a progress bar like "[████████████████████████████--------]   78%"'
@@ -231,6 +226,7 @@ def validate(
             disable_progressbar,
             rules,
             verbose_output,
+            progress,
         )
     )
 

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -3,7 +3,6 @@ import os
 import pickle
 import sys
 import time
-import click
 from functools import partial
 from multiprocessing import Pool
 from multiprocessing.managers import SyncManager
@@ -197,18 +196,16 @@ def run_validation(args: Validation_args):
             ):
                 results.append(rule_result)
         else:
-            with click.progressbar(
-                length=len(rules),
-                show_eta=False,
-                file=PseudoTTY(sys.stdout),
-                bar_template="%(info)s",
-            ) as bar:
-                for rule_result in pool.imap_unordered(
-                    partial(validate_single_rule, shared_cache, datasets, args),
-                    rules,
-                ):
-                    results.append(rule_result)
-                    bar.update(1)
+            counter = 0
+            rules_len = len(rules)
+            for rule_result in pool.imap_unordered(
+                partial(validate_single_rule, shared_cache, datasets, args),
+                rules,
+            ):
+                counter += 1
+                current_progress: int = int(counter / rules_len * 100)
+                sys.stdout.write(f"{current_progress}\n")
+                results.append(rule_result)
 
     # build all desired reports
     end = time.time()

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -8,6 +8,7 @@ from multiprocessing.managers import SyncManager
 from typing import List, Iterable, Callable
 
 from cdisc_rules_engine.config import config
+from cdisc_rules_engine.enums.progress_parameter_options import ProgressParameterOptions
 from cdisc_rules_engine.interfaces import CacheServiceInterface, DataServiceInterface
 from cdisc_rules_engine.models.dictionaries import DictionaryTypes
 from cdisc_rules_engine.models.dictionaries.get_dictionary_terms import (
@@ -40,7 +41,7 @@ class CacheManager(SyncManager):
     pass
 
 
-def validate_single_rule(cache, datasets, args, rule: dict = None):
+def validate_single_rule(cache, datasets, args: Validation_args, rule: dict = None):
     rule["conditions"] = ConditionCompositeFactory.get_condition_composite(
         rule["conditions"]
     )
@@ -61,7 +62,7 @@ def validate_single_rule(cache, datasets, args, rule: dict = None):
         for dataset in datasets
     ]
     results = list(itertools.chain(*results))
-    if args.verbose_output:
+    if args.progress == ProgressParameterOptions.VERBOSE_OUTPUT.value:
         engine_logger.log(f"{rule['core_id']} validation complete")
     return RuleValidationResult(rule, results)
 
@@ -124,7 +125,7 @@ def set_log_level(args):
         engine_logger.disabled = True
     else:
         engine_logger.setLevel(args.log_level.lower())
-    if args.verbose_output:
+    if args.progress == ProgressParameterOptions.VERBOSE_OUTPUT.value:
         engine_logger.disabled = False
         engine_logger.setLevel("verbose")
 

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -205,6 +205,7 @@ def run_validation(args: Validation_args):
                 counter += 1
                 current_progress: int = int(counter / rules_len * 100)
                 sys.stdout.write(f"{current_progress}\n")
+                sys.stdout.flush()
                 results.append(rule_result)
 
     # build all desired reports

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="cdisc-rules-engine",
-    version="0.5.2",
+    version="0.5.3",
     description="Open source offering of the cdisc rules engine",
     author="cdisc-org",
     url="https://github.com/cdisc-org/cdisc-rules-engine",


### PR DESCRIPTION
While working on a custom UI for the CORE engine we have identified the need to display the progress percentage as we had in the web version. 

Despite the fact that the CLI prints the progress bar to stdout by default, it is not very convenient to parse this progress bar on the desktop frontend and extract the percentage from it. So, in this PR I suggest parametrizing the progress bar in the following way - introduce a new parameter `-p, --progress` that can accept any of the following values:

- bar (default) - prints a progress bar like [████████████████████████████--------] 78%
- percents - prints only percents on new line like:
```
23
24
34
...
```
- disabled - disables the progress output (similarly to what `--disable-progressbar` flag does)

To preserve current behavior of the CLI, by default a progress bar is printed and instead of `--disable-progressbar` parameter we can pass `-p disabled`.