### PR TITLE
Handle single results from operations in BaseOperation

### DIFF
--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -35,9 +35,14 @@ class BaseOperation:
             return self._handle_grouped_result(result)
         elif isinstance(result, dict):
             return self._handle_dictionary_result(result)
+        elif isinstance(result, pd.Series):
+            self.evaluation_dataset[self.params.operation_id] = result
+            return self.evaluation_dataset
         else:
             # Handle single results
-            self.evaluation_dataset[self.params.operation_id] = result
+            self.evaluation_dataset[self.params.operation_id] = pd.Series(
+                [result] * len(self.evaluation_dataset)
+            )
             return self.evaluation_dataset
 
     def _handle_grouped_result(self, result):

--- a/cdisc_rules_engine/operations/dataset_column_order.py
+++ b/cdisc_rules_engine/operations/dataset_column_order.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 
 
@@ -14,6 +12,4 @@ class DatasetColumnOrder(BaseOperation):
 
         Length of Series is equal to the length of given dataframe.
         """
-        return pd.Series(
-            [self.params.dataframe.columns.to_list()] * len(self.params.dataframe)
-        )
+        return self.params.dataframe.columns.to_list()

--- a/cdisc_rules_engine/operations/distinct.py
+++ b/cdisc_rules_engine/operations/distinct.py
@@ -8,8 +8,7 @@ class Distinct(BaseOperation):
             data = self.params.dataframe[self.params.target].unique()
             if isinstance(data[0], bytes):
                 data = data.astype(str)
-            data_converted_to_set = set(data)
-            result = pd.Series([data_converted_to_set] * len(self.params.dataframe))
+            result = set(data)
         else:
             grouped = self.params.dataframe.groupby(
                 self.params.grouping, as_index=False

--- a/cdisc_rules_engine/operations/extract_metadata.py
+++ b/cdisc_rules_engine/operations/extract_metadata.py
@@ -11,5 +11,4 @@ class ExtractMetadata(BaseOperation):
 
         # extract target value. Metadata df always has one row
         target_value = metadata.get(self.params.target, pd.Series())[0]
-        result = pd.Series([target_value] * len(self.params.dataframe))
-        return result
+        return target_value

--- a/cdisc_rules_engine/operations/library_column_order.py
+++ b/cdisc_rules_engine/operations/library_column_order.py
@@ -1,7 +1,5 @@
 from typing import List, Optional, Tuple
 
-import pandas as pd
-
 from cdisc_rules_engine.constants.classes import (
     DETECTABLE_CLASSES,
     GENERAL_OBSERVATIONS_CLASS,
@@ -43,7 +41,7 @@ class LibraryColumnOrder(BaseOperation):
         variable_names_list = [
             var["name"].replace("--", self.params.domain) for var in variables_metadata
         ]
-        return pd.Series([variable_names_list] * len(self.params.dataframe))
+        return variable_names_list
 
     def _get_variables_metadata_from_standard_model(
         self, dataset_class: str

--- a/cdisc_rules_engine/operations/record_count.py
+++ b/cdisc_rules_engine/operations/record_count.py
@@ -15,4 +15,4 @@ class RecordCount(BaseOperation):
         dtype: int64
         """
         record_count: int = len(self.params.dataframe)
-        return pd.Series([record_count] * record_count)
+        return record_count

--- a/cdisc_rules_engine/operations/variable_names.py
+++ b/cdisc_rules_engine/operations/variable_names.py
@@ -22,4 +22,4 @@ class VariableNames(BaseOperation):
                     self.params.standard, self.params.standard_version
                 ).keys()
             )
-        return [variable_names] * len(self.evaluation_dataset)
+        return variable_names

--- a/tests/unit/test_operations/test_distinct.py
+++ b/tests/unit/test_operations/test_distinct.py
@@ -25,8 +25,9 @@ def test_distinct(data, expected, operation_params: OperationParams):
     data_service = DataServiceFactory(config, cache).get_data_service()
     operation_params.dataframe = data
     operation_params.target = "values"
-    result = Distinct(operation_params, pd.DataFrame(), cache, data_service).execute()
+    result = Distinct(operation_params, data, cache, data_service).execute()
     assert operation_params.operation_id in result
+    assert len(result[operation_params.operation_id]) > 0
     for val in result[operation_params.operation_id]:
         assert val == expected
 


### PR DESCRIPTION
This PR fixes an issue where operations were returning results that match the size of the dataset the operation was performed on rather than the size of the dataset the engine was currently evaluating. Since the could be of different sizes, the datasets were filled with NaN when the evaluation_dataset is greater than the operation dataset