### PR TITLE
Add valid_codelist_dates operation

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -39,6 +39,7 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
             cache_populator: CachePopulator = CachePopulator(cache, library_service)
             if standards_data:
                 asyncio.run(cache_populator.load_standard(standard, standard_version))
+                asyncio.run(cache_populator.load_available_ct_packages())
             asyncio.run(cache_populator.load_codelists(codelists))
         if not rule:
             raise KeyError("'rule' required in request")

--- a/cdisc_rules_engine/constants/cache_constants.py
+++ b/cdisc_rules_engine/constants/cache_constants.py
@@ -1,0 +1,1 @@
+PUBLISHED_CT_PACKAGES = "published_ct_packages"

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -44,6 +44,7 @@ from cdisc_rules_engine.operations.required_variables import RequiredVariables
 from cdisc_rules_engine.operations.expected_variables import ExpectedVariables
 from cdisc_rules_engine.operations.permissible_variables import PermissibleVariables
 from cdisc_rules_engine.operations.study_domains import StudyDomains
+from cdisc_rules_engine.operations.valid_codelist_dates import ValidCodelistDates
 
 
 class OperationsFactory(FactoryInterface):
@@ -76,6 +77,7 @@ class OperationsFactory(FactoryInterface):
         "expected_variables": ExpectedVariables,
         "permissible_variables": PermissibleVariables,
         "study_domains": StudyDomains,
+        "valid_codelist_dates": ValidCodelistDates,
     }
 
     @classmethod

--- a/cdisc_rules_engine/operations/valid_codelist_dates.py
+++ b/cdisc_rules_engine/operations/valid_codelist_dates.py
@@ -1,0 +1,41 @@
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+from cdisc_rules_engine.constants.cache_constants import PUBLISHED_CT_PACKAGES
+
+
+class ValidCodelistDates(BaseOperation):
+    """
+    Returns the valid codelist dates for a given standard
+    Ex:
+        Given a list of codelists: [sdtmct-2023-10-26, sdtmct-2023-12-13,
+                                    adamct-2023-12-13, cdashct-2023-05-19]
+        and standard: sdtmig
+        the operation will return ["2023-10-26", "2023-12-13"]
+
+    """
+
+    def _execute_operation(self):
+        # get metadata
+        ct_packages = self.cache.get(PUBLISHED_CT_PACKAGES)
+        if not ct_packages:
+            return []
+        return [
+            self._parse_date_from_ct_package(package)
+            for package in ct_packages
+            if self._is_applicable_ct_package(package)
+        ]
+
+    def _is_applicable_ct_package(self, package: str) -> bool:
+        standard_to_package_type_mapping = {
+            "sdtmig": {"sdtmct"},
+            "sendig": {"sendct"},
+            "cdashig": {"cdashct"},
+            "adamig": {"sdtmct", "adamct"},
+        }
+        package_type = package.split("-", 1)[0]
+        applicable_package_types = standard_to_package_type_mapping.get(
+            self.params.standard.lower(), set()
+        )
+        return package_type in applicable_package_types
+
+    def _parse_date_from_ct_package(self, package: str) -> str:
+        return package.split("-", 1)[-1]

--- a/cdisc_rules_engine/services/cache/cache_populator_service.py
+++ b/cdisc_rules_engine/services/cache/cache_populator_service.py
@@ -93,6 +93,13 @@ class CachePopulator:
         codelist_term_maps = await asyncio.gather(*coroutines)
         self.cache.add_batch(codelist_term_maps, "package")
 
+    async def load_available_ct_packages(self):
+        packages = self.library_service.get_all_ct_packages()
+        available_packages = [
+            package.get("href", "").split("/")[-1] for package in packages
+        ]
+        self.cache.add(PUBLISHED_CT_PACKAGES, available_packages)
+
     async def load_standard(self, standard: str, version: str):
         standards = [{"href": f"/mdr/{standard}/{version}"}]
         variable_codelist_maps = await self._get_variable_codelist_maps(standards)

--- a/cdisc_rules_engine/services/cache/cache_populator_service.py
+++ b/cdisc_rules_engine/services/cache/cache_populator_service.py
@@ -17,6 +17,7 @@ from cdisc_rules_engine.utilities.utils import (
     get_standard_details_cache_key,
     get_model_details_cache_key,
 )
