### PR TITLE
Add ability to specify standard and codelists

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -1,6 +1,12 @@
 import azure.functions as func
 from cdisc_rule_tester.models.rule_tester import RuleTester
+from cdisc_rules_engine.services.cache.in_memory_cache_service import (
+    InMemoryCacheService,
+)
+from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
+from cdisc_rules_engine.services.cache.cache_populator_service import CachePopulator
 import json
+import os
 
 
 def validate_datasets_payload(datasets):
@@ -17,17 +23,29 @@ def validate_datasets_payload(datasets):
         )
 
 
-def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+async def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     try:
         json_data = req.get_json()
+        api_key = os.environ.get("LIBRARY_API_KEY")
         rule = json_data.get("rule")
+        standards_data = json_data.get("standard", {})
+        standard = standards_data.get("product")
+        standard_version = standards_data.get("version")
+        codelists = json_data.get("codelists", [])
+        cache = InMemoryCacheService()
+        if standards_data or codelists:
+            library_service = CDISCLibraryService(api_key, cache)
+            cache_populator: CachePopulator = CachePopulator(cache, library_service)
+            if standards_data:
+                await cache_populator.load_standard(standard, standard_version)
+            await cache_populator.load_codelists(codelists)
         if not rule:
             raise KeyError("'rule' required in request")
         datasets = json_data.get("datasets")
         if not datasets:
             raise KeyError("'datasets' required in request")
         validate_datasets_payload(datasets)
-        tester = RuleTester(datasets)
+        tester = RuleTester(datasets, cache, standard, standard_version)
         return func.HttpResponse(json.dumps(tester.validate(rule)))
     except KeyError as e:
         return func.HttpResponse(

--- a/cdisc_rule_tester/models/rule_tester.py
+++ b/cdisc_rule_tester/models/rule_tester.py
@@ -14,15 +14,26 @@ from cdisc_rules_engine.config.config import ConfigService
 
 
 class RuleTester:
-    def __init__(self, datasets):
+    def __init__(
+        self,
+        datasets,
+        cache: InMemoryCacheService = None,
+        standard: str = None,
+        standard_version: str = None,
+    ):
         self.datasets = [DummyDataset(dataset_data) for dataset_data in datasets]
-        cache = InMemoryCacheService()
+        self.cache = cache or InMemoryCacheService()
         self.data_service = DummyDataService.get_instance(
-            cache, ConfigService(), data=self.datasets
+            self.cache, ConfigService(), data=self.datasets
         )
-        self.engine = RulesEngine(cache, self.data_service)
-        self.engine.rule_processor = RuleProcessor(self.data_service, cache)
-        self.engine.data_processor = DataProcessor(self.data_service, cache)
+        self.engine = RulesEngine(
+            self.cache,
+            self.data_service,
+            standard=standard,
+            standard_version=standard_version,
+        )
+        self.engine.rule_processor = RuleProcessor(self.data_service, self.cache)
+        self.engine.data_processor = DataProcessor(self.data_service, self.cache)
 
     def validate(self, rule) -> dict:
         results = {}

--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -106,10 +106,11 @@ class BaseOperation:
         ]
         """
         # get model details from cache
+        if not self.params.standard or not self.params.standard_version:
+            raise Exception("Please provide standard and version")
         cache_key: str = get_standard_details_cache_key(
             self.params.standard, self.params.standard_version
         )
-
         standard_details: dict = self.cache.get(cache_key) or {}
         model = standard_details.get("_links", {}).get("model")
         class_details, domain_details = self._get_class_and_domain_metadata(

--- a/cdisc_rules_engine/operations/required_variables.py
+++ b/cdisc_rules_engine/operations/required_variables.py
@@ -20,7 +20,6 @@ class RequiredVariables(BaseOperation):
 
         # get variables metadata from the standard model
         variables_metadata: List[dict] = self._get_variables_metadata_from_standard()
-
         return list(
             set(
                 [


### PR DESCRIPTION
This PR adds the ability to provide a standard and array of codelists to the engine to support validation against various standards.
This is done by adding the following json to the payload to the test endpoint:

```
	"standard": {
		"product": "sdtmig",
		"version": "3-4"
	},
	"codelists": [
		"sdtmct-2022-12-16",
		"cdashct-2022-12-16",
		"adamct-2022-06-24"
	]
```
When the test endpoint receives standard or codelist data it requests that data from the library and populates the in memory cache with that data.

Steps to test:

To test you will need to run the function app locally. To do that you will need to follow this guide:
https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cwindows%2Ccsharp%2Cportal%2Cbash

1. Run func start from the project root
2. Send the attached payload to the test endpoint.
3. Verify the correct required_variables appear in the response
4. Remove the "standard" from the json payload and send the request again
5. Verify an error is returned prompting the user to specify a standard and version
6. Remove the "Operation" from the rule and send the request again
7. Verify the rule executes successfully (This is due to the fact that error handling for missing standard info is handled in the operations where the standard info is needed)
[test_payload_with_standard.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11113111/test_payload_with_standard.txt)

