### PR TITLE
Filter non datasets from the list of datasets to validate

### DIFF
--- a/cdisc_rules_engine/models/validation_args.py
+++ b/cdisc_rules_engine/models/validation_args.py
@@ -15,6 +15,7 @@ Validation_args = namedtuple(
         "output_format",
         "raw_report",
         "define_version",
+        "data_format",
         "whodrug",
         "meddra",
         "rules",


### PR DESCRIPTION
Steps to test:

1. Add a non xpt file to the data directory specified in the -d flag
2. Run a validation
3. Verify that the validation completes
4. Run a new validation, specifying a single non xpt file using the -dp flag
5. Verify that the validation completes