### PR TITLE
Add Define Item Group Metadata Check rule type and test

### DIFF
--- a/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
@@ -60,6 +60,28 @@ class BaseDatasetBuilder:
             for dataset in get_corresponding_datasets(self.datasets, self.domain)
         ]
 
+    def get_define_xml_item_group_metadata(self, domain: str) -> List[dict]:
+        """
+        Gets Define XML item group metadata
+        returns a list of dictionaries containing the following keys:
+            "define_dataset_name"
+            "define_dataset_label"
+            "define_dataset_location"
+            "define_dataset_class"
+            "define_dataset_structure"
+            "define_dataset_is_non_standard"
+            "define_dataset_variables"
+        """
+        directory_path = get_directory_path(self.dataset_path)
+        define_xml_path: str = f"{directory_path}/{DEFINE_XML_FILE_NAME}"
+        define_xml_contents: bytes = self.data_service.get_define_xml_contents(
+            dataset_name=define_xml_path
+        )
+        define_xml_reader = DefineXMLReader.from_file_contents(
+            define_xml_contents, cache_service_obj=self.cache
+        )
+        return define_xml_reader.extract_domain_metadata(domain)
+
     def get_define_xml_variables_metadata(self) -> List[dict]:
         """
         Gets Define XML variables metadata.

--- a/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
+++ b/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
@@ -20,6 +20,9 @@ from cdisc_rules_engine.dataset_builders.define_variables_dataset_builder import
 from cdisc_rules_engine.dataset_builders.variables_metadata_with_define_dataset_builder import (
     VariablesMetadataWithDefineDatasetBuilder,
 )
+from cdisc_rules_engine.dataset_builders.define_item_group_dataset_builder import (
+    DefineItemGroupDatasetBuilder,
+)
 from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
 from cdisc_rules_engine.enums.rule_types import RuleTypes
 
@@ -34,6 +37,7 @@ class DatasetBuilderFactory(FactoryInterface):
         RuleTypes.VARIABLE_METADATA_CHECK_AGAINST_DEFINE.value: VariablesMetadataWithDefineDatasetBuilder,
         RuleTypes.DATASET_CONTENTS_CHECK_AGAINST_DEFINE_AND_LIBRARY.value: ContentsDatasetBuilder,
         RuleTypes.VALUE_LEVEL_METADATA_CHECK_AGAINST_DEFINE.value: ContentsDatasetBuilder,
+        RuleTypes.DEFINE_ITEM_GROUP_METADATA_CHECK.value: DefineItemGroupDatasetBuilder,
     }
 
     @classmethod

--- a/cdisc_rules_engine/dataset_builders/define_item_group_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/define_item_group_dataset_builder.py
@@ -1,0 +1,23 @@
+from cdisc_rules_engine.dataset_builders.base_dataset_builder import BaseDatasetBuilder
+import pandas as pd
+from typing import List
+
+
+class DefineItemGroupDatasetBuilder(BaseDatasetBuilder):
+    def build(self):
+        """
+        Returns a dataset containing metadata for the domains
+        extracted from the define.xml.
+        Columns available in the dataset are:
+            "define_dataset_name"
+            "define_dataset_label"
+            "define_dataset_location"
+            "define_dataset_class"
+            "define_dataset_structure"
+            "define_dataset_is_non_standard"
+            "define_dataset_variables"
+        """
+        item_group_metadata: List[dict] = self.get_define_xml_item_group_metadata(
+            self.domain
+        )
+        return pd.DataFrame([item_group_metadata])

--- a/cdisc_rules_engine/enums/rule_types.py
+++ b/cdisc_rules_engine/enums/rule_types.py
@@ -25,6 +25,7 @@ class RuleTypes(BaseEnum):
     DATE_ARITHMETIC = "Date Arithmetic"
     DATA_DOMAIN_AGGREGATION = "Data Domain Aggregation"
     DEFINE = "Define-XML"
+    DEFINE_ITEM_GROUP_METADATA_CHECK = "Define Item Group Metadata Check"
     POPULATED_VALUES = "Populated Values"
     UNIQUENESS = "Uniqueness"
     VARIABLE_LENGTH = "Variable Length"

--- a/cdisc_rules_engine/operations/variable_exists.py
+++ b/cdisc_rules_engine/operations/variable_exists.py
@@ -4,4 +4,5 @@ from cdisc_rules_engine.operations.base_operation import BaseOperation
 class VariableExists(BaseOperation):
     def _execute_operation(self):
         # get metadata
-        return self.params.target in self.params.dataframe
+        dataframe = self.data_service.get_dataset(self.params.domain)
+        return self.params.target in dataframe

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -85,7 +85,7 @@ class RulesEngine:
         self.rule_processor = RuleProcessor(self.data_service, self.cache)
         self.data_processor = DataProcessor(self.data_service, self.cache)
         return self.validate_single_rule(
-            rule, f"/{dataset_path}", dataset_dicts, dataset_domain
+            rule, f"{dataset_path}", dataset_dicts, dataset_domain
         )
 
     def validate(

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from io import IOBase
 from typing import List, Optional
+from cdisc_rules_engine.constants.define_xml_constants import DEFINE_XML_FILE_NAME
 
 import pandas as pd
 
@@ -122,6 +123,11 @@ class DummyDataService(BaseDataService):
         )
 
     def get_define_xml_contents(self, dataset_name: str) -> bytes:
+        if not self.define_xml:
+            # Search for define xml locally
+            with open(DEFINE_XML_FILE_NAME, "rb") as f:
+                return f.read()
+
         return bytes(self.define_xml)
 
     def has_all_files(self, prefix: str, file_names: List[str]) -> bool:

--- a/cdisc_rules_engine/services/data_services/local_data_service.py
+++ b/cdisc_rules_engine/services/data_services/local_data_service.py
@@ -110,7 +110,7 @@ class LocalDataService(BaseDataService):
         """
         Reads local define xml file as bytes
         """
-        with os.open(dataset_name, "rb") as f:
+        with open(dataset_name, "rb") as f:
             return f.read()
 
     def get_dataset_by_type(

--- a/cdisc_rules_engine/services/define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml_reader.py
@@ -93,8 +93,14 @@ class DefineXMLReader:
             f"Extracting domain metadata from Define-XML. domain_name={domain_name}"
         )
         metadata = self._odm_loader.MetaDataVersion()
+        item_mapping = {item.OID: item for item in metadata.ItemDef}
         domain_metadata = self._get_domain_metadata(metadata, domain_name)
         domain_metadata_dict: dict = self._get_metadata_representation(domain_metadata)
+        domain_metadata_dict["define_dataset_variables"] = [
+            item_mapping.get(item.ItemOID).Name
+            for item in domain_metadata.ItemRef
+            if item.ItemOID in item_mapping
+        ]
         logger.info(f"Extracted domain metadata = {domain_metadata_dict}")
         return domain_metadata_dict
 
@@ -272,12 +278,12 @@ class DefineXMLReader:
         Returns metadata as dictionary.
         """
         return {
-            "dataset_name": metadata.Domain,
-            "dataset_label": str(metadata.Description.TranslatedText[0]),
-            "dataset_location": getattr(metadata.leaf, "href", None),
-            "dataset_class": str(metadata.Class.Name),
-            "dataset_structure": str(metadata.Structure),
-            "dataset_is_non_standard": str(metadata.IsNonStandard),
+            "define_dataset_name": metadata.Domain,
+            "define_dataset_label": str(metadata.Description.TranslatedText[0]),
+            "define_dataset_location": getattr(metadata.leaf, "href", None),
+            "define_dataset_class": str(metadata.Class.Name),
+            "define_dataset_structure": str(metadata.Structure),
+            "define_dataset_is_non_standard": str(metadata.IsNonStandard),
         }
 
     def validate_schema(self) -> bool:

