### PR TITLE
Update DY calculation to merge dm with evaluation dataset and calcula…

### DIFF
--- a/tests/unit/test_operations/test_day_data_validtor.py
+++ b/tests/unit/test_operations/test_day_data_validtor.py
@@ -21,10 +21,11 @@ from cdisc_rules_engine.services.cache.cache_service_factory import CacheService
                         "2022-05-20T13:44",
                         None,
                         "2022-05-19T13:44",
-                    ]
+                    ],
+                    "USUBJID": [1, 2, 3, 4, 5, 6, 7],
                 }
             ),
-            [4, 32, 1, 13, "NaN", "NaN", -1],
+            [4, 32, 1, 13, "", "", -1],
         ),
     ],
 )
@@ -44,7 +45,8 @@ def test_day_data_calculation(
                     "TEST",
                     "2022-05-20T13:44",
                     "2022-05-20T13:44",
-                ]
+                ],
+                "USUBJID": [1, 2, 3, 4, 5, 6, 7],
             }
         )
     }
@@ -58,7 +60,7 @@ def test_day_data_calculation(
     operation_params.dataframe = data
     operation_params.target = "values"
     result = DayDataValidator(
-        operation_params, pd.DataFrame(), cache, mock_data_service
+        operation_params, data, cache, mock_data_service
     ).execute()
     assert operation_params.operation_id in result
     for i, val in enumerate(result[operation_params.operation_id]):


### PR DESCRIPTION
…te day difference

This PR updates the day-difference calculation, to properly calculate the day difference.

Steps for calculation:

1. Merge DM dataset with the evaluation dataset on usubjid
2. Calculate the day difference between the associated RFSTDTC from the DM domain and the target value in the the evaluation dataset.

Note: This operation now assumes that both the evaluation dataset and the dm dataset have a USUBJID column. If this is not present the operation will raise an error and the rule using the operation will be skipped