+from cdisc_rules_engine.constants.cache_constants import PUBLISHED_CT_PACKAGES
 
 
 class CachePopulator:
@@ -48,6 +49,14 @@ class CachePopulator:
         # save codelists to cache as a map of codelist to terms
         codelist_term_maps = await self._get_codelist_term_maps()
         self.cache.add_batch(codelist_term_maps, "package")
+
+        # Add a list of all published ct packages to the cache
+        available_packages = [
+            package.get("package")
+            for package in codelist_term_maps
+            if "package" in package
+        ]
+        self.cache.add(PUBLISHED_CT_PACKAGES, available_packages)
 
         # save standard codelists to cache as a map of variable to allowed_values
         standards = self.library_service.get_all_tabulation_ig_standards()

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -12,13 +12,16 @@ from cdisc_rules_engine.models.dictionaries.get_dictionary_terms import (
     extract_dictionary_terms,
 )
 from cdisc_rules_engine.utilities.utils import get_rules_cache_key
+from cdisc_rules_engine.constants.cache_constants import PUBLISHED_CT_PACKAGES
 
 
 def fill_cache_with_provided_data(cache, args):
     cache_files = next(os.walk(args.cache), (None, None, []))[2]
+    published_ct_packages = set()
     for file_name in cache_files:
         if "ct-" in file_name:
             ct_version = file_name.split(".")[0]
+            published_ct_packages.add(ct_version)
             if (
                 args.controlled_terminology_package
                 and ct_version in args.controlled_terminology_package
@@ -32,6 +35,7 @@ def fill_cache_with_provided_data(cache, args):
         with open(f"{args.cache}/{file_name}", "rb") as f:
             data = pickle.load(f)
             cache.add_all(data)
+    cache.add(PUBLISHED_CT_PACKAGES, published_ct_packages)
     return cache
 
 

--- a/tests/unit/test_operations/test_valid_codelist_dates.py
+++ b/tests/unit/test_operations/test_valid_codelist_dates.py
@@ -1,0 +1,44 @@
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.operations.valid_codelist_dates import ValidCodelistDates
+from cdisc_rules_engine.models.operation_params import OperationParams
+import pandas as pd
+from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+from cdisc_rules_engine.constants.cache_constants import PUBLISHED_CT_PACKAGES
+import pytest
+
+
+@pytest.mark.parametrize(
+    "standard, expected",
+    [
+        ("sdtmig", ["2022-09-30", "2022-12-16"]),
+        ("adamig", ["2022-09-30", "2022-12-16", "2021-12-17", "2022-06-24"]),
+        ("sendig", ["2014-09-26", "2014-12-19"]),
+        ("cdashig", ["2014-09-26", "2015-03-27"]),
+    ],
+)
+def test_variable_count(
+    standard, expected, mock_data_service, operation_params: OperationParams
+):
+    valid_codelists = [
+        "sdtmct-2022-09-30",
+        "sdtmct-2022-12-16",
+        "sendct-2014-09-26",
+        "sendct-2014-12-19",
+        "adamct-2021-12-17",
+        "adamct-2022-06-24",
+        "cdashct-2014-09-26",
+        "cdashct-2015-03-27",
+    ]
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    cache.add(PUBLISHED_CT_PACKAGES, valid_codelists)
+    operation_params.standard = standard
+    result = ValidCodelistDates(
+        operation_params,
+        pd.DataFrame.from_dict({"test": [1, 2, 33]}),
+        cache,
+        mock_data_service,
+    ).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        assert val == expected


### PR DESCRIPTION
This PR adds a new operation:

`valid_codelist_dates`

Which returns the valid codelists for a given standard type

Steps to test:
1. Run the unit tests
2. Write a rule with the following logic:
```yaml
Check:
- all:
     - name: TSVCDVER
       operator: is_contained_by
       value: $valid_codelists
Operations:
   - id: $valid_codelists
     operator: "valid_codelists"
```
3. Run the rule using the test functionality with the appropriate data. 
4. Verify the results are correct
5. Perform the same test using the test endpoint