### PR TITLE
Parent lib model col order Operation added

### DIFF
--- a/cdisc_rules_engine/operations/library_model_column_order.py
+++ b/cdisc_rules_engine/operations/library_model_column_order.py
@@ -26,17 +26,16 @@ class LibraryModelColumnOrder(BaseOperation):
         The lists with column names are sorted
         in accordance to "ordinal" key of library metadata.
         """
+        return self._get_variable_names_list(self.params.domain, self.params.dataframe)
 
+    def _get_variable_names_list(self, domain, dataframe):
         # get variables metadata from the standard model
         variables_metadata: List[
             dict
-        ] = self._get_variables_metadata_from_standard_model(
-            self.params.domain, self.params.dataframe
-        )
-
+        ] = self._get_variables_metadata_from_standard_model(domain, dataframe)
         # create a list of variable names in accordance to the "ordinal" key
         variable_names_list = self._replace_variable_wildcards(
-            variables_metadata, self.params.domain
+            variables_metadata, domain
         )
         return list(OrderedDict.fromkeys(variable_names_list))
 

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -10,6 +10,9 @@ from cdisc_rules_engine.operations.library_column_order import LibraryColumnOrde
 from cdisc_rules_engine.operations.library_model_column_order import (
     LibraryModelColumnOrder,
 )
+from cdisc_rules_engine.operations.parent_library_model_column_order import (
+    ParentLibraryModelColumnOrder,
+)
 from cdisc_rules_engine.operations.max_date import MaxDate
 from cdisc_rules_engine.operations.maximum import Maximum
 from cdisc_rules_engine.operations.mean import Mean
@@ -51,6 +54,7 @@ class OperationsFactory(FactoryInterface):
         "get_column_order_from_dataset": DatasetColumnOrder,
         "get_column_order_from_library": LibraryColumnOrder,
         "get_model_column_order": LibraryModelColumnOrder,
+        "get_parent_model_column_order": ParentLibraryModelColumnOrder,
         "max": Maximum,
         "max_date": MaxDate,
         "mean": Mean,

--- a/cdisc_rules_engine/operations/parent_library_model_column_order.py
+++ b/cdisc_rules_engine/operations/parent_library_model_column_order.py
@@ -30,7 +30,7 @@ class ParentLibraryModelColumnOrder(LibraryModelColumnOrder):
             for dataset in self.params.datasets
             if dataset["domain"] == rdomain
         ]
-        if len(parent_datasets) != 1:
+        if len(parent_datasets) < 1:
             return []
         parent_dataframe = self.data_service.get_dataset(parent_datasets[0])
         # get variables metadata from the standard model

--- a/cdisc_rules_engine/operations/parent_library_model_column_order.py
+++ b/cdisc_rules_engine/operations/parent_library_model_column_order.py
@@ -27,7 +27,7 @@ class ParentLibraryModelColumnOrder(LibraryModelColumnOrder):
                 self._get_parent_variable_names_list(domain_to_datasets, rdomain),
             )
             for rdomain in self.params.dataframe.get(
-                "RDOMAIN", [None] * self.params.dataframe.shape[0]
+                "RDOMAIN", [None] * len(self.params.dataframe)
             )
         )
 

--- a/cdisc_rules_engine/operations/parent_library_model_column_order.py
+++ b/cdisc_rules_engine/operations/parent_library_model_column_order.py
@@ -2,6 +2,7 @@ from cdisc_rules_engine.operations.library_model_column_order import (
     LibraryModelColumnOrder,
 )
 from pandas import Series
+from collections import defaultdict
 
 
 class ParentLibraryModelColumnOrder(LibraryModelColumnOrder):
@@ -18,21 +19,25 @@ class ParentLibraryModelColumnOrder(LibraryModelColumnOrder):
         The lists with column names are sorted
         in accordance to "ordinal" key of library metadata.
         """
+        domain_to_datasets = self._get_domain_to_datasets()
         rdomain_names_list = {}
         return Series(
             rdomain_names_list.setdefault(
-                rdomain, self._get_parent_variable_names_list(rdomain)
+                rdomain,
+                self._get_parent_variable_names_list(domain_to_datasets, rdomain),
             )
             for rdomain in self.params.dataframe.get("RDOMAIN", [])
         )
 
