### PR TITLE
Get dataset variables as well as class variables

### DIFF
--- a/cdisc_rules_engine/constants/classes.py
+++ b/cdisc_rules_engine/constants/classes.py
@@ -3,6 +3,6 @@ from typing import Set
 FINDINGS: str = "Findings"
 INTERVENTIONS: str = "Interventions"
 EVENTS: str = "Events"
-DETECTABLE_CLASSES: Set[str] = {FINDINGS, INTERVENTIONS, EVENTS}
 FINDINGS_ABOUT: str = "Findings About"
+DETECTABLE_CLASSES: Set[str] = {FINDINGS, INTERVENTIONS, EVENTS, FINDINGS_ABOUT}
 GENERAL_OBSERVATIONS_CLASS: str = "General Observations"

--- a/cdisc_rules_engine/constants/classes.py
+++ b/cdisc_rules_engine/constants/classes.py
@@ -1,4 +1,8 @@
 from typing import Set
 
-DETECTABLE_CLASSES: Set[str] = {"Findings", "Interventions", "Events"}
+FINDINGS: str = "Findings"
+INTERVENTIONS: str = "Interventions"
+EVENTS: str = "Events"
+DETECTABLE_CLASSES: Set[str] = {FINDINGS, INTERVENTIONS, EVENTS}
+FINDINGS_ABOUT: str = "Findings About"
 GENERAL_OBSERVATIONS_CLASS: str = "General Observations"

--- a/cdisc_rules_engine/operations/library_column_order.py
+++ b/cdisc_rules_engine/operations/library_column_order.py
@@ -76,19 +76,10 @@ class LibraryColumnOrder(BaseOperation):
         model_cache_key = get_model_details_cache_key(model_type, model_version)
         model_details = self.cache.get(model_cache_key) or {}
 
-        # model class details includes all variables allowed in the domain
-        model_class_details: dict = self._get_class_metadata(
-            model_details, class_details.get("name")
-        )
-        class_variables: dict = {
-            v["name"].replace("--", self.params.domain): v
-            for v in model_class_details.get("classVariables", [])
-        }
         dataset_variables: dict = {
             v["name"]: v for v in domain_details.get("datasetVariables", [])
         }
-        variables: dict = {**class_variables, **dataset_variables}
-        variables_metadata = list(variables.values())
+        variables_metadata = list(dataset_variables.values())
         variables_metadata.sort(key=lambda item: item["ordinal"])
         if class_details.get("name") in DETECTABLE_CLASSES:
             # if the class is one of Interventions, Findings, or Events

--- a/cdisc_rules_engine/operations/library_column_order.py
+++ b/cdisc_rules_engine/operations/library_column_order.py
@@ -80,9 +80,16 @@ class LibraryColumnOrder(BaseOperation):
         model_class_details: dict = self._get_class_metadata(
             model_details, class_details.get("name")
         )
-        variables_metadata: List[dict] = model_class_details.get("classVariables", [])
+        class_variables: dict = {
+            v["name"].replace("--", self.params.domain): v
+            for v in model_class_details.get("classVariables", [])
+        }
+        dataset_variables: dict = {
+            v["name"]: v for v in domain_details.get("datasetVariables", [])
+        }
+        variables: dict = {**class_variables, **dataset_variables}
+        variables_metadata = list(variables.values())
         variables_metadata.sort(key=lambda item: item["ordinal"])
-
         if class_details.get("name") in DETECTABLE_CLASSES:
             # if the class is one of Interventions, Findings, or Events
             # and the standard is SDTMIG

--- a/cdisc_rules_engine/operations/library_column_order.py
+++ b/cdisc_rules_engine/operations/library_column_order.py
@@ -76,10 +76,7 @@ class LibraryColumnOrder(BaseOperation):
         model_cache_key = get_model_details_cache_key(model_type, model_version)
         model_details = self.cache.get(model_cache_key) or {}
 
-        dataset_variables: dict = {
-            v["name"]: v for v in domain_details.get("datasetVariables", [])
-        }
-        variables_metadata = list(dataset_variables.values())
+        variables_metadata = domain_details.get("datasetVariables", [])
         variables_metadata.sort(key=lambda item: item["ordinal"])
         if class_details.get("name") in DETECTABLE_CLASSES:
             # if the class is one of Interventions, Findings, or Events