--- a/cdisc_rules_engine/utilities/decorators.py
+++ b/cdisc_rules_engine/utilities/decorators.py
@@ -24,7 +24,8 @@ def retry_request(retries: int, status_code_ranges: List[int] = None):
                     response.status_code >= code_range
                     for code_range in status_code_ranges
                 )
-                # no need for else. If should be retied -> loop will go to the next iteration
+                # no need for else.
+                # If should be retied -> loop will go to the next iteration
                 if not request_should_be_retried:
                     return response
             raise NumberOfAttemptsExceeded(
@@ -37,19 +38,21 @@ def retry_request(retries: int, status_code_ranges: List[int] = None):
     return decorator
 
 
-def cached(cache_key: str):
+def cached(cache_key: str):  # noqa: C901
     """
-    Generic decorator for cached data. All cached data should have a cache key of the format:
-    {study_id}/{data_bundle_id}/{domain_name}/key.
+    Generic decorator for cached data.
+    #All cached data should have a cache key of the format:
+    {study_id}/{data_bundle_id}/{domain_name}/{arg}.../key.
 
     Note: It is expected that the instance has a cache_service property.
     """
 
     def format_cache_key(
-        key: str, study_id=None, data_bundle_id=None, domain_name=None
+        key: str, args=[], study_id=None, data_bundle_id=None, domain_name=None
     ):
         """
-        If a study_id and data_bundle_id are available, cache_key = {study_id}/{data_bundle_id}/key
+        If a study_id and data_bundle_id are available,
+        cache_key = {study_id}/{data_bundle_id}/key
         else the function just returns the provided cache key.
         """
         if domain_name:
@@ -58,6 +61,9 @@ def cached(cache_key: str):
             key = f"{data_bundle_id}/" + key
         if study_id:
             key = f"{study_id}/" + key
+        for arg in args:
+            if isinstance(arg, str):
+                key = f"{arg}/" + key
         return key
 
     def decorator(func: Callable):
@@ -85,6 +91,7 @@ def cached(cache_key: str):
             ):
                 key = format_cache_key(
                     cache_key,
+                    args,
                     study_id=study_id,
                     data_bundle_id=data_bundle_id,
                     domain_name=domain_name,

--- a/scripts/test_rule.py
+++ b/scripts/test_rule.py
@@ -65,7 +65,7 @@ def validate_single_rule(cache, path, args, datasets, rule: dict = None):
             validated_domains.add(dataset.domain)
             results.append(
                 engine.test_validation(
-                    rule, f"{path}/{dataset.filename}", datasets, dataset.domain
+                    rule, f"{dataset.filename}", datasets, dataset.domain
                 )
             )
     results = list(itertools.chain(*results))
@@ -109,9 +109,7 @@ def test(args: TestArgs):
             show_eta=False,
         ) as bar:
             for rule_result in pool.imap_unordered(
-                partial(
-                    validate_single_rule, shared_cache, "./scripts", args, datasets
-                ),
+                partial(validate_single_rule, shared_cache, "", args, datasets),
                 rules,
             ):
                 results.append(rule_result)

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -47,12 +47,12 @@ def test_read_define_xml():
         for item in metadata:
             assert isinstance(item, dict)
             assert list(item.keys()) == [
-                "dataset_name",
-                "dataset_label",
-                "dataset_location",
-                "dataset_class",
-                "dataset_structure",
-                "dataset_is_non_standard",
+                "define_dataset_name",
+                "define_dataset_label",
+                "define_dataset_location",
+                "define_dataset_class",
+                "define_dataset_structure",
+                "define_dataset_is_non_standard",
             ]
 
 
