### PR TITLE
Get dataset name from file name and add optional_condition_parameters

### DIFF
--- a/cdisc_rules_engine/dummy_models/dummy_dataset.py
+++ b/cdisc_rules_engine/dummy_models/dummy_dataset.py
@@ -21,7 +21,7 @@ class DummyDataset:
     def get_metadata(self):
         return {
             "dataset_size": [self.filesize or 1000],
-            "dataset_name": [self.domain or "test"],
+            "dataset_name": [self.filename.split(".")[0].upper() or "test"],
             "dataset_label": [self.label or "test"],
             "filename": [self.filename],
         }

--- a/cdisc_rules_engine/enums/optional_condition_parameters.py
+++ b/cdisc_rules_engine/enums/optional_condition_parameters.py
@@ -7,3 +7,6 @@ class OptionalConditionParameters(BaseEnum):
     SUFFIX = "suffix"
     CONTEXT = "context"
     VALUE_IS_LITERAL = "value_is_literal"
+    WITHIN = "within"
+    ORDERING = "ordering"
+    ORDER = "order"

--- a/cdisc_rules_engine/services/data_services/local_data_service.py
+++ b/cdisc_rules_engine/services/data_services/local_data_service.py
@@ -170,13 +170,14 @@ class LocalDataService(BaseDataService):
 
     def read_metadata(self, file_path: str) -> dict:
         file_size = os.path.getsize(file_path)
+        file_name = extract_file_name_from_path_string(file_path)
         file_metadata = {
             "path": file_path,
-            "name": extract_file_name_from_path_string(file_path),
+            "name": file_name,
             "size": file_size,
         }
         with open(file_path, "rb") as f:
-            contents_metadata = DatasetMetadataReader(f.read()).read()
+            contents_metadata = DatasetMetadataReader(f.read(), file_name).read()
 
         return {
             "file_metadata": file_metadata,

--- a/cdisc_rules_engine/services/dataset_metadata_reader.py
+++ b/cdisc_rules_engine/services/dataset_metadata_reader.py
@@ -17,10 +17,11 @@ class DatasetMetadataReader:
 
     # TODO. Maybe in future it is worth having multiple constructors
     #  like from_bytes, from_file etc. But now there is no immediate need for that.
-    def __init__(self, contents_in_bytes: bytes):
+    def __init__(self, contents_in_bytes: bytes, file_name: str):
         self._file_contents = contents_in_bytes
         self._metadata_container = None
         self._domain_name = None
+        self._dataset_name = file_name.split(".")[0].upper()
 
     def read(self) -> dict:
         """
@@ -45,7 +46,7 @@ class DatasetMetadataReader:
             "number_of_variables": len(dataset.columns),
             "dataset_label": dataset.dataset_label,
             "domain_name": self._domain_name,
-            "dataset_name": dataset.name,
+            "dataset_name": self._dataset_name,
             "dataset_modification_date": dataset.modified.isoformat(),
         }
         self._domain_name = self._extract_domain_name(dataset)
@@ -92,14 +93,14 @@ class DatasetMetadataReader:
         return {
             "variable_labels": self._metadata_container.column_labels,
             "variable_names": self._metadata_container.column_names,
-            "variable_name_to_label_map": self._metadata_container.column_names_to_labels,
-            "variable_name_to_data_type_map": self._metadata_container.readstat_variable_types,
-            "variable_name_to_size_map": self._metadata_container.variable_storage_width,
+            "variable_name_to_label_map": self._metadata_container.column_names_to_labels,  # noqa
+            "variable_name_to_data_type_map": self._metadata_container.readstat_variable_types,  # noqa
+            "variable_name_to_size_map": self._metadata_container.variable_storage_width,  # noqa
             "number_of_variables": self._metadata_container.number_columns,
             "dataset_label": self._metadata_container.file_label,
             "domain_name": self._domain_name,
-            "dataset_name": self._metadata_container.table_name,
-            "dataset_modification_date": self._metadata_container.dataset_modification_date,
+            "dataset_name": self._dataset_name,
+            "dataset_modification_date": self._metadata_container.dataset_modification_date,  # noqa
         }
 
     def _extract_adam_info(self, variable_names):

--- a/tests/unit/test_adam_dataset_metadata_reader.py
+++ b/tests/unit/test_adam_dataset_metadata_reader.py
@@ -16,7 +16,7 @@ def test_read_metadata():
     )
     with open(test_dataset_path, "rb") as file:
         file_contents: bytes = file.read()
-        reader = DatasetMetadataReader(file_contents)
+        reader = DatasetMetadataReader(file_contents, file_name="test_adam_dataset.xpt")
         metadata: dict = reader.read()
         assert metadata["adam_info"] == {
             "categorization_scheme": {"CRIT1": 1},

--- a/tests/unit/test_dataset_metadata_reader.py
+++ b/tests/unit/test_dataset_metadata_reader.py
@@ -16,9 +16,9 @@ def test_read_metadata():
     )
     with open(test_dataset_path, "rb") as file:
         file_contents: bytes = file.read()
-        reader = DatasetMetadataReader(file_contents)
+        reader = DatasetMetadataReader(file_contents, file_name="test_dataset.xpt")
         metadata: dict = reader.read()
-        assert metadata["dataset_name"] == "EX", "Test file has been changed"
+        assert metadata["dataset_name"] == "TEST_DATASET", "Test file has been changed"
         assert metadata["domain_name"] == "EX", "Test file has been changed"
         assert metadata["dataset_label"] == "Exposure", "Test file has been changed"
         assert metadata["number_of_variables"] == 17, "Test file has been changed"


### PR DESCRIPTION
This PR adds missing optional condition parameters when generating executable rule and updates dataset metadata reader to get dataset_name from file name