### PR TITLE
Add study domains operation and upgrade rule engine

### DIFF
--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -40,6 +40,7 @@ from cdisc_rules_engine.operations.variable_count import VariableCount
 from cdisc_rules_engine.operations.required_variables import RequiredVariables
 from cdisc_rules_engine.operations.expected_variables import ExpectedVariables
 from cdisc_rules_engine.operations.permissible_variables import PermissibleVariables
+from cdisc_rules_engine.operations.study_domains import StudyDomains
 
 
 class OperationsFactory(FactoryInterface):
@@ -70,6 +71,7 @@ class OperationsFactory(FactoryInterface):
         "required_variables": RequiredVariables,
         "expected_variables": ExpectedVariables,
         "permissible_variables": PermissibleVariables,
+        "study_domains": StudyDomains,
     }
 
     @classmethod

--- a/cdisc_rules_engine/operations/study_domains.py
+++ b/cdisc_rules_engine/operations/study_domains.py
@@ -1,0 +1,9 @@
+from .base_operation import BaseOperation
+
+
+class StudyDomains(BaseOperation):
+    def _execute_operation(self):
+        """
+        Returns a list of the domains in the study
+        """
+        return list({dataset.get("domain", "") for dataset in self.params.datasets})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pytest==7.1.2
 pytest-cov==3.0.0
 pandas==1.3.5
-business-rules-enhanced==1.2.6
+business-rules-enhanced==1.3.0
 python-dotenv==0.20.0
 cdisc-library-client==0.1.4
 pytest-asyncio==0.18.3

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     python_requires=">=3.8",
     install_requires=[
         "pandas>=1.3.5",
-        "business-rules-enhanced==1.2.5",
+        "business-rules-enhanced==1.3.0",
         "python-dotenv==0.20.0",
         "cdisc-library-client==0.1.4",
         "odmlib==0.1.4",

--- a/tests/unit/test_operations/test_study_domains.py
+++ b/tests/unit/test_operations/test_study_domains.py
@@ -1,0 +1,47 @@
+import pandas as pd
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.operations.study_domains import StudyDomains
+from cdisc_rules_engine.models.operation_params import OperationParams
+
+from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+from cdisc_rules_engine.services.data_services.data_service_factory import (
+    DataServiceFactory,
+)
+
+
+def test_get_study_domains_with_duplicates(operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    datasets = [
+        {"filename": "dm.xpt", "domain": "DM"},
+        {"filename": "dm1.xpt", "domain": "DM"},
+        {"filename": "ae.xpt", "domain": "AE"},
+        {"filename": "tv.xpt", "domain": "TV"},
+    ]
+    operation_params.datasets = datasets
+    result = StudyDomains(
+        operation_params, pd.DataFrame.from_dict({"A": [1, 2, 3]}), cache, data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        assert sorted(val) == ["AE", "DM", "TV"]
+
+
+def test_get_study_domains_with_missing_domains(operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    datasets = [
+        {"filename": "dm.xpt"},
+        {"filename": "dm1.xpt", "domain": "DM"},
+        {"filename": "ae.xpt", "domain": "AE"},
+        {"filename": "tv.xpt", "domain": "TV"},
+    ]
+    operation_params.datasets = datasets
+    result = StudyDomains(
+        operation_params, pd.DataFrame.from_dict({"A": [1, 2, 3]}), cache, data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        assert sorted(val) == ["", "AE", "DM", "TV"]


### PR DESCRIPTION
Adds new operation study domains to support CORERULES-203 and 204

Steps to test:
1. Run the unit test

Note: The current test functionality cannot test this because the source of "study domains" is the same as the source for dataset metadata