@@ -65,12 +65,25 @@ def test_extract_domain_metadata():
         reader = DefineXMLReader.from_file_contents(contents)
         domain_metadata: dict = reader.extract_domain_metadata(domain_name="TS")
         assert domain_metadata == {
-            "dataset_name": "TS",
-            "dataset_label": "Trial Summary",
-            "dataset_location": "ts.xml",
-            "dataset_class": "TRIAL DESIGN",
-            "dataset_structure": "One record per trial summary parameter value",
-            "dataset_is_non_standard": "None",
+            "define_dataset_name": "TS",
+            "define_dataset_label": "Trial Summary",
+            "define_dataset_location": "ts.xml",
+            "define_dataset_class": "TRIAL DESIGN",
+            "define_dataset_structure": "One record per trial summary parameter value",
+            "define_dataset_is_non_standard": "None",
+            "define_dataset_variables": [
+                "STUDYID",
+                "DOMAIN",
+                "TSSEQ",
+                "TSGRPID",
+                "TSPARMCD",
+                "TSPARM",
+                "TSVAL",
+                "TSVALNF",
+                "TSVALCD",
+                "TSVCDREF",
+                "TSVCDVER",
+            ],
         }
 
 
@@ -142,16 +155,16 @@ def test_extract_value_level_metadata():
         mock_filter_pass_row_data = {"AETERM": "INJECTION SITE REACTION"}
         mock_filter_fail_row_data = {"AETERM": "ALL_GOOD"}
         assert (
-            value_level_metadata[0]["type_check"](mock_invalid_type_row_data) == False
+            value_level_metadata[0]["type_check"](mock_invalid_type_row_data) is False
         )
         assert (
             value_level_metadata[0]["length_check"](mock_invalid_length_row_data)
-            == False
+            is False
         )
-        assert value_level_metadata[0]["type_check"](mock_valid_row_data) == True
-        assert value_level_metadata[0]["length_check"](mock_valid_row_data) == True
-        assert value_level_metadata[0]["filter"](mock_filter_pass_row_data) == True
-        assert value_level_metadata[0]["filter"](mock_filter_fail_row_data) == False
+        assert value_level_metadata[0]["type_check"](mock_valid_row_data) is True
+        assert value_level_metadata[0]["length_check"](mock_valid_row_data) is True
+        assert value_level_metadata[0]["filter"](mock_filter_pass_row_data) is True
+        assert value_level_metadata[0]["filter"](mock_filter_fail_row_data) is False
 
 
 def test_extract_domain_metadata_not_found():


### PR DESCRIPTION
This PR adds a new rule type for getting the define item group metadata for a domain, and updates the variable exists operator logic to check the dataset contents rather than assuming the contents are in the current dataset.

Steps to test:

* Run the test command using the attached rule, dataset, and define.xml. Ensure the define.xml file is in the same directory as the dataset. (Note: Be sure to change the define file to an xml file and the define_rule and dataset file to .json files)
* Verify VS is the only reported erroneous dataset.
[define.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11254813/define.txt)
[define_rule.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11254814/define_rule.txt)
[dataset.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11254816/dataset.txt)
