### PR TITLE
Fix logic for getting library column order

### DIFF
--- a/cdisc_rules_engine/operations/library_column_order.py
+++ b/cdisc_rules_engine/operations/library_column_order.py
@@ -82,10 +82,8 @@ class LibraryColumnOrder(BaseOperation):
         )
         variables_metadata: List[dict] = model_class_details.get("classVariables", [])
         variables_metadata.sort(key=lambda item: item["ordinal"])
-        if (
-            class_details.get("name") in DETECTABLE_CLASSES
-            and self.params.standard.lower() == "sdtmig"
-        ):
+
+        if class_details.get("name") in DETECTABLE_CLASSES:
             # if the class is one of Interventions, Findings, or Events
             # and the standard is SDTMIG
             # -> add General Observation class variables to variables metadata

--- a/cdisc_rules_engine/operations/library_column_order.py
+++ b/cdisc_rules_engine/operations/library_column_order.py
@@ -34,7 +34,6 @@ class LibraryColumnOrder(BaseOperation):
         ] = self._get_variables_metadata_from_standard_model()
 
         # create a list of variable names in accordance to the "ordinal" key
-        variables_metadata.sort(key=lambda item: item["ordinal"])
         variable_names_list = [
             var["name"].replace("--", self.params.domain) for var in variables_metadata
         ]
@@ -83,6 +82,7 @@ class LibraryColumnOrder(BaseOperation):
         # if model describes the domain -> get metadata from the model domain
         variables_metadata: List[dict] = domain_details.get("datasetVariables", [])
 
+        variables_metadata.sort(key=lambda item: item["ordinal"])
         if (
             class_details.get("name") in DETECTABLE_CLASSES
             and self.params.standard == "sdtmig"
@@ -99,9 +99,12 @@ class LibraryColumnOrder(BaseOperation):
                 gen_obs_class_metadata["classVariables"]
             )
             # Identifiers are added to the beginning and Timing to the end
-            variables_metadata: List[dict] = (
-                identifiers_metadata + variables_metadata + timing_metadata
-            )
+            if identifiers_metadata:
+                identifiers_metadata.sort(key=lambda item: item["ordinal"])
+                variables_metadata = identifiers_metadata + variables_metadata
+            if timing_metadata:
+                timing_metadata.sort(key=lambda item: item["ordinal"])
+                variables_metadata = variables_metadata + timing_metadata
 
         return variables_metadata
 

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -161,7 +161,7 @@ def get_standard_details_cache_key(standard_type: str, standard_version: str) ->
 
 
 def get_model_details_cache_key(standard_type: str, model_version: str) -> str:
-    return f"models/{standard_type}/{model_version}"
+    return f"models/{standard_type}/{model_version.replace('.', '-')}"
 
 
 def replace_pattern_in_list_of_strings(

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -160,8 +160,8 @@ def get_standard_details_cache_key(standard_type: str, standard_version: str) ->
     return f"standards/{standard_type}/{standard_version}"
 
 
-def get_model_details_cache_key(standard_type: str, model_version: str) -> str:
-    return f"models/{standard_type}/{model_version.replace('.', '-')}"
+def get_model_details_cache_key(standard: str, model_version: str) -> str:
+    return f"models/{standard}/{model_version.replace('.', '-')}"
 
 
 def replace_pattern_in_list_of_strings(

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -123,7 +123,6 @@ def get_dataset_cache_key_from_study(
 
 
 def get_dataset_cache_key_from_path(dataset_path: str, dataset_type: str) -> str:
-
     return DATASET_CACHE_KEY_TEMPLATE.format(
         dataset_path=dataset_path, dataset_type=dataset_type
     )

--- a/scripts/test_rule.py
+++ b/scripts/test_rule.py
@@ -48,8 +48,8 @@ def validate_single_rule(cache, path, args, datasets, rule: dict = None):
     # call rule engine
     engine = RulesEngine(
         cache=cache,
-        standard="sdtmig",
-        standard_version="3-4",
+        standard=args.standard,
+        standard_version=args.version,
         ct_package=args.controlled_terminology_package,
         meddra_path=args.meddra,
         whodrug_path=args.whodrug,

--- a/tests/unit/test_operations/test_library_column_order.py
+++ b/tests/unit/test_operations/test_library_column_order.py
@@ -9,92 +9,78 @@ from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.library_column_order import LibraryColumnOrder
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import get_model_details_cache_key
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+    get_model_details_cache_key,
+)
 
 
 @pytest.mark.parametrize(
-    "model_metadata",
+    "model_metadata, standard_metadata",
     [
-        {
-            "datasets": [
-                {
-                    "name": "AE",
-                    "datasetVariables": [
-                        {
-                            "name": "AETERM",
-                            "ordinal": 4,
-                        },
-                        {
-                            "name": "AESEQ",
-                            "ordinal": 3,
-                        },
-                    ],
-                }
-            ],
-            "classes": [
-                {
-                    "name": GENERAL_OBSERVATIONS_CLASS,
-                    "classVariables": [
-                        {
-                            "name": "DOMAIN",
-                            "role": VariableRoles.IDENTIFIER.value,
-                            "ordinal": 2,
-                        },
-                        {
-                            "name": "STUDYID",
-                            "role": VariableRoles.IDENTIFIER.value,
-                            "ordinal": 1,
-                        },
-                        {
-                            "name": "TIMING_VAR",
-                            "role": VariableRoles.TIMING.value,
-                            "ordinal": 33,
-                        },
-                    ],
-                },
-            ],
-        },
-        {
-            "classes": [
-                {
-                    "name": "Events",
-                    "classVariables": [
-                        {
-                            "name": "AETERM",
-                            "ordinal": 4,
-                        },
-                        {
-                            "name": "AESEQ",
-                            "ordinal": 3,
-                        },
-                    ],
-                },
-                {
-                    "name": GENERAL_OBSERVATIONS_CLASS,
-                    "classVariables": [
-                        {
-                            "name": "DOMAIN",
-                            "role": VariableRoles.IDENTIFIER.value,
-                            "ordinal": 2,
-                        },
-                        {
-                            "name": "STUDYID",
-                            "role": VariableRoles.IDENTIFIER.value,
-                            "ordinal": 1,
-                        },
-                        {
-                            "name": "TIMING_VAR",
-                            "role": VariableRoles.TIMING.value,
-                            "ordinal": 33,
-                        },
-                    ],
-                },
-            ],
-        },
+        (
+            {
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "datasetVariables": [
+                            {
+                                "name": "AETERM",
+                                "ordinal": 4,
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": 3,
+                            },
+                        ],
+                    }
+                ],
+                "classes": [
+                    {
+                        "name": GENERAL_OBSERVATIONS_CLASS,
+                        "classVariables": [
+                            {
+                                "name": "DOMAIN",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 2,
+                            },
+                            {
+                                "name": "STUDYID",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 1,
+                            },
+                            {
+                                "name": "TIMING_VAR",
+                                "role": VariableRoles.TIMING.value,
+                                "ordinal": 33,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+                "classes": [
+                    {
+                        "name": "Events",
+                        "datasets": [
+                            {
+                                "name": "AE",
+                                "label": "Adverse Events",
+                                "datasetVariables": [
+                                    {"name": "AETEST", "ordinal": 1},
+                                    {"name": "AENEW", "ordinal": 2},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
     ],
 )
 def test_get_column_order_from_library(
-    operation_params: OperationParams, model_metadata: dict
+    operation_params: OperationParams, model_metadata: dict, standard_metadata: dict
 ):
     """
     Unit test for DataProcessor.get_column_order_from_library.
@@ -115,17 +101,18 @@ def test_get_column_order_from_library(
         }
     )
     operation_params.domain = "AE"
-    operation_params.standard = "sdtm"
+    operation_params.standard = "sdtmig"
     operation_params.standard_version = "3-4"
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
     cache.add(
-        get_model_details_cache_key(
+        get_standard_details_cache_key(
             operation_params.standard, operation_params.standard_version
         ),
-        model_metadata,
+        standard_metadata,
     )
+    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
 
     # execute operation
     data_service = LocalDataService.get_instance(cache_service=cache)
@@ -136,8 +123,8 @@ def test_get_column_order_from_library(
     variables: List[str] = [
         "STUDYID",
         "DOMAIN",
-        "AESEQ",
-        "AETERM",
+        "AETEST",
+        "AENEW",
         "TIMING_VAR",
     ]
     expected: pd.Series = pd.Series(

--- a/tests/unit/test_operations/test_library_column_order.py
+++ b/tests/unit/test_operations/test_library_column_order.py
@@ -37,6 +37,13 @@ from cdisc_rules_engine.utilities.utils import (
                 ],
                 "classes": [
                     {
+                        "name": "Events",
+                        "classVariables": [
+                            {"name": "--TERM", "ordinal": 1},
+                            {"name": "--SEQ", "ordinal": 2},
+                        ],
+                    },
+                    {
                         "name": GENERAL_OBSERVATIONS_CLASS,
                         "classVariables": [
                             {
@@ -123,8 +130,8 @@ def test_get_column_order_from_library(
     variables: List[str] = [
         "STUDYID",
         "DOMAIN",
-        "AETEST",
-        "AENEW",
+        "AETERM",
+        "AESEQ",
         "TIMING_VAR",
     ]
     expected: pd.Series = pd.Series(

--- a/tests/unit/test_rules_engine.py
+++ b/tests/unit/test_rules_engine.py
@@ -2151,6 +2151,13 @@ def test_validate_variables_order_against_library_metadata(
     cache_data: dict = {
         "classes": [
             {
+                "name": "Events",
+                "classVariables": [
+                    {"name": "--TERM", "ordinal": 1},
+                    {"name": "--SEQ", "ordinal": 2},
+                ],
+            },
+            {
                 "name": GENERAL_OBSERVATIONS_CLASS,
                 "classVariables": [
                     {

--- a/tests/unit/test_rules_engine.py
+++ b/tests/unit/test_rules_engine.py
@@ -2143,26 +2143,13 @@ def test_validate_variables_order_against_library_metadata(
         }
     )
 
-    standard: str = "sdtm"
+    standard: str = "sdtmig"
     standard_version: str = "3-1-2"
 
     # fill cache
     cache = InMemoryCacheService.get_instance()
     cache_data: dict = {
         "classes": [
-            {
-                "name": "Events",
-                "classVariables": [
-                    {
-                        "name": "AETERM",
-                        "ordinal": 4,
-                    },
-                    {
-                        "name": "AESEQ",
-                        "ordinal": 3,
-                    },
-                ],
-            },
             {
                 "name": GENERAL_OBSERVATIONS_CLASS,
                 "classVariables": [
@@ -2185,8 +2172,25 @@ def test_validate_variables_order_against_library_metadata(
             },
         ]
     }
-    cache.add(get_model_details_cache_key(standard, standard_version), cache_data)
-
+    standard_data = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "datasetVariables": [
+                            {"name": "AETERM", "ordinal": 1},
+                            {"name": "AESEQ", "ordinal": 2},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    cache.add(get_model_details_cache_key("sdtm", "1-5"), cache_data)
+    cache.add(get_standard_details_cache_key(standard, standard_version), standard_data)
     # run validation
     engine = RulesEngine(
         cache=cache,
@@ -2215,8 +2219,8 @@ def test_validate_variables_order_against_library_metadata(
                         "$column_order_from_library": [
                             "STUDYID",
                             "DOMAIN",
-                            "AESEQ",
                             "AETERM",
+                            "AESEQ",
                             "TIMING_VAR",
                         ],
                         "$column_order_from_dataset": [


### PR DESCRIPTION
This PR fixes logic in the library column order operation. The operation should function as follows:

1. Get all variables from the domain and standard
2. If domain belongs to general observation class, add timing and identifier variables from the general observation class in the model. Identifier variables should appear before the domain specific variables and timing variables should appear after domain specific variables.