--- a/cdisc_rules_engine/operations/library_model_column_order.py
+++ b/cdisc_rules_engine/operations/library_model_column_order.py
@@ -3,6 +3,8 @@ from typing import List, Optional, Tuple
 from cdisc_rules_engine.constants.classes import (
     DETECTABLE_CLASSES,
     GENERAL_OBSERVATIONS_CLASS,
+    FINDINGS_ABOUT,
+    FINDINGS,
 )
 from cdisc_rules_engine.enums.variable_roles import VariableRoles
 from cdisc_rules_engine.operations.base_operation import BaseOperation
@@ -13,7 +15,7 @@ from cdisc_rules_engine.utilities.utils import (
 )
 
 
-class LibraryColumnOrder(BaseOperation):
+class LibraryModelColumnOrder(BaseOperation):
     def _execute_operation(self):
         """
         Fetches column order for a given domain from the CDISC library.
@@ -69,19 +71,43 @@ class LibraryColumnOrder(BaseOperation):
 
         standard_details: dict = self.cache.get(cache_key) or {}
         model = standard_details.get("_links", {}).get("model")
-        class_details, domain_details = self._get_class_and_domain_metadata(
-            standard_details
-        )
         model_type, model_version = self._get_model_type_and_version(model)
         model_cache_key = get_model_details_cache_key(model_type, model_version)
         model_details = self.cache.get(model_cache_key) or {}
-
+        domain_details = self._get_model_domain_metadata(
+            model_details, self.params.domain
+        )
+        class_title = domain_details["_links"]["parentClass"]["title"]
+        class_details = self._get_model_class_metadata(model_details, class_title)
         variables_metadata = domain_details.get("datasetVariables", [])
         variables_metadata.sort(key=lambda item: item["ordinal"])
-        if class_details.get("name") in DETECTABLE_CLASSES:
-            # if the class is one of Interventions, Findings, Events
-            # -> add General Observation class variables to variables metadata
-            gen_obs_class_metadata: dict = self._get_class_metadata(
+        class_name = class_details.get("name")
+        if class_name in DETECTABLE_CLASSES or class_name == FINDINGS_ABOUT:
+            # if the class is one of Interventions, Findings, Events, or Findings About
+            # -> get class variables instead of datasetVariables add
+            # General Observation class variables to variables metadata
+            variables_metadata = class_details.get("classVariables", [])
+            variables_metadata.sort(key=lambda item: item["ordinal"])
+
+            if class_name == FINDINGS_ABOUT:
+                # Add FINDINGS class variables. Findings About class variables should
+                # Appear in the list after the --TEST variable
+                findings_class_metadata: dict = self._get_model_class_metadata(
+                    model_details, FINDINGS
+                )
+                findings_class_variables = findings_class_metadata["classVariables"]
+                findings_class_variables.sort(key=lambda item: item["ordinal"])
+                test_index = len(findings_class_variables) - 1
+                for i, v in enumerate(findings_class_variables):
+                    if v["name"].lower().endswith("test"):
+                        test_index = i
+                variables_metadata = (
+                    findings_class_variables[: test_index + 1]
+                    + variables_metadata
+                    + findings_class_variables[test_index + 1 :]
+                )
+
+            gen_obs_class_metadata: dict = self._get_model_class_metadata(
                 model_details, GENERAL_OBSERVATIONS_CLASS
             )
             identifiers_metadata, timing_metadata = self._sort_class_variables_by_role(
@@ -108,10 +134,10 @@ class LibraryColumnOrder(BaseOperation):
             model_version = ""
         return model_type, model_version
 
-    def _get_class_metadata(
+    def _get_model_class_metadata(
         self,
         model_details: dict,
-        dataset_class: str,
+        class_title: str,
     ) -> dict:
         """
         Extracts metadata of a certain class
