### PR TITLE
Endpoint supports define.xml

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -27,7 +27,8 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
         if not datasets:
             raise KeyError("'datasets' required in request")
         validate_datasets_payload(datasets)
-        tester = RuleTester(datasets)
+        define_xml = json_data.get("define_xml")
+        tester = RuleTester(datasets, define_xml)
         return func.HttpResponse(json.dumps(tester.validate(rule)))
     except KeyError as e:
         return func.HttpResponse(

--- a/cdisc_rule_tester/models/rule_tester.py
+++ b/cdisc_rule_tester/models/rule_tester.py
@@ -14,11 +14,11 @@ from cdisc_rules_engine.config.config import ConfigService
 
 
 class RuleTester:
-    def __init__(self, datasets):
+    def __init__(self, datasets, define_xml=None):
         self.datasets = [DummyDataset(dataset_data) for dataset_data in datasets]
         cache = InMemoryCacheService()
         self.data_service = DummyDataService.get_instance(
-            cache, ConfigService(), data=self.datasets
+            cache, ConfigService(), data=self.datasets, define_xml=define_xml
         )
         self.engine = RulesEngine(cache, self.data_service)
         self.engine.rule_processor = RuleProcessor(self.data_service, cache)

--- a/cdisc_rules_engine/interfaces/data_service_interface.py
+++ b/cdisc_rules_engine/interfaces/data_service_interface.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from io import IOBase
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional
 
 import pandas as pd
 
@@ -65,7 +65,7 @@ class DataServiceInterface(ABC):
         """
 
     @abstractmethod
-    def get_define_xml_contents(self, dataset_name: str) -> Union[bytes, str]:
+    def get_define_xml_contents(self, dataset_name: str) -> bytes:
         """
         Returns contents of define.xml file.
         """

--- a/cdisc_rules_engine/interfaces/data_service_interface.py
+++ b/cdisc_rules_engine/interfaces/data_service_interface.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from io import IOBase
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 import pandas as pd
 
@@ -65,7 +65,7 @@ class DataServiceInterface(ABC):
         """
 
     @abstractmethod
-    def get_define_xml_contents(self, dataset_name: str) -> bytes:
+    def get_define_xml_contents(self, dataset_name: str) -> Union[bytes, str]:
         """
         Returns contents of define.xml file.
         """

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -121,7 +121,7 @@ class DummyDataService(BaseDataService):
             dataset_name=dataset_name, **params
         )
 
-    def get_define_xml_contents(self, dataset_name: str) -> bytes:
+    def get_define_xml_contents(self, dataset_name: str) -> str:
         return self.define_xml
 
     def has_all_files(self, prefix: str, file_names: List[str]) -> bool:

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -27,6 +27,7 @@ class DummyDataService(BaseDataService):
     ):
         super(DummyDataService, self).__init__(cache_service, reader_factory, config)
         self.data: List[DummyDataset] = kwargs.get("data")
+        self.define_xml: str = kwargs.get("define_xml")
 
     @classmethod
     def get_instance(
@@ -121,7 +122,7 @@ class DummyDataService(BaseDataService):
         )
 
     def get_define_xml_contents(self, dataset_name: str) -> bytes:
-        pass
+        return self.define_xml
 
     def has_all_files(self, prefix: str, file_names: List[str]) -> bool:
         return True

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -121,8 +121,8 @@ class DummyDataService(BaseDataService):
             dataset_name=dataset_name, **params
         )
 
-    def get_define_xml_contents(self, dataset_name: str) -> str:
-        return self.define_xml
+    def get_define_xml_contents(self, dataset_name: str) -> bytes:
+        return bytes(self.define_xml)
 
     def has_all_files(self, prefix: str, file_names: List[str]) -> bool:
         return True

--- a/tests/unit/test_rule_tester/test_rule_tester.py
+++ b/tests/unit/test_rule_tester/test_rule_tester.py
@@ -1,4 +1,9 @@
 from cdisc_rule_tester.models.rule_tester import RuleTester
+from os import path
+
+test_define_file_path: str = (
+    f"{path.dirname(__file__)}/../../resources/test_defineV22-SDTM.xml"
+)
 
 
 def test_rule_with_errors():
@@ -154,3 +159,60 @@ def test_rule_skipped():
     assert len(data["LB"]) == 1
     assert len(data["LB"][0]["errors"]) == 0
     assert data["LB"][0]["executionStatus"] == "skipped"
+
+
+def test_rule_with_define_xml(define_xml_variable_validation_rule: dict):
+    datasets = [
+        {
+            "domain": "AE",
+            "filename": "ae.xpt",
+            "variables": [
+                {
+                    "name": "USUBJID",
+                    "label": "Unique Subject Id",
+                    "type": "Num",
+                    "length": 8,
+                },
+                {
+                    "name": "AESEQ",
+                    "label": "Sequence Number",
+                    "type": "Num",
+                    "length": 8,
+                },
+                {
+                    "name": "AESTDY",
+                    "label": "Study Day",
+                    "type": "Char",
+                    "length": 200,
+                },
+            ],
+            "records": {
+                "USUBJID": [
+                    1,
+                    2,
+                    2,
+                    1,
+                    3,
+                ],
+                "AESEQ": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                ],
+                "AESTDY": ["test", "alex", "alex", "test", "test"],
+            },
+        }
+    ]
+
+    with open(test_define_file_path, "rb") as file:
+        contents: bytes = file.read()
+        tester = RuleTester(datasets, contents)
+        data = tester.validate(define_xml_variable_validation_rule)
+        assert "AE" in data
+        assert len(data["AE"]) == 1
+        assert len(data["AE"][0]["errors"]) > 0
+        error = data["AE"][0]["errors"][0]
+        assert error["row"] == 2
+        assert error["value"] == {"variable_size": 8}


### PR DESCRIPTION
To test, run the new test case.

You can also run this branch of the rule editor https://github.com/cdisc-org/conformance-rules-editor/tree/133-support-definexml-test-files locally against this branch and test submitting a define.xml file.