### PR TITLE
Make test endpoint sync

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -7,6 +7,7 @@ from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryServic
 from cdisc_rules_engine.services.cache.cache_populator_service import CachePopulator
 import json
 import os
+import asyncio
 
 
 def validate_datasets_payload(datasets):
@@ -23,7 +24,7 @@ def validate_datasets_payload(datasets):
         )
 
 
-async def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     try:
         json_data = req.get_json()
         api_key = os.environ.get("LIBRARY_API_KEY")
@@ -37,8 +38,8 @@ async def main(req: func.HttpRequest, context: func.Context) -> func.HttpRespons
             library_service = CDISCLibraryService(api_key, cache)
             cache_populator: CachePopulator = CachePopulator(cache, library_service)
             if standards_data:
-                await cache_populator.load_standard(standard, standard_version)
-            await cache_populator.load_codelists(codelists)
+                asyncio.run(cache_populator.load_standard(standard, standard_version))
+            asyncio.run(cache_populator.load_codelists(codelists))
         if not rule:
             raise KeyError("'rule' required in request")
         datasets = json_data.get("datasets")


### PR DESCRIPTION
This PR fixes a bug introduced here: https://github.com/cdisc-org/cdisc-rules-engine/pull/353 caused by making the test endpoint async. Since some operators already run async code it caused an issue trying to create an event loop within an event loop.

The fix is to make the function sync again, and execute the logic for getting the standard and ct version synchronously. While this is slower than the async version it allows operations to run async operations which is better for local engine performance. Additionally the slower response time is only incurred when a standard or codelist is provided.

Steps to test:
1. Perform the steps outlined here: https://github.com/cdisc-org/cdisc-rules-engine/pull/353
2. Copy the request found in the attached file here: https://github.com/cdisc-org/cdisc-rules-engine/issues/363
3. Send that request to the locally  running test endpoint and ensure the execution is successful.