@@ -119,27 +145,32 @@ class LibraryColumnOrder(BaseOperation):
         """
         class_metadata: Optional[dict] = search_in_list_of_dicts(
             model_details.get("classes", []),
-            lambda item: item["name"] == dataset_class,
+            lambda item: item["label"] == class_title,
         )
         if not class_metadata:
             raise ValueError(
-                f"Variables metadata is not found in CDISC Library. "
+                f"Model class metadata is not found in CDISC Library. "
                 f"standard={self.params.standard}, "
                 f"version={self.params.standard_version}, "
-                f"class={dataset_class}"
+                f"class={class_title}"
             )
         return class_metadata
 
-    def _get_class_and_domain_metadata(self, standard_details) -> Tuple:
-        # Get domain and class details for domain. This logic is specific
-        # to SDTM based standards. Needs to be expanded for other models
-        for c in standard_details.get("classes"):
-            domain_details = search_in_list_of_dicts(
-                c.get("datasets", []), lambda item: item["name"] == self.params.domain
+    def _get_model_domain_metadata(self, model_details, domain_name) -> Tuple:
+        # Get domain metadata from model
+        domain_details: Optional[dict] = search_in_list_of_dicts(
+            model_details.get("datasets", []), lambda item: item["name"] == domain_name
+        )
+
+        if not domain_details:
+            raise ValueError(
+                f"Model domain metadata is not found in CDISC Library. "
+                f"standard={self.params.standard}, "
+                f"version={self.params.standard_version}, "
+                f"domain={domain_name}"
             )
-            if domain_details:
-                return c, domain_details
-        return {}, {}
+
+        return domain_details
 
     def _sort_class_variables_by_role(
         self, class_variables: List[dict]

--- a/cdisc_rules_engine/operations/library_model_column_order.py
+++ b/cdisc_rules_engine/operations/library_model_column_order.py
@@ -90,6 +90,7 @@ class LibraryModelColumnOrder(BaseOperation):
             class_name = self.data_service.get_dataset_class(
                 self.params.dataframe, self.params.dataset_path, self.params.datasets
             )
+            class_details = self._get_model_class_metadata(model_details, class_name)
 
         if class_name in DETECTABLE_CLASSES:
             # if the class is one of Interventions, Findings, Events, or Findings About

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -7,6 +7,9 @@ from cdisc_rules_engine.operations.day_data_validator import DayDataValidator
 from cdisc_rules_engine.operations.distinct import Distinct
 from cdisc_rules_engine.operations.extract_metadata import ExtractMetadata
 from cdisc_rules_engine.operations.library_column_order import LibraryColumnOrder
+from cdisc_rules_engine.operations.library_model_column_order import (
+    LibraryModelColumnOrder,
+)
 from cdisc_rules_engine.operations.max_date import MaxDate
 from cdisc_rules_engine.operations.maximum import Maximum
 from cdisc_rules_engine.operations.mean import Mean
@@ -42,6 +45,7 @@ class OperationsFactory(FactoryInterface):
         "extract_metadata": ExtractMetadata,
         "get_column_order_from_dataset": DatasetColumnOrder,
         "get_column_order_from_library": LibraryColumnOrder,
+        "get_model_column_order": LibraryModelColumnOrder,
         "max": Maximum,
         "max_date": MaxDate,
         "mean": Mean,

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -143,9 +143,10 @@ class BaseDataService(DataServiceInterface, ABC):
         elif self._contains_topic_variable(dataset, "TRT"):
             return INTERVENTIONS
         elif self._contains_topic_variable(dataset, "TESTCD"):
-            return FINDINGS
-        elif self._contains_topic_variable(dataset, "OBJ"):
-            return FINDINGS_ABOUT
+            if self._contains_topic_variable(dataset, "OBJ"):
+                return FINDINGS_ABOUT
+            else:
+                return FINDINGS
         elif self._is_associated_persons(dataset):
             return self._get_associated_persons_inherit_class(
                 dataset, file_path, datasets

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -12,6 +12,12 @@ from cdisc_rules_engine.interfaces import (
     ConfigInterface,
     DataServiceInterface,
 )
+from cdisc_rules_engine.constants.classes import (
+    FINDINGS,
+    FINDINGS_ABOUT,
+    EVENTS,
+    INTERVENTIONS,
+)
 from cdisc_rules_engine.models.dataset_types import DatasetTypes
 from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.services.data_readers import DataReaderFactory
@@ -133,11 +139,13 @@ class BaseDataService(DataServiceInterface, ABC):
         self, dataset: pd.DataFrame, file_path: str, datasets: List[dict]
     ) -> Optional[str]:
         if self._contains_topic_variable(dataset, "TERM"):
-            return "Events"
+            return EVENTS
         elif self._contains_topic_variable(dataset, "TRT"):
-            return "Interventions"
+            return INTERVENTIONS
         elif self._contains_topic_variable(dataset, "TESTCD"):
-            return "Findings"
+            return FINDINGS
+        elif self._contains_topic_variable(dataset, "OBJ"):
+            return FINDINGS_ABOUT
         elif self._is_associated_persons(dataset):
             return self._get_associated_persons_inherit_class(
                 dataset, file_path, datasets
@@ -186,7 +194,10 @@ class BaseDataService(DataServiceInterface, ABC):
         Checks if the given dataset-class string ends with a particular variable string.
         Returns True/False
         """
