### PR TITLE
Add domain label operation

### DIFF
--- a/cdisc_rules_engine/operations/domain_label.py
+++ b/cdisc_rules_engine/operations/domain_label.py
@@ -10,7 +10,7 @@ from cdisc_rules_engine import config
 class DomainLabel(BaseOperation):
     def _execute_operation(self):
         """
-        Return the set of variable names for the given standard
+        Return the domain label for the currently executing domain
         """
         cache_key = get_standard_details_cache_key(
             self.params.standard, self.params.standard_version

--- a/cdisc_rules_engine/operations/domain_label.py
+++ b/cdisc_rules_engine/operations/domain_label.py
@@ -1,0 +1,34 @@
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+    search_in_list_of_dicts,
+)
+from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
+from cdisc_rules_engine import config
+
+
+class DomainLabel(BaseOperation):
+    def _execute_operation(self):
+        """
+        Return the set of variable names for the given standard
+        """
+        cache_key = get_standard_details_cache_key(
+            self.params.standard, self.params.standard_version
+        )
+        standard_data: dict = self.cache.get(cache_key)
+        if standard_data is None:
+            cdisc_library_service = CDISCLibraryService(config, self.cache)
+            standard_data = set(
+                cdisc_library_service.get_standard(
+                    self.params.standard.lower(), self.params.standard_version
+                )
+            )
+            self.cache.set(cache_key, standard_data)
+        domain_details = None
+        for c in standard_data.get("classes", []):
+            domain_details = search_in_list_of_dicts(
+                c.get("datasets", []), lambda item: item["name"] == self.params.domain
+            )
+            if domain_details:
+                return domain_details.get("label", "")
+        return ""

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -10,6 +10,7 @@ from cdisc_rules_engine.operations.library_column_order import LibraryColumnOrde
 from cdisc_rules_engine.operations.max_date import MaxDate
 from cdisc_rules_engine.operations.maximum import Maximum
 from cdisc_rules_engine.operations.mean import Mean
+from cdisc_rules_engine.operations.domain_label import DomainLabel
 from cdisc_rules_engine.operations.meddra_code_references_validator import (
     MedDRACodeReferencesValidator,
 )
@@ -58,6 +59,7 @@ class OperationsFactory(FactoryInterface):
         "variable_permissibilities": VariablePermissibility,
         "variable_value_count": VariableValueCount,
         "variable_count": VariableCount,
+        "domain_label": DomainLabel,
     }
 
     @classmethod

--- a/tests/unit/test_operations/test_domain_label.py
+++ b/tests/unit/test_operations/test_domain_label.py
@@ -1,0 +1,194 @@
+import pandas as pd
+from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.operations.domain_label import DomainLabel
+from cdisc_rules_engine.services.cache import InMemoryCacheService
+from cdisc_rules_engine.services.data_services import LocalDataService
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+)
+
+
+def test_get_domain_label_from_library(operation_params: OperationParams):
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1},
+                            {"name": "AENEW", "ordinal": 2},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    operation_params.dataframe = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.domain = "AE"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    cache.add(
+        get_standard_details_cache_key(
+            operation_params.standard, operation_params.standard_version
+        ),
+        standard_metadata,
+    )
+    # execute operation
+    data_service = LocalDataService.get_instance(cache_service=cache)
+    operation = DomainLabel(
+        operation_params, operation_params.dataframe, cache, data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    expected: pd.Series = pd.Series(
+        [
+            "Adverse Events",
+            "Adverse Events",
+            "Adverse Events",
+        ]
+    )
+    assert result[operation_params.operation_id].equals(expected)
+
+
+def test_get_domain_label_from_library_domain_not_found(
+    operation_params: OperationParams,
+):
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1},
+                            {"name": "AENEW", "ordinal": 2},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    operation_params.dataframe = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.domain = "VS"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    cache.add(
+        get_standard_details_cache_key(
+            operation_params.standard, operation_params.standard_version
+        ),
+        standard_metadata,
+    )
+    # execute operation
+    data_service = LocalDataService.get_instance(cache_service=cache)
+    operation = DomainLabel(
+        operation_params, operation_params.dataframe, cache, data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    expected: pd.Series = pd.Series(
+        [
+            "",
+            "",
+            "",
+        ]
+    )
+    assert result[operation_params.operation_id].equals(expected)
+
+
+def test_get_domain_label_from_library_domain_missing_label(
+    operation_params: OperationParams,
+):
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1},
+                            {"name": "AENEW", "ordinal": 2},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    operation_params.dataframe = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.domain = "AE"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    cache.add(
+        get_standard_details_cache_key(
+            operation_params.standard, operation_params.standard_version
+        ),
+        standard_metadata,
+    )
+    # execute operation
+    data_service = LocalDataService.get_instance(cache_service=cache)
+    operation = DomainLabel(
+        operation_params, operation_params.dataframe, cache, data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    expected: pd.Series = pd.Series(
+        [
+            "",
+            "",
+            "",
+        ]
+    )
+    assert result[operation_params.operation_id].equals(expected)


### PR DESCRIPTION
This PR adds a domain_label operation which gets the domain label for the current dataset. Steps to test:

1. Run the unit tests