-    def _get_parent_variable_names_list(self, rdomain: str):
-        parent_datasets = [
-            dataset["filename"]
-            for dataset in self.params.datasets
-            if dataset["domain"] == rdomain
-        ]
+    def _get_domain_to_datasets(self):
+        domain_to_datasets = defaultdict(list)
+        for dataset in self.params.datasets:
+            domain_to_datasets[dataset["domain"]].append(dataset)
+        return domain_to_datasets
+
+    def _get_parent_variable_names_list(self, domain_to_datasets: dict, rdomain: str):
+        parent_datasets = domain_to_datasets.get(rdomain, [])
         if len(parent_datasets) < 1:
             return []
-        parent_dataframe = self.data_service.get_dataset(parent_datasets[0])
+        parent_dataframe = self.data_service.get_dataset(parent_datasets[0]["filename"])
         return self._get_variable_names_list(rdomain, parent_dataframe)

--- a/cdisc_rules_engine/operations/parent_library_model_column_order.py
+++ b/cdisc_rules_engine/operations/parent_library_model_column_order.py
@@ -1,0 +1,45 @@
+from typing import List
+from collections import OrderedDict
+from cdisc_rules_engine.operations.library_model_column_order import (
+    LibraryModelColumnOrder,
+)
+
+
+class ParentLibraryModelColumnOrder(LibraryModelColumnOrder):
+    def _execute_operation(self):
+        """
+        Fetches column order for a supp's parent domain from the CDISC library.
+        Returns it as a Series of lists like:
+        0    ["STUDYID", "DOMAIN", ...]
+        1    ["STUDYID", "DOMAIN", ...]
+        2    ["STUDYID", "DOMAIN", ...]
+        ...
+
+        Length of Series is equal to the length of given dataframe.
+        The lists with column names are sorted
+        in accordance to "ordinal" key of library metadata.
+        """
+        if "RDOMAIN" not in self.params.dataframe:
+            return []
+        rdomains = self.params.dataframe["RDOMAIN"].unique()
+        if len(rdomains) != 1:
+            return []
+        rdomain = rdomains[0]
+        parent_datasets = [
+            dataset["filename"]
+            for dataset in self.params.datasets
+            if dataset["domain"] == rdomain
+        ]
+        if len(parent_datasets) != 1:
+            return []
+        parent_dataframe = self.data_service.get_dataset(parent_datasets[0])
+        # get variables metadata from the standard model
+        variables_metadata: List[
+            dict
+        ] = self._get_variables_metadata_from_standard_model(rdomain, parent_dataframe)
+
+        # create a list of variable names in accordance to the "ordinal" key
+        variable_names_list = self._replace_variable_wildcards(
+            variables_metadata, rdomain
+        )
+        return list(OrderedDict.fromkeys(variable_names_list))

--- a/cdisc_rules_engine/operations/parent_library_model_column_order.py
+++ b/cdisc_rules_engine/operations/parent_library_model_column_order.py
@@ -26,7 +26,9 @@ class ParentLibraryModelColumnOrder(LibraryModelColumnOrder):
                 rdomain,
                 self._get_parent_variable_names_list(domain_to_datasets, rdomain),
             )
-            for rdomain in self.params.dataframe.get("RDOMAIN", [])
+            for rdomain in self.params.dataframe.get(
+                "RDOMAIN", [None] * self.params.dataframe.shape[0]
+            )
         )
 
     def _get_domain_to_datasets(self):