-        return dataset.columns.str.endswith(variable).any()
+        if "DOMAIN" not in dataset:
+            return False
+        domain = dataset["DOMAIN"].values[0]
+        return domain.upper() + variable in dataset
 
     def _domain_starts_with(self, domain, variable):
         """

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -3,7 +3,11 @@ from typing import List, Optional, Set, Union, Tuple
 
 import pandas as pd
 
-from cdisc_rules_engine.constants.classes import DETECTABLE_CLASSES
+from cdisc_rules_engine.constants.classes import (
+    DETECTABLE_CLASSES,
+    FINDINGS_ABOUT,
+    FINDINGS,
+)
 from cdisc_rules_engine.constants.domains import (
     AP_DOMAIN,
     APFA_DOMAIN,
@@ -174,9 +178,9 @@ class RuleProcessor:
                 dataset, file_path, datasets
             )
             if (
-                class_name not in included_classes
-                and ALL_KEYWORD not in included_classes
-            ):
+                (class_name not in included_classes)
+                and not (class_name == FINDINGS_ABOUT and FINDINGS in included_classes)
+            ) and ALL_KEYWORD not in included_classes:
                 is_included = False
 
         if excluded_classes:
@@ -184,7 +188,10 @@ class RuleProcessor:
             class_name = self.data_service.get_dataset_class(
                 dataset, file_path, datasets
             )
-            if class_name and class_name in excluded_classes:
+            if class_name and (
+                (class_name in excluded_classes)
+                or (class_name == FINDINGS_ABOUT and FINDINGS in excluded_classes)
+            ):
                 is_excluded = True
         return is_included and not is_excluded
 

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -90,8 +90,14 @@ def test_get_raw_dataset_metadata(
         ),
         (
             [{"domain": "AE", "filename": "ae.xpt"}],
-            {"DOMAIN": ["AE"], "AEOBJ": ["test"]},
+            {"DOMAIN": ["AE"], "AETESTCD": ["test"], "AEOBJ": ["test"]},
             "Findings About",
+            "ae.xpt",
+        ),
+        (
+            [{"domain": "AE", "filename": "ae.xpt"}],
+            {"DOMAIN": ["AE"], "AEOBJ": ["test"]},
+            None,
             "ae.xpt",
         ),
         ([{"domain": "AE", "filename": "ae.xpt"}], {"UNKNOWN": ["test"]}, None, "None"),

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -134,6 +134,7 @@ def test_cached_data_cache_exists():
     dataset, so the function should not be called
     and the cache data should be returned.
     """
