### PR TITLE
Fixed jira links in github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/rule-blocking-bug.md
+++ b/.github/ISSUE_TEMPLATE/rule-blocking-bug.md
@@ -12,8 +12,8 @@ assignees: ''
 - Fill in the following information
 
 **Links to related JIRA Tickets**
-- https://jira.cdisc.org/projects/CORERULES/issues/CORERULES-
-- https://jira.cdisc.org/projects/CORERULES/issues/CORERULES-
+- https://jira.cdisc.org/browse/CORERULES-
+- https://jira.cdisc.org/browse/CORERULES-
 
 **Rule Information**
 - **Standard**:

--- a/.github/ISSUE_TEMPLATE/rule-blocking-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/rule-blocking-enhancement.md
@@ -12,8 +12,8 @@ assignees: ''
 - Fill in the following information
 
 **Links to related JIRA Tickets**
-- https://jira.cdisc.org/projects/CORERULES/issues/CORERULES-
-- https://jira.cdisc.org/projects/CORERULES/issues/CORERULES-
+- https://jira.cdisc.org/browse/CORERULES-
+- https://jira.cdisc.org/browse/CORERULES-
 
 **Rule Information**
 - **Standard**:


### PR DESCRIPTION
old links don't work in all cases