--- a/tests/unit/test_operations/test_parent_library_model_column_order.py
+++ b/tests/unit/test_operations/test_parent_library_model_column_order.py
@@ -1,0 +1,381 @@
+from typing import List
+
+import pandas as pd
+import pytest
+from unittest.mock import patch
+
+from cdisc_rules_engine.constants.classes import (
+    GENERAL_OBSERVATIONS_CLASS,
+    FINDINGS,
+    FINDINGS_ABOUT,
+)
+from cdisc_rules_engine.enums.variable_roles import VariableRoles
+from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.operations.parent_library_model_column_order import (
+    ParentLibraryModelColumnOrder,
+)
+from cdisc_rules_engine.services.cache import InMemoryCacheService
+from cdisc_rules_engine.services.data_services import LocalDataService
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+    get_model_details_cache_key,
+)
+
+
+@pytest.mark.parametrize(
+    "data, model_metadata, standard_metadata",
+    [
+        (
+            pd.DataFrame.from_dict(
+                {
+                    "RDOMAIN": ["AE", "AE", "AE", "AE"],
+                    "IDVAR": ["AESEQ", "AESEQ", "AESEQ", "AESEQ"],
+                    "IDVARVAL": [1, 2, 1, 3],
+                }
+            ),
+            {
+                "datasets": [
+                    {
+                        "_links": {"parentClass": {"title": "Events"}},
+                        "name": "AE",
+                        "datasetVariables": [
+                            {
+                                "name": "AETERM",
+                                "ordinal": 4,
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": 3,
+                            },
+                        ],
+                    }
+                ],
+                "classes": [
+                    {
+                        "name": "Events",
+                        "label": "Events",
+                        "classVariables": [
+                            {"name": "--TERM", "ordinal": 1},
+                            {"name": "--SEQ", "ordinal": 2},
+                        ],
+                    },
+                    {
+                        "name": GENERAL_OBSERVATIONS_CLASS,
+                        "label": GENERAL_OBSERVATIONS_CLASS,
+                        "classVariables": [
+                            {
+                                "name": "DOMAIN",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 2,
+                            },
+                            {
+                                "name": "STUDYID",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 1,
+                            },
+                            {
+                                "name": "TIMING_VAR",
+                                "role": VariableRoles.TIMING.value,
+                                "ordinal": 33,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+                "classes": [
+                    {
+                        "name": "Events",
+                        "datasets": [
+                            {
+                                "name": "AE",
+                                "label": "Adverse Events",
+                                "datasetVariables": [
+                                    {"name": "AETEST", "ordinal": 1},
+                                    {"name": "AENEW", "ordinal": 2},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ),
+    ],
+)
+def test_get_parent_column_order_from_library(
+    data: dict,
+    operation_params: OperationParams,
+    model_metadata: dict,
+    standard_metadata: dict,
+):
+    datasets: List[dict] = [
+        {
+            "domain": "AE",
+            "filename": "ae.xpt",
+        },
+        {
+            "domain": "EC",
+            "filename": "ec.xpt",
+        },
+        {
+            "domain": "SUPP",
+            "filename": "supp.xpt",
+        },
+        {
+            "domain": "DM",
+            "filename": "dm.xpt",
+        },
+    ]
+    ae = pd.DataFrame.from_dict(
+        {
+            "AESTDY": [4, 5, 6],
+            "STUDYID": [101, 201, 300],
+            "AESEQ": [1, 2, 3],
+        }
+    )
+    ec = pd.DataFrame.from_dict(
+        {
+            "ECSTDY": [500, 4],
+            "STUDYID": [201, 101],
+            "ECSEQ": [2, 1],
+        }
+    )
+    dm = pd.DataFrame.from_dict({"USUBJID": [1, 2, 3, 4, 5, 6000]})
+    path_to_dataset_map: dict = {
+        "ae.xpt": ae,
+        "ec.xpt": ec,
+        "dm.xpt": dm,
+        "data.xpt": data,
+    }
+    with patch(
+        "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",
+        side_effect=lambda dataset_name: path_to_dataset_map[dataset_name],
+    ):
+        operation_params.dataframe = data
+        operation_params.domain = "SUPPAE"
+        operation_params.standard = "sdtmig"
+        operation_params.standard_version = "3-4"
+        operation_params.datasets = datasets
+
+        # save model metadata to cache
+        cache = InMemoryCacheService.get_instance()
+        cache.add(
+            get_standard_details_cache_key(
+                operation_params.standard, operation_params.standard_version
+            ),
+            standard_metadata,
+        )
+        cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
+
+        # execute operation
+        data_service = LocalDataService.get_instance(cache_service=cache)
+        operation = ParentLibraryModelColumnOrder(
+            operation_params, operation_params.dataframe, cache, data_service
+        )
+        result: pd.DataFrame = operation.execute()
+        variables: List[str] = [
+            "STUDYID",
+            "DOMAIN",
+            "AETERM",
+            "AESEQ",
+            "TIMING_VAR",
+        ]
+        expected: pd.Series = pd.Series(
+            [
+                variables,
+                variables,
+                variables,
+                variables,
+            ]
+        )
+        assert result[operation_params.operation_id].equals(expected)
+
+
+@pytest.mark.parametrize(
+    "data, model_metadata, standard_metadata",
+    [
+        (
+            pd.DataFrame.from_dict(
+                {
+                    "RDOMAIN": ["AE", "AE", "AE", "AE"],
+                    "IDVAR": ["AESEQ", "AESEQ", "AESEQ", "AESEQ"],
+                    "IDVARVAL": [1, 2, 1, 3],
+                }
+            ),
+            {
+                "datasets": [
+                    {
+                        "_links": {"parentClass": {"title": FINDINGS_ABOUT}},
+                        "name": "NOTTHESAME",
+                        "datasetVariables": [
+                            {
+                                "name": "AETERM",
+                                "ordinal": 4,
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": 3,
+                            },
+                        ],
+                    }
+                ],
+                "classes": [
+                    {
+                        "name": FINDINGS_ABOUT,
+                        "label": FINDINGS_ABOUT,
+                        "classVariables": [
+                            {"name": "--OBJ", "ordinal": 1},
+                        ],
+                    },
+                    {
+                        "name": FINDINGS,
+                        "label": FINDINGS,
+                        "classVariables": [
+                            {"name": "--VAR1", "ordinal": 1},
+                            {"name": "--TEST", "ordinal": 2},
+                            {"name": "--VAR2", "ordinal": 3},
+                        ],
+                    },
+                    {
+                        "name": GENERAL_OBSERVATIONS_CLASS,
+                        "label": GENERAL_OBSERVATIONS_CLASS,
+                        "classVariables": [
+                            {
+                                "name": "DOMAIN",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 2,
+                            },
+                            {
+                                "name": "STUDYID",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 1,
+                            },
+                            {
+                                "name": "TIMING_VAR",
+                                "role": VariableRoles.TIMING.value,
+                                "ordinal": 33,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+                "classes": [
+                    {
+                        "name": FINDINGS_ABOUT,
+                        "datasets": [
+                            {
+                                "name": "AE",
+                                "label": "Adverse Events",
+                                "datasetVariables": [
+                                    {"name": "AETEST", "ordinal": 1},
+                                    {"name": "AENEW", "ordinal": 2},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+    ],
+)
+def test_get_parent_findings_class_column_order_from_library(
+    data: dict,
+    operation_params: OperationParams,
+    model_metadata: dict,
+    standard_metadata: dict,
+):
+    datasets: List[dict] = [
+        {
+            "domain": "AE",
+            "filename": "ae.xpt",
+        },
+        {
+            "domain": "EC",
+            "filename": "ec.xpt",
+        },
+        {
+            "domain": "SUPP",
+            "filename": "supp.xpt",
+        },
+        {
+            "domain": "DM",
+            "filename": "dm.xpt",
+        },
+    ]
+    ae = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "DOMAIN": ["AE", "AE", "AE"],
+            "AEOBJ": [
+                "test",
+                "test",
+                "test",
+            ],
+            "AETESTCD": ["test", "test", "test"],
+        }
+    )
+    ec = pd.DataFrame.from_dict(
+        {
+            "ECSTDY": [500, 4],
+            "STUDYID": [201, 101],
+            "ECSEQ": [2, 1],
+        }
+    )
+    dm = pd.DataFrame.from_dict({"USUBJID": [1, 2, 3, 4, 5, 6000]})
+    path_to_dataset_map: dict = {
+        "ae.xpt": ae,
+        "ec.xpt": ec,
+        "dm.xpt": dm,
+        "data.xpt": data,
+    }
+    with patch(
+        "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",
+        side_effect=lambda dataset_name: path_to_dataset_map[dataset_name],
+    ):
+        operation_params.dataframe = data
+        operation_params.domain = "SUPPAE"
+        operation_params.standard = "sdtmig"
+        operation_params.standard_version = "3-4"
+        operation_params.datasets = datasets
+
+        # save model metadata to cache
+        cache = InMemoryCacheService.get_instance()
+        cache.add(
+            get_standard_details_cache_key(
+                operation_params.standard, operation_params.standard_version
+            ),
+            standard_metadata,
+        )
+        cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
+
+        # execute operation
+        data_service = LocalDataService.get_instance(cache_service=cache)
+        operation = ParentLibraryModelColumnOrder(
+            operation_params, operation_params.dataframe, cache, data_service
+        )
+        result: pd.DataFrame = operation.execute()
+        variables: List[str] = [
+            "STUDYID",
+            "DOMAIN",
+            "AEVAR1",
+            "AETEST",
+            "AEOBJ",
+            "AEVAR2",
+            "TIMING_VAR",
+        ]
+        expected: pd.Series = pd.Series(
+            [
+                variables,
+                variables,
+                variables,
+                variables,
+            ]
+        )
+        assert result[operation_params.operation_id].equals(expected)

--- a/tests/unit/test_operations/test_parent_library_model_column_order.py
+++ b/tests/unit/test_operations/test_parent_library_model_column_order.py
@@ -8,6 +8,7 @@ from cdisc_rules_engine.constants.classes import (
     GENERAL_OBSERVATIONS_CLASS,
     FINDINGS,
     FINDINGS_ABOUT,
+    INTERVENTIONS,
 )
 from cdisc_rules_engine.enums.variable_roles import VariableRoles
 from cdisc_rules_engine.models.operation_params import OperationParams
@@ -113,19 +114,7 @@ def test_get_parent_column_order_from_library(
         {
             "domain": "AE",
             "filename": "ae.xpt",
-        },
-        {
-            "domain": "EC",
-            "filename": "ec.xpt",
-        },
-        {
-            "domain": "SUPP",
-            "filename": "supp.xpt",
-        },
-        {
-            "domain": "DM",
-            "filename": "dm.xpt",
-        },
+        }
     ]
     ae = pd.DataFrame.from_dict(
         {
@@ -134,20 +123,7 @@ def test_get_parent_column_order_from_library(
             "AESEQ": [1, 2, 3],
         }
     )
-    ec = pd.DataFrame.from_dict(
-        {
-            "ECSTDY": [500, 4],
-            "STUDYID": [201, 101],
-            "ECSEQ": [2, 1],
-        }
-    )
-    dm = pd.DataFrame.from_dict({"USUBJID": [1, 2, 3, 4, 5, 6000]})
-    path_to_dataset_map: dict = {
-        "ae.xpt": ae,
-        "ec.xpt": ec,
-        "dm.xpt": dm,
-        "data.xpt": data,
-    }
+    path_to_dataset_map: dict = {"ae.xpt": ae}
     with patch(
         "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",
         side_effect=lambda dataset_name: path_to_dataset_map[dataset_name],
@@ -238,6 +214,15 @@ def test_get_parent_column_order_from_library(
                         ],
                     },
                     {
+                        "name": INTERVENTIONS,
+                        "label": INTERVENTIONS,
+                        "classVariables": [
+                            {"name": "--VAR1", "ordinal": 1},
+                            {"name": "--TRT", "ordinal": 2},
+                            {"name": "--VAR2", "ordinal": 3},
+                        ],
+                    },
+                    {
                         "name": GENERAL_OBSERVATIONS_CLASS,
                         "label": GENERAL_OBSERVATIONS_CLASS,
                         "classVariables": [
@@ -296,14 +281,6 @@ def test_get_parent_findings_class_column_order_from_library(
             "domain": "EC",
             "filename": "ec.xpt",
         },
-        {
-            "domain": "SUPP",
-            "filename": "supp.xpt",
-        },
-        {
-            "domain": "DM",
-            "filename": "dm.xpt",
-        },
     ]
     ae = pd.DataFrame.from_dict(
         {
@@ -325,15 +302,14 @@ def test_get_parent_findings_class_column_order_from_library(
         {
             "ECSTDY": [500, 4],
             "STUDYID": [201, 101],
+            "DOMAIN": ["EC", "EC"],
             "ECSEQ": [2, 1],
+            "ECTRT": [2, 1],
         }
     )
-    dm = pd.DataFrame.from_dict({"USUBJID": [1, 2, 3, 4, 5, 6000]})
     path_to_dataset_map: dict = {
         "ae.xpt": ae,
         "ec.xpt": ec,
-        "dm.xpt": dm,
-        "data.xpt": data,
     }
     with patch(
         "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",


### PR DESCRIPTION
New operation. Given a supp dataset, the operation will find the parent domain, find the class of the parent domain, and return the possible model variables (in order) for the parent domain.
This will allow us to write a rule to check whether a supp qnam value is in the list of parent model variables.

To test, verify and run the unit tests.