+
     # create a test wrapped function
     @cached_dataset(DatasetTypes.CONTENTS.value)
     def to_be_decorated(instance, dataset_name: str):

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -72,20 +72,26 @@ def test_get_raw_dataset_metadata(
     [
         (
             [{"domain": "AE", "filename": "ae.xpt"}],
-            {"AETERM": ["test"]},
+            {"DOMAIN": ["AE"], "AETERM": ["test"]},
             "Events",
             "ae.xpt",
         ),
         (
             [{"domain": "AE", "filename": "ae.xpt"}],
-            {"AETRT": ["test"]},
+            {"DOMAIN": ["AE"], "AETRT": ["test"]},
             "Interventions",
             "ae.xpt",
         ),
         (
             [{"domain": "AE", "filename": "ae.xpt"}],
-            {"AETESTCD": ["test"]},
+            {"DOMAIN": ["AE"], "AETESTCD": ["test"]},
             "Findings",
+            "ae.xpt",
+        ),
+        (
+            [{"domain": "AE", "filename": "ae.xpt"}],
+            {"DOMAIN": ["AE"], "AEOBJ": ["test"]},
+            "Findings About",
             "ae.xpt",
         ),
         ([{"domain": "AE", "filename": "ae.xpt"}], {"UNKNOWN": ["test"]}, None, "None"),
@@ -104,7 +110,7 @@ def test_get_dataset_class_associated_domains():
         {"domain": "CE", "filename": "ce.xpt"},
     ]
     ap_dataset = pd.DataFrame.from_dict({"DOMAIN": ["APCE"]})
-    ce_dataset = pd.DataFrame.from_dict({"CETERM": ["test"]})
+    ce_dataset = pd.DataFrame.from_dict({"DOMAIN": ["CE"], "CETERM": ["test"]})
     data_bundle_path = "cdisc/databundle"
     path_to_dataset_map: dict = {
         f"{data_bundle_path}/ap.xpt": ap_dataset,

--- a/tests/unit/test_operations/test_library_column_order.py
+++ b/tests/unit/test_operations/test_library_column_order.py
@@ -131,7 +131,9 @@ def test_get_column_order_from_library(
         "STUDYID",
         "DOMAIN",
         "AETERM",
+        "AETEST",
         "AESEQ",
+        "AENEW",
         "TIMING_VAR",
     ]
     expected: pd.Series = pd.Series(
@@ -141,4 +143,5 @@ def test_get_column_order_from_library(
             variables,
         ]
     )
+    print(result[operation_params.operation_id])
     assert result[operation_params.operation_id].equals(expected)

--- a/tests/unit/test_operations/test_library_column_order.py
+++ b/tests/unit/test_operations/test_library_column_order.py
@@ -141,5 +141,4 @@ def test_get_column_order_from_library(
             variables,
         ]
     )
-    print(result[operation_params.operation_id])
     assert result[operation_params.operation_id].equals(expected)

--- a/tests/unit/test_operations/test_library_column_order.py
+++ b/tests/unit/test_operations/test_library_column_order.py
@@ -130,9 +130,7 @@ def test_get_column_order_from_library(
     variables: List[str] = [
         "STUDYID",
         "DOMAIN",
-        "AETERM",
         "AETEST",
-        "AESEQ",
         "AENEW",
         "TIMING_VAR",
     ]

--- a/tests/unit/test_operations/test_library_model_column_order.py
+++ b/tests/unit/test_operations/test_library_model_column_order.py
@@ -161,7 +161,7 @@ def test_get_column_order_from_library(
                 "datasets": [
                     {
                         "_links": {"parentClass": {"title": FINDINGS_ABOUT}},
-                        "name": "AE",
+                        "name": "NOTTHESAME",
                         "datasetVariables": [
                             {
                                 "name": "AETERM",
@@ -249,7 +249,8 @@ def test_get_findings_class_column_order_from_library(
                 "TEST_STUDY",
                 "TEST_STUDY",
             ],
-            "AETERM": [
+            "DOMAIN": ["AE", "AE", "AE"],
+            "AEOBJ": [
                 "test",
                 "test",
                 "test",

--- a/tests/unit/test_operations/test_library_model_column_order.py
+++ b/tests/unit/test_operations/test_library_model_column_order.py
@@ -255,6 +255,7 @@ def test_get_findings_class_column_order_from_library(
                 "test",
                 "test",
             ],
+            "AETESTCD": ["test", "test", "test"],
         }
     )
     operation_params.domain = "AE"

--- a/tests/unit/test_operations/test_library_model_column_order.py
+++ b/tests/unit/test_operations/test_library_model_column_order.py
@@ -218,7 +218,7 @@ def test_get_column_order_from_library(
                 "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
                 "classes": [
                     {
-                        "name": "Findings About",
+                        "name": FINDINGS_ABOUT,
                         "datasets": [
                             {
                                 "name": "AE",

--- a/tests/unit/test_operations/test_library_model_column_order.py
+++ b/tests/unit/test_operations/test_library_model_column_order.py
@@ -1,0 +1,295 @@
+from typing import List
+
+import pandas as pd
+import pytest
+
+from cdisc_rules_engine.constants.classes import (
+    GENERAL_OBSERVATIONS_CLASS,
+    FINDINGS,
+    FINDINGS_ABOUT,
+)
+from cdisc_rules_engine.enums.variable_roles import VariableRoles
+from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.operations.library_model_column_order import (
+    LibraryModelColumnOrder,
+)
+from cdisc_rules_engine.services.cache import InMemoryCacheService
+from cdisc_rules_engine.services.data_services import LocalDataService
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+    get_model_details_cache_key,
+)
+
+
+@pytest.mark.parametrize(
+    "model_metadata, standard_metadata",
+    [
+        (
+            {
+                "datasets": [
+                    {
+                        "_links": {"parentClass": {"title": "Events"}},
+                        "name": "AE",
+                        "datasetVariables": [
+                            {
+                                "name": "AETERM",
+                                "ordinal": 4,
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": 3,
+                            },
+                        ],
+                    }
+                ],
+                "classes": [
+                    {
+                        "name": "Events",
+                        "label": "Events",
+                        "classVariables": [
+                            {"name": "--TERM", "ordinal": 1},
+                            {"name": "--SEQ", "ordinal": 2},
+                        ],
+                    },
+                    {
+                        "name": GENERAL_OBSERVATIONS_CLASS,
+                        "label": GENERAL_OBSERVATIONS_CLASS,
+                        "classVariables": [
+                            {
+                                "name": "DOMAIN",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 2,
+                            },
+                            {
+                                "name": "STUDYID",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 1,
+                            },
+                            {
+                                "name": "TIMING_VAR",
+                                "role": VariableRoles.TIMING.value,
+                                "ordinal": 33,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+                "classes": [
+                    {
+                        "name": "Events",
+                        "datasets": [
+                            {
+                                "name": "AE",
+                                "label": "Adverse Events",
+                                "datasetVariables": [
+                                    {"name": "AETEST", "ordinal": 1},
+                                    {"name": "AENEW", "ordinal": 2},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+    ],
+)
+def test_get_column_order_from_library(
+    operation_params: OperationParams, model_metadata: dict, standard_metadata: dict
+):
+    """
+    Unit test for DataProcessor.get_column_order_from_library.
+    Mocks cache call to return metadata.
+    """
+    operation_params.dataframe = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.domain = "AE"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    cache.add(
+        get_standard_details_cache_key(
+            operation_params.standard, operation_params.standard_version
+        ),
+        standard_metadata,
+    )
+    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
+
+    # execute operation
+    data_service = LocalDataService.get_instance(cache_service=cache)
+    operation = LibraryModelColumnOrder(
+        operation_params, operation_params.dataframe, cache, data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    variables: List[str] = [
+        "STUDYID",
+        "DOMAIN",
+        "AETERM",
+        "AESEQ",
+        "TIMING_VAR",
+    ]
+    expected: pd.Series = pd.Series(
+        [
+            variables,
+            variables,
+            variables,
+        ]
+    )
+    assert result[operation_params.operation_id].equals(expected)
+
+
+@pytest.mark.parametrize(
+    "model_metadata, standard_metadata",
+    [
+        (
+            {
+                "datasets": [
+                    {
+                        "_links": {"parentClass": {"title": FINDINGS_ABOUT}},
+                        "name": "AE",
+                        "datasetVariables": [
+                            {
+                                "name": "AETERM",
+                                "ordinal": 4,
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": 3,
+                            },
+                        ],
+                    }
+                ],
+                "classes": [
+                    {
+                        "name": FINDINGS_ABOUT,
+                        "label": FINDINGS_ABOUT,
+                        "classVariables": [
+                            {"name": "--OBJ", "ordinal": 1},
+                        ],
+                    },
+                    {
+                        "name": FINDINGS,
+                        "label": FINDINGS,
+                        "classVariables": [
+                            {"name": "--VAR1", "ordinal": 1},
+                            {"name": "--TEST", "ordinal": 2},
+                            {"name": "--VAR2", "ordinal": 3},
+                        ],
+                    },
+                    {
+                        "name": GENERAL_OBSERVATIONS_CLASS,
+                        "label": GENERAL_OBSERVATIONS_CLASS,
+                        "classVariables": [
+                            {
+                                "name": "DOMAIN",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 2,
+                            },
+                            {
+                                "name": "STUDYID",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 1,
+                            },
+                            {
+                                "name": "TIMING_VAR",
+                                "role": VariableRoles.TIMING.value,
+                                "ordinal": 33,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+                "classes": [
+                    {
+                        "name": "Findings About",
+                        "datasets": [
+                            {
+                                "name": "AE",
+                                "label": "Adverse Events",
+                                "datasetVariables": [
+                                    {"name": "AETEST", "ordinal": 1},
+                                    {"name": "AENEW", "ordinal": 2},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+    ],
+)
+def test_get_findings_class_column_order_from_library(
+    operation_params: OperationParams, model_metadata: dict, standard_metadata: dict
+):
+    """
+    Unit test for DataProcessor.get_column_order_from_library.
+    Mocks cache call to return metadata.
+    """
+    operation_params.dataframe = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.domain = "AE"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    cache.add(
+        get_standard_details_cache_key(
+            operation_params.standard, operation_params.standard_version
+        ),
+        standard_metadata,
+    )
+    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
+
+    # execute operation
+    data_service = LocalDataService.get_instance(cache_service=cache)
+    operation = LibraryModelColumnOrder(
+        operation_params, operation_params.dataframe, cache, data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    variables: List[str] = [
+        "STUDYID",
+        "DOMAIN",
+        "AEVAR1",
+        "AETEST",
+        "AEOBJ",
+        "AEVAR2",
+        "TIMING_VAR",
+    ]
+    expected: pd.Series = pd.Series(
+        [
+            variables,
+            variables,
+            variables,
+        ]
+    )
+    assert result[operation_params.operation_id].equals(expected)

--- a/tests/unit/test_utilities/test_rule_processor.py
+++ b/tests/unit/test_utilities/test_rule_processor.py
@@ -319,6 +319,22 @@ def test_rule_applies_to_domain_split_datasets(
             "Findings About",
             False,
         ),
+        (
+            [{"domain": "AE", "filename": "ae.xpt"}],
+            "AE",
+            {"classes": {"Exclude": ["Findings About"]}},
+            {"AETESTCD": [10, 20]},
+            "Findings About",
+            False,
+        ),
+        (
+            [{"domain": "AE", "filename": "ae.xpt"}],
+            "AE",
+            {"classes": {"Include": ["Findings About"]}},
+            {"AETESTCD": [10, 20]},
+            "Findings About",
+            True,
+        ),
     ],
 )
 def test_rule_applies_to_class(

--- a/tests/unit/test_utilities/test_rule_processor.py
+++ b/tests/unit/test_utilities/test_rule_processor.py
@@ -303,6 +303,22 @@ def test_rule_applies_to_domain_split_datasets(
             "Associated Persons",
             True,
         ),
+        (
+            [{"domain": "AE", "filename": "ae.xpt"}],
+            "AE",
+            {"classes": {"Include": ["Findings"]}},
+            {"AETESTCD": [10, 20]},
+            "Findings About",
+            True,
+        ),
+        (
+            [{"domain": "AE", "filename": "ae.xpt"}],
+            "AE",
+            {"classes": {"Exclude": ["Findings"]}},
+            {"AETESTCD": [10, 20]},
+            "Findings About",
+            False,
+        ),
     ],
 )
 def test_rule_applies_to_class(


### PR DESCRIPTION
This PR updates the library column order operation to generate the list using the  datasetVariables for a domain. If the dataset is a general observations class, the Identifier and Timing variables are added.

This PR also adds a new operation "get_model_column_order", which gets the dataset variables for a domain from the model, and appends Identifier and Timing variables as necessary. Additionally, if the dataset is apart of the findings about class, the findings variables and findings about variables are also added to the list of allowed variables