### PR TITLE
Abstact Dataset Builders

### DIFF
--- a/cdisc_rules_engine/dataset_builders/__init__.py
+++ b/cdisc_rules_engine/dataset_builders/__init__.py
@@ -1,4 +1,4 @@
-from cdisc_rules_engine.dataset_builder.dataset_builder_factory import (
+from .dataset_builder_factory import (
     DatasetBuilderFactory,
 )
 

--- a/cdisc_rules_engine/dataset_builders/__init__.py
+++ b/cdisc_rules_engine/dataset_builders/__init__.py
@@ -1,0 +1,5 @@
+from cdisc_rules_engine.dataset_builder.dataset_builder_factory import (
+    DatasetBuilderFactory,
+)
+
+builder_factory = DatasetBuilderFactory()

--- a/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
@@ -1,0 +1,67 @@
+from abc import abstractmethod
+from cdisc_rules_engine.constants.define_xml_constants import DEFINE_XML_FILE_NAME
+from cdisc_rules_engine.services.define_xml_reader import DefineXMLReader
+import pandas as pd
+from cdisc_rules_engine.utilities.utils import (
+    get_directory_path,
+    get_corresponding_datasets,
+)
+from typing import List
+
+
+class BaseDatasetBuilder:
+    def __init__(
+        self,
+        rule,
+        data_service,
+        cache_service,
+        rule_processor,
+        data_processor,
+        dataset_path,
+        datasets,
+        domain,
+    ):
+        self.data_service = data_service
+        self.cache = (cache_service,)
+        self.data_processor = data_processor
+        self.rule_processor = rule_processor
+        self.dataset_path = dataset_path
+        self.datasets = datasets
+        self.domain = domain
+        self.rule = rule
+
+    @abstractmethod
+    def build(self) -> pd.DataFrame:
+        """
+        Returns correct dataframe to operate on
+        """
+        pass
+
+    def get_dataset(self, **kwargs):
+        # By default do not handle split datasets
+        # This method is overridden in the ContentDatasetBuilder for handling
+        # split datasets when validating the actual content of a dataset.
+        # In cases when validating metadata, split datasets don't matter.
+        # single dataset. the most common case
+        return self.build()
+
+    def get_corresponding_datasets_names(self) -> List[str]:
+        directory_path = get_directory_path(self.dataset_path)
+        return [
+            f"{directory_path}/{dataset['filename']}"
+            for dataset in get_corresponding_datasets(self.datasets, self.domain)
+        ]
+
+    def get_define_xml_variables_metadata(self) -> List[dict]:
+        """
+        Gets Define XML variables metadata.
+        """
+        directory_path = get_directory_path(self.dataset_path)
+        define_xml_path: str = f"{directory_path}/{DEFINE_XML_FILE_NAME}"
+        define_xml_contents: bytes = self.data_service.get_define_xml_contents(
+            dataset_name=define_xml_path
+        )
+        define_xml_reader = DefineXMLReader.from_file_contents(
+            define_xml_contents, cache_service_obj=self.cache
+        )
+        return define_xml_reader.extract_variables_metadata(domain_name=self.domain)

--- a/cdisc_rules_engine/dataset_builders/content_metadata_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/content_metadata_dataset_builder.py
@@ -1,0 +1,16 @@
+from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
+
+
+class ContentMetadataDatasetBuilder(BaseDatasetBuilder):
+    def build(self):
+        """
+        Returns the metadata from a given file as a dataframe with columns:
+        dataset_size - File size
+        dataset_location - Path to file
+        dataset_name - Name of the dataset
+        dataset_label - Label for the dataset
+        """
+        size_unit: str = self.rule_processor.get_size_unit_from_rule(self.rule)
+        return self.data_service.get_dataset_metadata(
+            self.dataset_path, size_unit=size_unit
+        )

--- a/cdisc_rules_engine/dataset_builders/contents_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/contents_dataset_builder.py
@@ -1,0 +1,26 @@
+from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
+from cdisc_rules_engine.utilities.utils import is_split_dataset
+import pandas as pd
+
+
+class ContentsDatasetBuilder(BaseDatasetBuilder):
+    def build(self):
+        """
+        Returns the contents of a file as a dataframe for evaluation.
+        """
+        return self.data_service.get_dataset(self.dataset_path)
+
+    def get_dataset(self, **kwargs):
+        # If validating dataset content, ensure split datasets are handled.
+        if is_split_dataset(self.datasets, self.domain):
+            # Handle split datasets for content checks.
+            # A content check is any check that is not in the list of rule types
+            dataset: pd.DataFrame = self.data_service.join_split_datasets(
+                func_to_call=self.build,
+                dataset_names=self.get_corresponding_datasets_names(),
+                **kwargs,
+            )
+        else:
+            # single dataset. the most common case
+            dataset: pd.DataFrame = self.build()
+        return dataset

--- a/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
+++ b/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
@@ -1,0 +1,66 @@
+# flake8: noqa
+from typing import Type
+
+from cdisc_rules_engine.interfaces import FactoryInterface
+from cdisc_rules_engine.dataset_builders.contents_dataset_builder import (
+    ContentsDatasetBuilder,
+)
+from cdisc_rules_engine.dataset_builders.content_metadata_dataset_builder import (
+    ContentMetadataDatasetBuilder,
+)
+from cdisc_rules_engine.dataset_builders.variables_metadata_dataset_builder import (
+    VariablesMetadataDatasetBuilder,
+)
+from cdisc_rules_engine.dataset_builders.domain_list_dataset_builder import (
+    DomainListDatasetBuilder,
+)
+from cdisc_rules_engine.dataset_builders.define_variables_dataset_builder import (
+    DefineVariablesDatasetBuilder,
+)
+from cdisc_rules_engine.dataset_builders.variables_metadata_with_define_dataset_builder import (
+    VariablesMetadataWithDefineDatasetBuilder,
+)
+from cdisc_rules_engine.enums.rule_types import RuleTypes
+
+
+class DatasetBuilderFactory(FactoryInterface):
+    _builders_map = {
+        RuleTypes.DATASET_METADATA_CHECK.value: ContentMetadataDatasetBuilder,
+        RuleTypes.DATASET_METADATA_CHECK_AGAINST_DEFINE.value: ContentMetadataDatasetBuilder,
+        RuleTypes.VARIABLE_METADATA_CHECK.value: VariablesMetadataDatasetBuilder,
+        RuleTypes.DOMAIN_PRESENCE_CHECK.value: DomainListDatasetBuilder,
+        RuleTypes.DEFINE.value: DefineVariablesDatasetBuilder,
+        RuleTypes.VARIABLE_METADATA_CHECK_AGAINST_DEFINE.value: VariablesMetadataWithDefineDatasetBuilder,
+        RuleTypes.DATASET_CONTENTS_CHECK_AGAINST_DEFINE_AND_LIBRARY.value: ContentsDatasetBuilder,
+        RuleTypes.VALUE_LEVEL_METADATA_CHECK_AGAINST_DEFINE.value: ContentsDatasetBuilder,
+    }
+
+    @classmethod
+    def register_service(cls, name: str, builder: Type[BaseDatasetBuilder]) -> None:
+        """
+        Save mapping of operation name and it's implementation
+        """
+        if not name:
+            raise ValueError("Builder name must not be empty!")
+        if not issubclass(builder, BaseDatasetBuilder):
+            raise TypeError("Implementation of BaseDatasetBuilder required!")
+        cls._operations_map[name] = builder
+
+    def get_service(
+        self,
+        name,
+        **kwargs,
+    ) -> BaseDatasetBuilder:
+        """
+        Get instance of dataset builder by name.
+        """
+        return self._builders_map.get(name, ContentsDatasetBuilder)(
+            kwargs.get("rule"),
+            kwargs.get("data_service"),
+            kwargs.get("cache_service"),
+            kwargs.get("data_processor"),
+            kwargs.get("rule_processor"),
+            kwargs.get("dataset_path"),
+            kwargs.get("datasets"),
+            kwargs.get("domain"),
+        )

--- a/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
+++ b/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
@@ -20,6 +20,7 @@ from cdisc_rules_engine.dataset_builders.define_variables_dataset_builder import
 from cdisc_rules_engine.dataset_builders.variables_metadata_with_define_dataset_builder import (
     VariablesMetadataWithDefineDatasetBuilder,
 )
+from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
 from cdisc_rules_engine.enums.rule_types import RuleTypes
 
 
@@ -54,13 +55,14 @@ class DatasetBuilderFactory(FactoryInterface):
         """
         Get instance of dataset builder by name.
         """
-        return self._builders_map.get(name, ContentsDatasetBuilder)(
+        builder = self._builders_map.get(name, ContentsDatasetBuilder)(
             kwargs.get("rule"),
             kwargs.get("data_service"),
             kwargs.get("cache_service"),
-            kwargs.get("data_processor"),
             kwargs.get("rule_processor"),
+            kwargs.get("data_processor"),
             kwargs.get("dataset_path"),
             kwargs.get("datasets"),
             kwargs.get("domain"),
         )
+        return builder

--- a/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
@@ -1,0 +1,24 @@
+from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
+import pandas as pd
+from typing import List
+
+
+class DefineVariablesDatasetBuilder(BaseDatasetBuilder):
+    def build(self):
+        """
+        Returns a dataset containing metadata for the variables
+        in the specified domain extracted from the define.xml.
+        Columns available in the dataset are:
+        "define_variable_name",
+        "define_variable_label",
+        "define_variable_data_type",
+        "define_variable_role",
+        "define_variable_size",
+        "define_variable_ccode",
+        "define_variable_format",
+        "define_variable_allowed_terms",
+        "define_variable_origin_type",
+        """
+        # get Define XML metadata for domain and use it as a rule comparator
+        variable_metadata: List[dict] = self.get_define_xml_variables_metadata()
+        return pd.DataFrame(variable_metadata)

--- a/cdisc_rules_engine/dataset_builders/domain_list_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/domain_list_dataset_builder.py
@@ -1,0 +1,19 @@
+from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
+import pandas as pd
+
+
+class DomainListDatasetBuilder(BaseDatasetBuilder):
+    def build(self):
+        """
+        Returns a dataframe with a single row.
+        The row contains a column for each domain and the value of that
+        column is the domains file name
+
+        dataset example:
+           AE      EC
+        0  ae.xpt  ec.xpt
+        """
+
+        return pd.DataFrame(
+            {ds["domain"]: ds["filename"] for ds in self.datasets}, index=[0]
+        )

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
@@ -1,0 +1,18 @@
+from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
+
+
+class VariablesMetadataDatasetBuilder(BaseDatasetBuilder):
+    def build(self):
+        """
+         Returns the variable metadata from a given file as a dataframe.
+         The resulting dataframe has the following columns:
+        variable_name
+        variable_order
+        variable_label
+        variable_size
+        variable_data_type
+
+        """
+        return self.data_service.get_variables_metadata(
+            self.dataset_path, drop_duplicates=True
+        )

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_dataset_builder.py
@@ -1,0 +1,39 @@
+from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
+from typing import List
+import pandas as pd
+
+
+class VariablesMetadataWithDefineDatasetBuilder(BaseDatasetBuilder):
+    def build(self):
+        """
+        Returns the variable metadata from a given file.
+        Returns a dataframe with the following columns:
+        variable_name
+        variable_order
+        variable_label
+        variable_size
+        variable_data_type
+        define_variable_name,
+        define_variable_label,
+        define_variable_data_type,
+        define_variable_role,
+        define_variable_size,
+        define_variable_ccode,
+        define_variable_format,
+        define_variable_allowed_terms,
+        define_variable_origin_type,
+
+        """
+        # get Define XML metadata for domain and use it as a rule comparator
+        variable_metadata: List[dict] = self.get_define_xml_variables_metadata()
+        # get dataset metadata and execute the rule
+        content_metadata: pd.DataFrame = self.data_service.get_variables_metadata(
+            self.dataset_path, drop_duplicates=True
+        )
+        define_metadata: pd.DataFrame = pd.DataFrame(variable_metadata)
+        return content_metadata.merge(
+            define_metadata,
+            left_on="variable_name",
+            right_on="define_variable_name",
+            how="left",
+        )

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -241,7 +241,6 @@ class RulesEngine:
                 )
             )
             define_metadata: List[dict] = builder.get_define_xml_variables_metadata()
