### PR TITLE
ISS-235: Add variable format to variable metadata dataframe

### DIFF
--- a/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
@@ -11,6 +11,7 @@ class VariablesMetadataDatasetBuilder(BaseDatasetBuilder):
         variable_label
         variable_size
         variable_data_type
+        variable_format
         """
         return self.data_service.get_variables_metadata(
             self.dataset_path, drop_duplicates=True

--- a/cdisc_rules_engine/dummy_models/dummy_variable.py
+++ b/cdisc_rules_engine/dummy_models/dummy_variable.py
@@ -4,3 +4,4 @@ class DummyVariable:
         self.label = variable_data.get("label")
         self.type = variable_data.get("type")
         self.length = variable_data.get("length")
+        self.format = variable_data.get("format")

--- a/cdisc_rules_engine/models/variable_metadata_container.py
+++ b/cdisc_rules_engine/models/variable_metadata_container.py
@@ -4,6 +4,7 @@ from cdisc_rules_engine.interfaces import RepresentationInterface
 class VariableMetadataContainer(RepresentationInterface):
     def __init__(self, contents_metadata: dict):
         variable_names = contents_metadata["variable_names"]
+        self.formats = contents_metadata["variable_formats"]
         self.names = variable_names
         self.order = [(variable_names.index(name) + 1) for name in variable_names]
         self.labels = contents_metadata["variable_name_to_label_map"].values()
@@ -17,4 +18,5 @@ class VariableMetadataContainer(RepresentationInterface):
             "variable_label": self.labels,
             "variable_size": self.sizes,
             "variable_data_type": self.data_types,
+            "variable_format": self.formats,
         }

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -84,7 +84,7 @@ class DummyDataService(BaseDataService):
             "variable_label": [],
             "variable_size": [],
             "variable_data_type": [],
-            "variable_format": []
+            "variable_format": [],
         }
         dataset: DummyDataset = self.get_dataset_data(dataset_name)
         for i, variable in enumerate(dataset.variables):
@@ -103,7 +103,9 @@ class DummyDataService(BaseDataService):
             metadata_to_return["variable_data_type"] = metadata_to_return[
                 "variable_data_type"
             ] + [variable.type]
-            metadata_to_return["variable_format"] = metadata_to_return["variable_format"] + [variable.format]
+            metadata_to_return["variable_format"] = metadata_to_return[
+                "variable_format"
+            ] + [variable.format]
         return pd.DataFrame.from_dict(metadata_to_return)
 
     def get_dataset_by_type(

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -84,6 +84,7 @@ class DummyDataService(BaseDataService):
             "variable_label": [],
             "variable_size": [],
             "variable_data_type": [],
+            "variable_format": []
         }
         dataset: DummyDataset = self.get_dataset_data(dataset_name)
         for i, variable in enumerate(dataset.variables):
@@ -102,7 +103,7 @@ class DummyDataService(BaseDataService):
             metadata_to_return["variable_data_type"] = metadata_to_return[
                 "variable_data_type"
             ] + [variable.type]
-
+            metadata_to_return["variable_format"] = metadata_to_return["variable_format"] + [variable.format]
         return pd.DataFrame.from_dict(metadata_to_return)
 
     def get_dataset_by_type(

--- a/cdisc_rules_engine/services/dataset_metadata_reader.py
+++ b/cdisc_rules_engine/services/dataset_metadata_reader.py
@@ -34,6 +34,7 @@ class DatasetMetadataReader:
         self._metadata_container = {
             "variable_labels": list(dataset.contents.Label.values),
             "variable_names": list(dataset.contents.Variable.values),
+            "variable_formats": list(dataset.contents.Format.values),
             "variable_name_to_label_map": pd.Series(
                 dataset.contents.Label.values, index=dataset.contents.Variable
             ).to_dict(),
@@ -92,6 +93,7 @@ class DatasetMetadataReader:
         """
         return {
             "variable_labels": self._metadata_container.column_labels,
+            "variable_formats": self._metadata_container.column_formats,
             "variable_names": self._metadata_container.column_names,
             "variable_name_to_label_map": self._metadata_container.column_names_to_labels,  # noqa
             "variable_name_to_data_type_map": self._metadata_container.readstat_variable_types,  # noqa

--- a/tests/unit/test_dataset_metadata_reader.py
+++ b/tests/unit/test_dataset_metadata_reader.py
@@ -38,3 +38,17 @@ def test_read_metadata():
         ), "pyreadstat values has not been converted"
         assert isinstance(metadata["variable_name_to_label_map"], dict)
         assert isinstance(metadata["variable_name_to_size_map"], dict)
