### PR TITLE
Upgrade business rules and add tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pytest==7.1.2
 pytest-cov==3.0.0
 pandas==1.3.5
-business-rules-enhanced==1.3.0
+business-rules-enhanced==1.3.1
 python-dotenv==0.20.0
 cdisc-library-client==0.1.4
 pytest-asyncio==0.18.3

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     python_requires=">=3.8",
     install_requires=[
         "pandas>=1.3.5",
-        "business-rules-enhanced==1.3.0",
+        "business-rules-enhanced==1.3.1",
         "python-dotenv==0.20.0",
         "cdisc-library-client==0.1.4",
         "odmlib==0.1.4",

--- a/tests/unit/test_operations/test_extract_metadata.py
+++ b/tests/unit/test_operations/test_extract_metadata.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.operations.extract_metadata import ExtractMetadata
+from cdisc_rules_engine.services.cache import InMemoryCacheService
+from cdisc_rules_engine.services.data_services import LocalDataService
+from unittest.mock import Mock
+
+
+def test_extract_metadata_get_dataset_name(operation_params: OperationParams):
+    mock_data_service = Mock(LocalDataService)
+    mock_data_service.get_dataset_metadata.return_value = pd.DataFrame.from_dict(
+        {"dataset_name": ["AE"]}
+    )
+    operation_params.dataframe = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.target = "dataset_name"
+    cache = InMemoryCacheService.get_instance()
+    # execute operation
+    operation = ExtractMetadata(
+        operation_params, operation_params.dataframe, cache, mock_data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    assert operation_params.operation_id in result
+    for item in result[operation_params.operation_id]:
+        assert item == "AE"


### PR DESCRIPTION
This PR upgrades the business_rules library to add the equals_string_part and does_not_equal_string_part operators. These operators coupled with the extract metadata operation allow users to compare part of the dataset name, with the value in the rdomain column. Ex:

```yaml
Check:
  all:
    - name: RDOMAIN
      operator: does_not_equal_string_part
      value: $dataset_name
      regex: ".{4}(..).*"
Operations:
  - name: dataset_name
    id: $dataset_name
    operator: extract_metadata
```

Steps to test:
1. Run the unit tests