-
             targets: List[
                 str
             ] = self.data_processor.filter_dataset_columns_by_metadata_and_rule(
@@ -276,7 +275,6 @@ class RulesEngine:
             variable_codelist_map = {}
         if codelist_term_maps is None:
             codelist_term_maps = []
-
         # Add conditions to rule for all variables if variables: all appears
         # in condition
         rule["conditions"] = RuleProcessor.duplicate_conditions_for_all_targets(

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -234,7 +234,6 @@ class RulesEngine:
             rule.get("rule_type")
             == RuleTypes.DATASET_CONTENTS_CHECK_AGAINST_DEFINE_AND_LIBRARY.value
         ):
-
             library_metadata: dict = self.cache.get(
                 get_library_variables_metadata_cache_key(
                     self.standard, self.standard_version

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Callable, List, Union
+from typing import List, Union
 
 import pandas as pd
 from business_rules import export_rule_data
@@ -22,7 +22,6 @@ from cdisc_rules_engine.interfaces import (
     DataServiceInterface,
 )
 from cdisc_rules_engine.models.actions import COREActions
-from cdisc_rules_engine.models.dataset_types import DatasetTypes
 from cdisc_rules_engine.models.dataset_variable import DatasetVariable
 from cdisc_rules_engine.models.failed_validation_entity import FailedValidationEntity
 from cdisc_rules_engine.models.validation_error_container import (
@@ -36,7 +35,6 @@ from cdisc_rules_engine.utilities.data_processor import DataProcessor
 from cdisc_rules_engine.utilities.dataset_preprocessor import DatasetPreprocessor
 from cdisc_rules_engine.utilities.rule_processor import RuleProcessor
 from cdisc_rules_engine.utilities.utils import (
-    get_corresponding_datasets,
     get_directory_path,
     get_library_variables_metadata_cache_key,
     get_standard_codelist_cache_key,
@@ -44,6 +42,7 @@ from cdisc_rules_engine.utilities.utils import (
     is_split_dataset,
     serialize_rule,
 )
+from cdisc_rules_engine.dataset_builders import builder_factory
 
 
 class RulesEngine:
@@ -165,284 +164,97 @@ class RulesEngine:
             # this wrapping into a list is necessary to keep return type consistent
             return [error_obj.to_representation()]
 
+    def get_dataset_builder(
+        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str
+    ):
+        return builder_factory.get_service(
+            rule.get("rule_type"),
+            rule=rule,
+            data_service=self.data_service,
+            cache_service=self.cache,
+            data_processor=self.data_processor,
+            rule_processor=self.rule_processor,
+            domain=domain,
+            datasets=datasets,
+            dataset_path=dataset_path,
+        )
+
     def validate_rule(
         self, rule: dict, dataset_path: str, datasets: List[dict], domain: str
     ) -> List[Union[dict, str]]:
         """
-        This function is an entrypoint for rule validation.
+         This function is an entrypoint for rule validation.
         It defines a rule validator based on its type and calls it.
         """
-        validator: Callable = self.get_dataset_validator(rule.get("rule_type"))
-        logger.info(f"Validator function name: {validator.__name__}")
-        return validator(rule, dataset_path, datasets, domain)
+        builder = self.get_dataset_builder(rule, dataset_path, datasets, domain)
+        dataset = builder.get_dataset()
+        kwargs = {}
+        # Update rule for certain rule types
+        # SPECIAL CASES FOR RULE TYPES ###############################
+        # TODO: Handle these special cases better.
+        if (
+            rule.get("rule_type")
+            == RuleTypes.DATASET_METADATA_CHECK_AGAINST_DEFINE.value
+        ):
+            # get Define XML metadata for domain and use it as a rule comparator
+            define_metadata: dict = self.get_define_xml_metadata_for_domain(
+                dataset_path, domain
+            )
+            self.rule_processor.add_comparator_to_rule_conditions(rule, define_metadata)
 
-    def get_dataset_validator(self, rule_type: str) -> Callable:
-        """
-        Returns a validator function based on rule type.
-        When extending the function bear in mind that validator
-        functions should have the same interface or kwargs specified.
-        """
-        rule_type_validator_map: dict = {
-            RuleTypes.DATASET_METADATA_CHECK.value: self.validate_dataset_metadata,
-            RuleTypes.DATASET_METADATA_CHECK_AGAINST_DEFINE.value: (
-                self.validate_dataset_metadata_against_define_xml
-            ),
-            RuleTypes.VARIABLE_METADATA_CHECK.value: self.validate_variables_metadata,
-            RuleTypes.DOMAIN_PRESENCE_CHECK.value: self.validate_domain_presence,
-            RuleTypes.VARIABLE_METADATA_CHECK_AGAINST_DEFINE.value: (
-                self.validate_variable_metadata_against_define_xml
-            ),
-            RuleTypes.VALUE_LEVEL_METADATA_CHECK_AGAINST_DEFINE.value: (
-                self.validate_value_level_metadata_against_define_xml
-            ),
-            RuleTypes.DATASET_CONTENTS_CHECK_AGAINST_DEFINE_AND_LIBRARY.value: (
-                self.validate_dataset_contents_against_define_and_library
-            ),
-            RuleTypes.DEFINE.value: self.validate_define_xml,
-        }
-        return rule_type_validator_map.get(
-            rule_type,
-            self.validate_dataset_contents,  # by default validate dataset contents
-        )
-
-    def validate_dataset_contents(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str
-    ) -> List[Union[dict, str]]:
-        """
-        Validates dataset contents.
-        """
-        dataset: pd.DataFrame = self.get_dataset_to_validate(
-            DatasetTypes.CONTENTS.value, dataset_path, datasets, domain
-        )
-        return self.execute_rule(rule, dataset, dataset_path, datasets, domain)
-
-    def validate_dataset_metadata(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str
-    ) -> List[Union[dict, str]]:
-        """
-        Validates metadata of a given dataset.
-        Checks file name, size, label etc.
-        """
-        size_unit: str = self.rule_processor.get_size_unit_from_rule(rule)
-        dataset: pd.DataFrame = self.get_dataset_to_validate(
-            DatasetTypes.METADATA.value,
-            dataset_path,
-            datasets,
-            domain,
-            size_unit=size_unit,
-        )
-        return self.execute_rule(rule, dataset, dataset_path, datasets, domain)
-
-    def validate_dataset_metadata_against_define_xml(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str
-    ) -> List[Union[dict, str]]:
-        """
-        Validates dataset metadata against define xml.
-        The idea here is to get define XML metadata for a domain
-        and use it as comparator in rule.
-        """
-        # get Define XML metadata for domain and use it as a rule comparator
-        define_metadata: dict = self.get_define_xml_metadata_for_domain(
-            dataset_path, domain
-        )
-        self.rule_processor.add_comparator_to_rule_conditions(rule, define_metadata)
-
-        # get dataset metadata and execute the rule
-        dataset: pd.DataFrame = self.get_dataset_to_validate(
-            DatasetTypes.METADATA.value, dataset_path, datasets, domain
-        )
-        return self.execute_rule(rule, dataset, dataset_path, datasets, domain)
-
-    def validate_variable_metadata_against_define_xml(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str
-    ) -> List[Union[dict, str]]:
-        """
-        Validates variable metadata against define xml.
-        The idea here is to get define XML metadata for all variables, and create
-        a dataframe by joining variable metadata from xpt with define metadata.
-        the comparator
-        """
-        # get Define XML metadata for domain and use it as a rule comparator
-        variable_metadata: List[dict] = self.get_define_xml_variables_metadata(
-            dataset_path, domain
-        )
-        self.rule_processor.add_comparator_to_rule_conditions(
-            rule, comparator=None, target_prefix="define_"
-        )
-        # get dataset metadata and execute the rule
-        xpt_metadata: pd.DataFrame = self.get_dataset_to_validate(
-            DatasetTypes.VARIABLES_METADATA.value,
-            dataset_path,
-            datasets,
-            domain,
-            drop_duplicates=True,
-        )
-        define_metadata: pd.DataFrame = pd.DataFrame(variable_metadata)
-        dataset = xpt_metadata.merge(
-            define_metadata,
-            left_on="variable_name",
-            right_on="define_variable_name",
-            how="left",
-        )
-        return self.execute_rule(rule, dataset, dataset_path, datasets, domain)
-
-    def validate_define_xml(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str
-    ) -> List[Union[dict, str]]:
-
-        # get Define XML metadata for domain and use it as a rule comparator
-        variable_metadata: List[dict] = self.get_define_xml_variables_metadata(
-            dataset_path, domain
-        )
-        define_metadata: pd.DataFrame = pd.DataFrame(variable_metadata)
-        variable_codelist_map_key = get_standard_codelist_cache_key(
-            self.standard, self.standard_version
-        )
-        variable_codelist_map = self.cache.get(variable_codelist_map_key) or {}
-        codelist_term_maps = [
-            self.cache.get(package) or {} for package in self.ct_package
-        ]
-        return self.execute_rule(
-            rule,
-            define_metadata,
-            dataset_path,
-            datasets,
-            domain,
-            variable_codelist_map=variable_codelist_map,
-            codelist_term_maps=codelist_term_maps,
-        )
-
-    def validate_value_level_metadata_against_define_xml(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str, **kwargs
-    ) -> List[Union[dict, str]]:
-        """
-        Validates variable metadata against define xml.
-        The idea here is to get define XML metadata for all variables, and create
-        a dataframe by joining variable metadata from xpt with define metadata.
-        the comparator
-        """
-        # get Define XML metadata for domain and use it as a rule comparator
-        value_level_metadata: List[dict] = self.get_define_xml_value_level_metadata(
-            dataset_path, domain
-        )
-        dataset: pd.DataFrame = self.get_dataset_to_validate(
-            DatasetTypes.CONTENTS.value, dataset_path, datasets, domain
-        )
-        return self.execute_rule(
-            rule, dataset, dataset_path, datasets, domain, value_level_metadata
-        )
-
-    def validate_dataset_contents_against_define_and_library(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str, **kwargs
-    ) -> List[Union[dict, str]]:
-        """
-        Validates dataset contents against Define.XML variable metadata
-        and Library variable metadata.
-
-        Example rule:
-            Library Variable Core Status = Permissible AND
-            Define.xml Variable Origin Type = Collected AND
-            Variable value is null
-        To validate the example, we need:
-            1. Extract variable metadata from CDISC Library;
-            2. Extract variable metadata from Define.XML;
-            3. Extract variable value from dataset.
-        """
-        # get metadata from library and define
-        library_metadata: dict = self.cache.get(
-            get_library_variables_metadata_cache_key(
+        elif rule.get("rule_type") == RuleTypes.DEFINE.value:
+            variable_codelist_map_key = get_standard_codelist_cache_key(
                 self.standard, self.standard_version
             )
-        )
-        define_metadata: List[dict] = self.get_define_xml_variables_metadata(
-            dataset_path, domain
-        )
+            variable_codelist_map = self.cache.get(variable_codelist_map_key) or {}
+            codelist_term_maps = [
+                self.cache.get(package) or {} for package in self.ct_package
+            ]
+            kwargs["variable_codelist_map"] = variable_codelist_map
+            kwargs["codelist_term_maps"] = codelist_term_maps
 
-        # create a list of targets based on dataset columns and use them in rule
-        dataset: pd.DataFrame = self.get_dataset_to_validate(
-            DatasetTypes.CONTENTS.value, dataset_path, datasets, domain
-        )
-        targets: List[
-            str
-        ] = self.data_processor.filter_dataset_columns_by_metadata_and_rule(
-            dataset.columns.tolist(), define_metadata, library_metadata, rule
-        )
-        rule["conditions"] = RuleProcessor.duplicate_conditions_for_all_targets(
-            rule["conditions"], targets
-        )
-        # execute the rule
-        return self.execute_rule(rule, dataset, dataset_path, datasets, domain)
-
-    def validate_variables_metadata(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str, **kwargs
-    ) -> List[Union[dict, str]]:
-        """
-        Validates metadata of a single variable.
-        """
-        dataset: pd.DataFrame = self.get_dataset_to_validate(
-            DatasetTypes.VARIABLES_METADATA.value,
-            dataset_path,
-            datasets,
-            domain,
-            drop_duplicates=True,
-        )
-        return self.execute_rule(rule, dataset, dataset_path, datasets, domain)
-
-    def validate_domain_presence(
-        self, rule: dict, dataset_path: str, datasets: List[dict], domain: str, **kwargs
-    ) -> List[Union[dict, str]]:
-        """
-        Validates dataset presence against the
-        datasets provided in the request.
-
-        dataset example:
-           AE      EC
-        0  ae.xpt  ec.xpt
-        """
-        dataset: pd.DataFrame = pd.DataFrame(
-            {ds["domain"]: ds["filename"] for ds in datasets}, index=[0]
-        )
-        logger.info(f"Validating domain presence. domain={domain}")
-        return self.execute_rule(rule, dataset, dataset_path, datasets, domain)
-
-    def get_dataset_to_validate(
-        self,
-        dataset_type: str,
-        dataset_path: str,
-        datasets: List[dict],
-        domain: str,
-        **kwargs,
-    ) -> pd.DataFrame:
-        """
-        Gets the necessary dataset from the storage.
-        The idea is to return the needed dataset based on
-        what we need to validate: contents, metadata or variables metadata
-        AND handle the case when the dataset is split into multiple files.
-
-        dataset_type param can be:
-        dataset_contents, dataset_metadata or variables_metadata.
-        For passing additional params to storage calls, kwargs can be used.
-        """
-        dataset_type_function_map: dict = {
-            DatasetTypes.CONTENTS.value: self.data_service.get_dataset,
-            DatasetTypes.METADATA.value: self.data_service.get_dataset_metadata,
-            DatasetTypes.VARIABLES_METADATA.value: (
-                self.data_service.get_variables_metadata
-            ),
-        }
-        func_to_call: Callable = dataset_type_function_map[dataset_type]
-        if not is_split_dataset(datasets, domain):
-            # single dataset. the most common case
-            dataset: pd.DataFrame = func_to_call(dataset_name=dataset_path, **kwargs)
-        else:
-            dataset: pd.DataFrame = self.data_service.join_split_datasets(
-                func_to_call=func_to_call,
-                dataset_names=self.get_corresponding_datasets_names(
-                    dataset_path, datasets, domain
-                ),
-                **kwargs,
+        elif (
+            rule.get("rule_type")
+            == RuleTypes.VARIABLE_METADATA_CHECK_AGAINST_DEFINE.value
+        ):
+            self.rule_processor.add_comparator_to_rule_conditions(
+                rule, comparator=None, target_prefix="define_"
             )
-        return dataset
+
+        elif (
+            rule.get("rule_type")
+            == RuleTypes.VALUE_LEVEL_METADATA_CHECK_AGAINST_DEFINE.value
+        ):
+            value_level_metadata: List[dict] = self.get_define_xml_value_level_metadata(
+                dataset_path, domain
+            )
+            kwargs["value_level_metadata"] = value_level_metadata
+
+        elif (
+            rule.get("rule_type")
+            == RuleTypes.DATASET_CONTENTS_CHECK_AGAINST_DEFINE_AND_LIBRARY.value
+        ):
+
+            library_metadata: dict = self.cache.get(
+                get_library_variables_metadata_cache_key(
+                    self.standard, self.standard_version
+                )
+            )
+            define_metadata: List[dict] = builder.get_define_xml_variables_metadata()
+
+            targets: List[
+                str
+            ] = self.data_processor.filter_dataset_columns_by_metadata_and_rule(
+                dataset.columns.tolist(), define_metadata, library_metadata, rule
+            )
+            rule["conditions"] = RuleProcessor.duplicate_conditions_for_all_targets(
+                rule["conditions"], targets
+            )
+
+        logger.info(f"Using dataset build by: {builder.__class__}")
+        return self.execute_rule(
+            rule, dataset, dataset_path, datasets, domain, **kwargs
+        )
 
     def execute_rule(
         self,
@@ -530,31 +342,6 @@ class RulesEngine:
             define_xml_contents, cache_service_obj=self.cache
         )
         return define_xml_reader.extract_domain_metadata(domain_name=domain_name)
-
-    def get_define_xml_variables_metadata(
-        self, dataset_path: str, domain_name: str
-    ) -> List[dict]:
-        """
-        Gets Define XML variables metadata.
-        """
-        directory_path = get_directory_path(dataset_path)
-        define_xml_path: str = f"{directory_path}/{DEFINE_XML_FILE_NAME}"
-        define_xml_contents: bytes = self.data_service.get_define_xml_contents(
-            dataset_name=define_xml_path
-        )
-        define_xml_reader = DefineXMLReader.from_file_contents(
-            define_xml_contents, cache_service_obj=self.cache
-        )
-        return define_xml_reader.extract_variables_metadata(domain_name=domain_name)
-
-    def get_corresponding_datasets_names(
-        self, dataset_path: str, datasets: List[dict], domain: str
-    ) -> List[str]:
-        directory_path = get_directory_path(dataset_path)
-        return [
-            f"{directory_path}/{dataset['filename']}"
-            for dataset in get_corresponding_datasets(datasets, domain)
-        ]
 
     def is_custom_domain(self, domain: str) -> bool:
         """

--- a/tests/unit/test_rules_engine.py
+++ b/tests/unit/test_rules_engine.py
@@ -1160,8 +1160,8 @@ def test_validate_dataset_metadata_against_define_xml(
     ],
 )
 @patch(
-    "cdisc_rules_engine.dataset_builders.base_dataset_builder. \
-            BaseDatasetBuilder.get_define_xml_variables_metadata"
+    "cdisc_rules_engine.dataset_builders.base_dataset_builder."
+    + "BaseDatasetBuilder.get_define_xml_variables_metadata"
 )
 @patch(
     "cdisc_rules_engine.services.data_services.LocalDataService.get_variables_metadata"

--- a/tests/unit/test_rules_engine.py
+++ b/tests/unit/test_rules_engine.py
@@ -1159,7 +1159,10 @@ def test_validate_dataset_metadata_against_define_xml(
         ),
     ],
 )
-@patch("cdisc_rules_engine.rules_engine.RulesEngine.get_define_xml_variables_metadata")
+@patch(
+    "cdisc_rules_engine.dataset_builders.base_dataset_builder. \
+            BaseDatasetBuilder.get_define_xml_variables_metadata"
+)
 @patch(
     "cdisc_rules_engine.services.data_services.LocalDataService.get_variables_metadata"
 )
@@ -1515,76 +1518,6 @@ def test_validate_split_dataset_variables_metadata(
             "message": "Variable metadata is wrong.",
         }
     ]
-
-
-@pytest.mark.parametrize(
-    "variable_metadata, allowed_terms_map, expected_validation_result",
-    [
-        (
-            [
-                {
-                    "define_variable_name": "TEST",
-                    "define_variable_label": "TEST LABEL",
-                    "define_variable_size": 20,
-                    "define_variable_role": "VAR ROLE",
-                    "define_variable_data_type": "Char",
-                    "define_variable_allowed_terms": ["DEAD", "deceased"],
-                    "define_variable_ccode": "C12345",
-                }
-            ],
-            {"C12345": ["dead", "deceased"]},
-            [
-                {
-                    "domain": "EC",
-                    "executionStatus": ExecutionStatus.SUCCESS.value,
-                    "variables": [
-                        "define_variable_allowed_terms",
-                        "define_variable_ccode",
-                        "define_variable_name",
-                    ],
-                    "errors": [
-                        {
-                            "row": 1,
-                            "value": {
-                                "define_variable_ccode": "C12345",
-                                "define_variable_name": "TEST",
-                                "define_variable_allowed_terms": ["DEAD", "deceased"],
-                            },
-                        }
-                    ],
-                    "message": "Define specifies invalid codelist terms",
-                }
-            ],
-        )
-    ],
-)
-@patch("cdisc_rules_engine.rules_engine.RulesEngine.get_define_xml_variables_metadata")
-def test_validate_define_ct_allowed_terms(
-    mock_get_define_xml_variables_metadata: MagicMock,
-    define_xml_allowed_terms_check_rule: dict,
-    variable_metadata: dict,
-    allowed_terms_map: pd.DataFrame,
-    expected_validation_result: List[dict],
-):
-    cache = InMemoryCacheService()
-    ct_package = "sdtmct-2021-12-17"
-    standard = "sdtmig"
-    standard_version = "3-3"
-    cache.add(ct_package, allowed_terms_map)
-    mock_get_define_xml_variables_metadata.return_value = variable_metadata
-    rules_engine = RulesEngine(
-        cache=cache,
-        ct_package=ct_package,
-        standard=standard,
-        standard_version=standard_version,
-    )
-    result = rules_engine.validate_define_xml(
-        define_xml_allowed_terms_check_rule,
-        "test/",
-        [{"domain": "EC", "filename": "ec.xpt"}],
-        "EC",
-    )
-    assert result == expected_validation_result
 
 
 def test_validate_record_in_parent_domain(


### PR DESCRIPTION
The goal of this PR is to cleanup how we handle different rule types. This PR extracts logic to build datasets based on rule type to a DatasetBuilder class. Each DatasetBuilder is a plugin based on the rule type and will generate the appropriate dataset for evaluation as necessary.