+
+def test_read_metadata_with_variable_formats():
+    """
+    Unit test for function read.
+    Loads test .xpt file and extracts metadata.
+    """
+    test_dataset_path: str = (
+        f"{os.path.dirname(__file__)}/../resources/test_adam_dataset.xpt"
+    )
+    with open(test_dataset_path, "rb") as file:
+        file_contents: bytes = file.read()
+        reader = DatasetMetadataReader(file_contents, file_name="test_adam_dataset.xpt")
+        metadata: dict = reader.read()
+        assert metadata["variable_formats"] == ['', '', '', '', '', 'DATE9.', 'DATE9.', 'DATE9.', 'DATE9.', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'DATE9.', '', '', '', '', '', '', '', '']

--- a/tests/unit/test_dataset_metadata_reader.py
+++ b/tests/unit/test_dataset_metadata_reader.py
@@ -39,6 +39,7 @@ def test_read_metadata():
         assert isinstance(metadata["variable_name_to_label_map"], dict)
         assert isinstance(metadata["variable_name_to_size_map"], dict)
 
+
 def test_read_metadata_with_variable_formats():
     """
     Unit test for function read.
@@ -51,4 +52,39 @@ def test_read_metadata_with_variable_formats():
         file_contents: bytes = file.read()
         reader = DatasetMetadataReader(file_contents, file_name="test_adam_dataset.xpt")
         metadata: dict = reader.read()
-        assert metadata["variable_formats"] == ['', '', '', '', '', 'DATE9.', 'DATE9.', 'DATE9.', 'DATE9.', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'DATE9.', '', '', '', '', '', '', '', '']
+        assert metadata["variable_formats"] == [
+            "",
+            "",
+            "",
+            "",
+            "",
+            "DATE9.",
+            "DATE9.",
+            "DATE9.",
+            "DATE9.",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "DATE9.",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]

--- a/tests/unit/test_local_data_service.py
+++ b/tests/unit/test_local_data_service.py
@@ -49,6 +49,7 @@ def test_get_dataset():
     data = data_service.get_dataset(dataset_name=dataset_path)
     assert isinstance(data, pd.DataFrame)
 
+
 def test_get_variables_metdata():
     dataset_path = f"{os.path.dirname(__file__)}/../resources/test_adam_dataset.xpt"
     mock_cache = MagicMock()
@@ -56,6 +57,12 @@ def test_get_variables_metdata():
     data_service = LocalDataService.get_instance(cache_service=mock_cache)
     data = data_service.get_variables_metadata(dataset_name=dataset_path)
     assert isinstance(data, pd.DataFrame)
-    expected_keys = ["variable_name", "variable_format", "variable_order", "variable_data_type", "variable_label"]
+    expected_keys = [
+        "variable_name",
+        "variable_format",
+        "variable_order",
+        "variable_data_type",
+        "variable_label",
+    ]
     for key in expected_keys:
         assert key in data

--- a/tests/unit/test_local_data_service.py
+++ b/tests/unit/test_local_data_service.py
@@ -19,6 +19,7 @@ def test_read_metadata():
     assert metadata["file_metadata"].get("size") == 823120
     assert "contents_metadata" in metadata
     assert "variable_labels" in metadata["contents_metadata"]
+    assert "variable_formats" in metadata["contents_metadata"]
     assert "variable_name_to_label_map" in metadata["contents_metadata"]
     assert "variable_name_to_size_map" in metadata["contents_metadata"]
     assert "number_of_variables" in metadata["contents_metadata"]
@@ -47,3 +48,14 @@ def test_get_dataset():
     data_service = LocalDataService.get_instance(cache_service=mock_cache)
     data = data_service.get_dataset(dataset_name=dataset_path)
     assert isinstance(data, pd.DataFrame)
+
+def test_get_variables_metdata():
+    dataset_path = f"{os.path.dirname(__file__)}/../resources/test_adam_dataset.xpt"
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+    data_service = LocalDataService.get_instance(cache_service=mock_cache)
+    data = data_service.get_variables_metadata(dataset_name=dataset_path)
+    assert isinstance(data, pd.DataFrame)
+    expected_keys = ["variable_name", "variable_format", "variable_order", "variable_data_type", "variable_label"]
+    for key in expected_keys:
+        assert key in data


### PR DESCRIPTION
This PR adds the variable_format to the variable_metadata dataframe output

Note: For rule authors to test against the variable_format, the datasets provided would need a "format" key for each variable
Steps to test:
run unit tests