### PR TITLE
ISS 304: added variable_is_null and define_variable_is_collected

### DIFF
--- a/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
+++ b/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
@@ -33,7 +33,7 @@ class DatasetBuilderFactory(FactoryInterface):
         RuleTypes.DATASET_METADATA_CHECK_AGAINST_DEFINE.value: ContentMetadataDatasetBuilder,
         RuleTypes.VARIABLE_METADATA_CHECK.value: VariablesMetadataDatasetBuilder,
         RuleTypes.DOMAIN_PRESENCE_CHECK.value: DomainListDatasetBuilder,
-        RuleTypes.DEFINE.value: DefineVariablesDatasetBuilder,
+        RuleTypes.DEFINE_ITEM_METADATA_CHECK.value: DefineVariablesDatasetBuilder,
         RuleTypes.VARIABLE_METADATA_CHECK_AGAINST_DEFINE.value: VariablesMetadataWithDefineDatasetBuilder,
         RuleTypes.DATASET_CONTENTS_CHECK_AGAINST_DEFINE_AND_LIBRARY.value: ContentsDatasetBuilder,
         RuleTypes.VALUE_LEVEL_METADATA_CHECK_AGAINST_DEFINE.value: ContentsDatasetBuilder,

--- a/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
@@ -18,6 +18,7 @@ class DefineVariablesDatasetBuilder(BaseDatasetBuilder):
         "define_variable_format",
         "define_variable_allowed_terms",
         "define_variable_origin_type",
+        "define_variable_is_collected",
         """
         # get Define XML metadata for domain and use it as a rule comparator
         variable_metadata: List[dict] = self.get_define_xml_variables_metadata()

--- a/cdisc_rules_engine/enums/define_xml_versions.py
+++ b/cdisc_rules_engine/enums/define_xml_versions.py
@@ -1,0 +1,6 @@
+from cdisc_rules_engine.enums.base_enum import BaseEnum
+
+
+class DefineXMLVersions(BaseEnum):
+    DEFINE_XML_2_0_0 = "2.0.0"
+    DEFINE_XML_2_1_0 = "2.1.0"

--- a/cdisc_rules_engine/enums/rule_types.py
+++ b/cdisc_rules_engine/enums/rule_types.py
@@ -24,7 +24,7 @@ class RuleTypes(BaseEnum):
     FUNCTIONAL_DEPENDENCY = "Functional Dependency"
     DATE_ARITHMETIC = "Date Arithmetic"
     DATA_DOMAIN_AGGREGATION = "Data Domain Aggregation"
-    DEFINE = "Define-XML"
+    DEFINE_ITEM_METADATA_CHECK = "Define Item Metadata Check"
     DEFINE_ITEM_GROUP_METADATA_CHECK = "Define Item Group Metadata Check"
     POPULATED_VALUES = "Populated Values"
     UNIQUENESS = "Uniqueness"

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -40,6 +40,7 @@ from cdisc_rules_engine.operations.whodrug_hierarchy_validator import (
 )
 from cdisc_rules_engine.operations.variable_permissibility import VariablePermissibility
 from cdisc_rules_engine.operations.variable_count import VariableCount
+from cdisc_rules_engine.operations.variable_is_null import VariableIsNull
 from cdisc_rules_engine.operations.required_variables import RequiredVariables
 from cdisc_rules_engine.operations.expected_variables import ExpectedVariables
 from cdisc_rules_engine.operations.permissible_variables import PermissibleVariables
@@ -72,6 +73,7 @@ class OperationsFactory(FactoryInterface):
         "variable_permissibilities": VariablePermissibility,
         "variable_value_count": VariableValueCount,
         "variable_count": VariableCount,
+        "variable_is_null": VariableIsNull,
         "domain_label": DomainLabel,
         "required_variables": RequiredVariables,
         "expected_variables": ExpectedVariables,

--- a/cdisc_rules_engine/operations/variable_is_null.py
+++ b/cdisc_rules_engine/operations/variable_is_null.py
@@ -1,0 +1,9 @@
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+
+
+class VariableIsNull(BaseOperation):
+    def _execute_operation(self):
+        target_variable = self.params.target.replace("--", self.params.domain, 1)
+        if target_variable in self.params.dataframe:
+            series = self.params.dataframe[target_variable]
+            return series.mask(series == "").isnull().all()

--- a/cdisc_rules_engine/operations/variable_is_null.py
+++ b/cdisc_rules_engine/operations/variable_is_null.py
@@ -4,6 +4,7 @@ from cdisc_rules_engine.operations.base_operation import BaseOperation
 class VariableIsNull(BaseOperation):
     def _execute_operation(self):
         target_variable = self.params.target.replace("--", self.params.domain, 1)
-        if target_variable in self.params.dataframe:
-            series = self.params.dataframe[target_variable]
-            return series.mask(series == "").isnull().all()
+        if target_variable not in self.params.dataframe:
+            return True
+        series = self.params.dataframe[target_variable]
+        return series.mask(series == "").isnull().all()

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -202,7 +202,7 @@ class RulesEngine:
             )
             self.rule_processor.add_comparator_to_rule_conditions(rule, define_metadata)
 
-        elif rule.get("rule_type") == RuleTypes.DEFINE.value:
+        elif rule.get("rule_type") == RuleTypes.DEFINE_ITEM_METADATA_CHECK.value:
             variable_codelist_map_key = get_standard_codelist_cache_key(
                 self.standard, self.standard_version
             )

--- a/cdisc_rules_engine/services/define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml_reader.py
@@ -1,4 +1,5 @@
 from typing import List, Union, Optional
+from functools import cache
 
 from odmlib.define_2_1.rules.metadata_schema import MetadataSchema
 from odmlib.define_loader import XMLDefineLoader
@@ -329,6 +330,7 @@ class DefineXMLReader:
         logger.info(f"Validated Define-XML schema. is_valid={is_valid}")
         return is_valid
 
+    @cache
     def get_define_version(self) -> Optional[str]:
         """Use to extract DefineVersion from file"""
         self.read()

--- a/tests/resources/test_defineV20-SDTM.xml
+++ b/tests/resources/test_defineV20-SDTM.xml
@@ -1,0 +1,7661 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../stylesheets/define2-0-0.xsl"?>
+<!-- ********************************************************************************** -->
+<!-- File: define2-0-0-example-sdtm.xml                                                 -->
+<!-- Author: CDISC XML Technologies Team                                                -->
+<!-- Description: This is an example define.xml V2.0.0 document based on the define.xml -->
+<!--    example of the published Metadata Submission Guideline (SDTM-MSG) V1, with      -->
+<!--    metadata adjustments to comply with the Define-XML 2.0 Specification            -->
+<!--    and to illustrate new features.                                                 -->
+<!-- Release Notes:                                                                     -->
+<!-- 1. If the define.xml document includes a style sheet reference (i.e, uncommented   -->
+<!--    line #2 in  this example) and the style sheet is available in the location      -->
+<!--    specified in the href attribute, most browser applications will display and     -->
+<!--    format the contents of the define.xml document based on the stylesheet          -->
+<!--    instructions.                                                                   -->
+<!--    a. The href attribute should be adjusted as necessary to reflect the            -->
+<!--       corresponding stylesheet location.                                           -->
+<!--    b. The stylesheet should have been developed to interpret the Define-XML        -->
+<!--       specification version indicated in the define.xml document.                  -->
+<!--    c. The resulting HTML presentation and the availability and usability of        -->
+<!--       functions will vary depending upon which browser application is used.        -->
+<!--    d. At the time this example was released, the Google Chrome browser does not    -->
+<!--       render an XML file by using an XSL stylesheet on a local system, and for     --> 
+<!--       other browsers it may depend on extensions that the user has installed.      -->
+<!-- ********************************************************************************** -->
+<ODM 
+  xmlns="http://www.cdisc.org/ns/odm/v1.3" 
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:def="http://www.cdisc.org/ns/def/v2.0"
+  ODMVersion="1.3.2"
+  FileOID="www.cdisc.org.Studycdisc01-Define-XML_2.0.0"
+  FileType="Snapshot"
+  CreationDateTime="2013-03-03T17:04:44"
+  Originator="CDISC XML Technologies Team"
+  SourceSystem="MH-System"
+  SourceSystemVersion="2.0.1"
+  > 
+
+  <!-- ******************************************  -->
+  <!-- OID conventions used in this example:       -->
+  <!--    MetaDataVersion         = MDV.           -->
+  <!--    def:leaf, leafID        = LF.            -->
+  <!--    def:ValueListDef        = VL.            -->
+  <!--    def:WhereClauseDef      = WC.            -->
+  <!--    ItemGroupDef            = IG.            -->
+  <!--    ItemDef                 = IT.            -->
+  <!--    CodeList                = CL.            -->
+  <!--    MethodDef               = MT.            -->
+  <!--    def:CommentDef          = COM.           -->
+  <!-- ******************************************  -->
+
+  <!-- ******************************************  -->
+  <!-- This example does not include Value Level   -->
+  <!-- Metadata (def:ValueListDef) for all items   -->
+  <!-- that may need separate definitions.         -->
+  <!-- The cases included are included for         -->
+  <!-- illustration purposes only.                 -->
+  <!-- ******************************************  -->
+  
+  <Study OID="cdisc01">
+    <GlobalVariables>
+      <StudyName>CDISC01</StudyName>
+      <StudyDescription>CDISC Test Study</StudyDescription>
+      <ProtocolName>CDISC01</ProtocolName>
+    </GlobalVariables>
+    <MetaDataVersion OID="MDV.CDISC01.SDTMIG.3.1.2.SDTM.1.2"
+      Name="Study CDISC01, Data Definitions"
+      Description="Study CDISC01, Data Definitions"
+      def:DefineVersion="2.0.0"
+      def:StandardName="SDTM-IG"
+      def:StandardVersion="3.1.2">
+
+      <!-- ******************** -->
+      <!-- Supporting Documents -->
+      <!-- ******************** -->
+
+      <def:AnnotatedCRF>
+        <def:DocumentRef leafID="LF.blankcrf"/>
+      </def:AnnotatedCRF>
+
+      <def:SupplementalDoc>
+        <def:DocumentRef leafID="LF.ReviewersGuide"/>
+        <def:DocumentRef leafID="LF.ComplexAlgorithms"/>
+      </def:SupplementalDoc>
+ 
+
+      <!-- ************************************************************************************************************************ -->
+      <!-- Value List Definitions Section (Required for Supplemental Qualifiers, Optional for other Normalized (Vertical) Datasets) -->
+      <!--       (Note that any definitions not provided at a Value Level will be inherited from the parent item definition)        -->
+      <!-- ************************************************************************************************************************ -->
+
+      <def:ValueListDef OID="VL.DA.DAORRES">
+        <ItemRef ItemOID="IT.DA.DAORRES.DISPAMT" OrderNumber="1" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.DA.DATESTCD.DISPAMT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.DA.DAORRES.RETAMT" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.DA.DATESTCD.RETAMT"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.EG.EGORRES">
+        <ItemRef ItemOID="IT.EG.EGORRES.INTP" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.EG.EGTESTCD.INTP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.EG.EGORRES.PRMEAN" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.EG.EGTESTCD.PRMEAN"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.EG.EGORRES.QRSDUR" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.EG.EGTESTCD.QRSDUR"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.EG.EGORRES.QTMEAN" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.EG.EGTESTCD.QTMEAN"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.EG.EGORRES.VRMEAN" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.EG.EGTESTCD.VRMEAN"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.EG.EGSTRESC">
+        <ItemRef ItemOID="IT.EG.EGSTRESC.QTCB" OrderNumber="1" Mandatory="Yes" MethodOID="MT.QTCB">
+          <def:WhereClauseRef WhereClauseOID="WC.EG.EGTESTCD.QTCB"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.EG.EGSTRESC.QTCF" OrderNumber="2" Mandatory="Yes" MethodOID="MT.QTCF">
+          <def:WhereClauseRef WhereClauseOID="WC.EG.EGTESTCD.QTCF"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.IE.IEORRES">
+        <ItemRef ItemOID="IT.IE.IEORRES.EXCL01" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.IE.IETESTCD.EXCL01"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.IE.IEORRES.EXCL02" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.IE.IETESTCD.EXCL02"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.IE.IEORRES.EXCL03" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.IE.IETESTCD.EXCL03"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.IE.IEORRES.INCL01" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.IE.IETESTCD.INCL01"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.IE.IEORRES.INCL02" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.IE.IETESTCD.INCL02"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.IE.IEORRES.INCL03" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.IE.IETESTCD.INCL03"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.LB.LBORRES">
+        <ItemRef ItemOID="IT.LB.LBORRES.BILI.LBCAT.CHEMISTRY.LBSPEC.BLOOD" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.BILI.LBCAT.CHEMISTRY.LBSPEC.BLOOD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.BUN.LBCAT.CHEMISTRY.LBSPEC.BLOOD" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.BUN.LBCAT.CHEMISTRY.LBSPEC.BLOOD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.GLUC.LBCAT.CHEMISTRY.LBSPEC.BLOOD" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.GLUC.LBCAT.CHEMISTRY.LBSPEC.BLOOD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.GLUC.LBCAT.URINALYSIS.LBSPEC.URINE.LBMETHOD.DIPSTICK" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.GLUC.LBCAT.URINALYSIS.LBSPEC.URINE.LBMETHOD.DIPSTICK"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.GLUC.LBCAT.URINALYSIS.LBSPEC.URINE.LBMETHOD.QUANT" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.GLUC.LBCAT.URINALYSIS.LBSPEC.URINE.LBMETHOD.QUANT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.HCT.LBCAT.HEMATOLOGY.LBSPEC.BLOOD" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.HCT.LBCAT.HEMATOLOGY.LBSPEC.BLOOD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.HGB.LBCAT.HEMATOLOGY.LBSPEC.BLOOD" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.HGB.LBCAT.HEMATOLOGY.LBSPEC.BLOOD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.LYM.LBCAT.HEMATOLOGY.LBSPEC.BLOOD" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.LYM.LBCAT.HEMATOLOGY.LBSPEC.BLOOD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.OCCBLD.LBCAT.URINALYSIS.LBSPEC.URINE" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.OCCBLD.LBCAT.URINALYSIS.LBSPEC.URINE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.PH.LBCAT.URINALYSIS.LBSPEC.URINE" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.PH.LBCAT.URINALYSIS.LBSPEC.URINE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.VITB12.LBCAT.CHEMISTRY.LBSPEC.SERUM" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.VITB12.LBCAT.CHEMISTRY.LBSPEC.SERUM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.VITB9.LBCAT.CHEMISTRY.LBSPEC.BLOOD" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB.LBTESTCD.VITB9.LBCAT.CHEMISTRY.LBSPEC.BLOOD"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.PE.PEORRES">
+        <ItemRef ItemOID="IT.PE.PEORRES.PE01" OrderNumber="1" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE01"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.PE.PEORRES.PE02" OrderNumber="2" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE02"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.PE.PEORRES.PE03" OrderNumber="3" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE03"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.PE.PEORRES.PE04" OrderNumber="4" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE04"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.PE.PEORRES.PE05" OrderNumber="5" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE05"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.PE.PEORRES.PE06" OrderNumber="6" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE06"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.PE.PEORRES.PE07" OrderNumber="7" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE07"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.PE.PEORRES.PE08" OrderNumber="8" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE08"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.PE.PEORRES.PE09" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.PE.PETESTCD.PE09"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.QS.QSORRES">
+        <ItemRef ItemOID="IT.QS.QSORRES.CGIGLOB" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CGIGLOB"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD01" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD01"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD02" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD02"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD03" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD03"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD04" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD04"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD05" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD05"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD06" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD06"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD07" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD07"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD08" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD08"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD09" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD09"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD10" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD10"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD11" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD11"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD12" OrderNumber="13" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD12"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD13" OrderNumber="14" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD13"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD14" OrderNumber="15" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD14"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD15" OrderNumber="16" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD15"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD16" OrderNumber="17" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD16"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD17" OrderNumber="18" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD17"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD18" OrderNumber="19" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD18"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDD19" OrderNumber="20" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDD19"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.CSDDTOT" OrderNumber="21" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.CSDDTOT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.MMSEA1" OrderNumber="22" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.MMSEA1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.MMSEA2" OrderNumber="23" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.MMSEA2"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.MMSEB" OrderNumber="24" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.MMSEB"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.MMSEC" OrderNumber="25" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.MMSEC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.MMSED" OrderNumber="26" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.MMSED"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.MMSEET" OrderNumber="27" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.MMSEET"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QS.QSORRES.MMSETOT" OrderNumber="28" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.QS.QSTESTCD.MMSETOT"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SC.SCORRES">
+        <ItemRef ItemOID="IT.SC.SCORRES.EDLEVEL" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SC.SCTESTCD.EDLEVEL"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SC.SCORRES.MARISTAT" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SC.SCTESTCD.MARISTAT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SC.SCORRES.SUBJINIT" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SC.SCTESTCD.SUBJINIT"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPAE.QVAL">
+        <ItemRef ItemOID="IT.SUPPAE.QVAL.AETRTEM" OrderNumber="1" Mandatory="No" MethodOID="MT.AETRTEM">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPAE.QNAM.AETRTEM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPAE.QVAL.HLGT" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPAE.QNAM.HLGT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPAE.QVAL.HLT" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPAE.QNAM.HLT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPAE.QVAL.LLT" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPAE.QNAM.LLT"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPCM.QVAL">
+        <ItemRef ItemOID="IT.SUPPCM.QVAL.ATC4CODE" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPCM.QNAM.ATC4CODE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPCM.QVAL.ATC4TERM" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPCM.QNAM.ATC4TERM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPCM.QVAL.CPREFCD" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPCM.QNAM.CPREFCD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPCM.QVAL.PDDREAS" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPCM.QNAM.PDDREAS"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPCM.QVAL.PDRESP" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPCM.QNAM.PDRESP"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPDM.QVAL">
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.RACE1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPDM.QNAM.RACE1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.RACE2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPDM.QNAM.RACE2"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.RACE3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPDM.QNAM.RACE3"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.RACEOTH" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPDM.QNAM.RACEOTH"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.RAND" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPDM.QNAM.RAND"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.RANDNO" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPDM.QNAM.RANDNO"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.SAFETY" OrderNumber="7" Mandatory="No" MethodOID="MT.SAFETY">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPDM.QNAM.SAFETY"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPEG.QVAL">
+        <ItemRef ItemOID="IT.SUPPEG.QVAL.EGCLSIG" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPEG.QNAM.EGCLSIG"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPEX.QVAL">
+        <ItemRef ItemOID="IT.SUPPEX.QVAL.SMNO" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPEX.QNAM.SMNO"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPLB.QVAL">
+        <ItemRef ItemOID="IT.SUPPLB.QVAL.LBCLSIG" OrderNumber="1" Mandatory="No" MethodOID="MT.CLSIG">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPLB.QNAM.LBCLSIG"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPQS.QVAL">
+        <ItemRef ItemOID="IT.SUPPQS.QVAL.RTRINIT" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPQS.QNAM.RTRINIT"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPVS.QVAL">
+        <ItemRef ItemOID="IT.SUPPVS.QVAL.VSCLSIG" OrderNumber="1" Mandatory="No" MethodOID="MT.CLSIG">
+          <def:WhereClauseRef WhereClauseOID="WC.SUPPVS.QNAM.VSCLSIG"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.TS.TSVAL">
+        <ItemRef ItemOID="IT.TS.TSVAL.ADDON" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.ADDON"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.AGEMAX" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.AGEMAX"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.AGEMIN" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.AGEMIN"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.AGESPAN" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.AGESPAN"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.AGEU" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.AGEU"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.DOSE" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.DOSE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.DOSFRQ" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.DOSFRQ"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.DOSU" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.DOSU"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.LENGTH" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.LENGTH"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.OBJPRIM" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.OBJPRIM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.OBJSEC" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.OBJSEC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.PLANSUB" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.PLANSUB"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.RANDOM" OrderNumber="13" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.RANDOM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.ROUTE" OrderNumber="14" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.ROUTE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.SEXPOP" OrderNumber="15" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.SEXPOP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.SPONSOR" OrderNumber="16" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.SPONSOR"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.TBLIND" OrderNumber="17" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.TBLIND"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.TCNTRL" OrderNumber="18" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.TCNTRL"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.TINDTP" OrderNumber="19" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.TINDTP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.TITLE" OrderNumber="20" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.TITLE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.TPHASE" OrderNumber="21" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.TPHASE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.TRT" OrderNumber="22" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.TRT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.TTYPE" OrderNumber="23" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS.TSPARMCD.TTYPE"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.VS.VSORRES">
+        <ItemRef ItemOID="IT.VS.VSORRES.DIABP" OrderNumber="1" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.DIABP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.FRMSIZE" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.FRMSIZE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.HEIGHT" OrderNumber="3" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.HEIGHT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.PULSE" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.PULSE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.SYSBP" OrderNumber="5" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.SYSBP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.WEIGHT" OrderNumber="6" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.WEIGHT"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.VS.VSORRESU">
+        <ItemRef ItemOID="IT.VS.VSORRESU.HEIGHT.DM.COUNTRY.CMETRIC" OrderNumber="1" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.HEIGHT.[DM].COUNTRY.CMETRIC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRESU.HEIGHT.DM.COUNTRY.CNMETRIC" OrderNumber="2" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.HEIGHT.[DM].COUNTRY.CNMETRIC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRESU.WEIGHT.DM.COUNTRY.CMETRIC" OrderNumber="3" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.WEIGHT.[DM].COUNTRY.CMETRIC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRESU.WEIGHT.DM.COUNTRY.CNMETRIC" OrderNumber="4" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.VS.VSTESTCD.WEIGHT.[DM].COUNTRY.CNMETRIC"/>
+        </ItemRef>
+      </def:ValueListDef>
+
+
+      <!-- ************************************************************************** -->
+      <!-- WhereClause Definitions Section (Used/Referenced in Value List Definitions) -->
+      <!-- ************************************************************************** -->
+
+      <def:WhereClauseDef OID="WC.DA.DATESTCD.DISPAMT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.DA.DATESTCD" Comparator="EQ">
+          <CheckValue>DISPAMT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.DA.DATESTCD.RETAMT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.DA.DATESTCD" Comparator="EQ">
+          <CheckValue>RETAMT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.EG.EGTESTCD.INTP">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+          <CheckValue>INTP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.EG.EGTESTCD.PRMEAN">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+          <CheckValue>PRMEAN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.EG.EGTESTCD.QRSDUR">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+          <CheckValue>QRSDUR</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.EG.EGTESTCD.QTMEAN">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+          <CheckValue>QTMEAN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.EG.EGTESTCD.VRMEAN">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+          <CheckValue>VRMEAN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.EG.EGTESTCD.QTCB">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+          <CheckValue>QTCB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.EG.EGTESTCD.QTCF">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.EG.EGTESTCD" Comparator="EQ">
+          <CheckValue>QTCF</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.IE.IETESTCD.EXCL01">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+          <CheckValue>EXCL01</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.IE.IETESTCD.EXCL02">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+          <CheckValue>EXCL02</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.IE.IETESTCD.EXCL03">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+          <CheckValue>EXCL03</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.IE.IETESTCD.INCL01">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+          <CheckValue>INCL01</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.IE.IETESTCD.INCL02">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+          <CheckValue>INCL02</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.IE.IETESTCD.INCL03">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.IE.IETESTCD" Comparator="EQ">
+          <CheckValue>INCL03</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.BILI.LBCAT.CHEMISTRY.LBSPEC.BLOOD">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>BILI</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>CHEMISTRY</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>BLOOD</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.BUN.LBCAT.CHEMISTRY.LBSPEC.BLOOD">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>BUN</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>CHEMISTRY</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>BLOOD</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.GLUC.LBCAT.CHEMISTRY.LBSPEC.BLOOD">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>GLUC</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>CHEMISTRY</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>BLOOD</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.GLUC.LBCAT.URINALYSIS.LBSPEC.URINE.LBMETHOD.DIPSTICK">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>GLUC</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>URINALYSIS</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>URINE</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBMETHOD" Comparator="EQ">
+          <CheckValue>DIPSTICK</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.GLUC.LBCAT.URINALYSIS.LBSPEC.URINE.LBMETHOD.QUANT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>GLUC</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>URINALYSIS</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>URINE</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBMETHOD" Comparator="EQ">
+          <CheckValue>QUANT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.HCT.LBCAT.HEMATOLOGY.LBSPEC.BLOOD">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>HCT</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>HEMATOLOGY</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>BLOOD</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.HGB.LBCAT.HEMATOLOGY.LBSPEC.BLOOD">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>HGB</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>HEMATOLOGY</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>BLOOD</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.LYM.LBCAT.HEMATOLOGY.LBSPEC.BLOOD">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>LYM</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>HEMATOLOGY</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>BLOOD</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.OCCBLD.LBCAT.URINALYSIS.LBSPEC.URINE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>OCCBLD</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>URINALYSIS</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>URINE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.PH.LBCAT.URINALYSIS.LBSPEC.URINE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>PH</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>URINALYSIS</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>URINE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.VITB12.LBCAT.CHEMISTRY.LBSPEC.SERUM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>VITB12</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>CHEMISTRY</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>SERUM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB.LBTESTCD.VITB9.LBCAT.CHEMISTRY.LBSPEC.BLOOD">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD" Comparator="EQ">
+          <CheckValue>VITB9</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBCAT" Comparator="EQ">
+          <CheckValue>CHEMISTRY</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.LB.LBSPEC" Comparator="EQ">
+          <CheckValue>BLOOD</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE01">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE01</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE02">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE02</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE03">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE03</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE04">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE04</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE05">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE05</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE06">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE06</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE07">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE07</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE08">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE08</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PE.PETESTCD.PE09">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.PE.PETESTCD" Comparator="EQ">
+          <CheckValue>PE09</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CGIGLOB">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CGIGLOB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD01">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD01</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD02">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD02</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD03">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD03</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD04">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD04</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD05">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD05</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD06">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD06</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD07">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD07</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD08">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD08</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD09">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD09</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD10">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD10</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD11">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD11</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD12">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD12</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD13">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD13</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD14">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD14</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD15">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD15</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD16">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD16</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD17">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD17</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD18">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD18</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDD19">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDD19</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.CSDDTOT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>CSDDTOT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.MMSEA1">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>MMSEA1</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.MMSEA2">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>MMSEA2</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.MMSEB">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>MMSEB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.MMSEC">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>MMSEC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.MMSED">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>MMSED</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.MMSEET">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>MMSEET</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.QS.QSTESTCD.MMSETOT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.QS.QSTESTCD" Comparator="EQ">
+          <CheckValue>MMSETOT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SC.SCTESTCD.EDLEVEL">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ">
+          <CheckValue>EDLEVEL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SC.SCTESTCD.MARISTAT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ">
+          <CheckValue>MARISTAT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SC.SCTESTCD.SUBJINIT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SC.SCTESTCD" Comparator="EQ">
+          <CheckValue>SUBJINIT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPAE.QNAM.AETRTEM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPAE.QNAM" Comparator="EQ">
+          <CheckValue>AETRTEM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPAE.QNAM.HLGT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPAE.QNAM" Comparator="EQ">
+          <CheckValue>HLGT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPAE.QNAM.HLT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPAE.QNAM" Comparator="EQ">
+          <CheckValue>HLT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPAE.QNAM.LLT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPAE.QNAM" Comparator="EQ">
+          <CheckValue>LLT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPCM.QNAM.ATC4CODE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPCM.QNAM" Comparator="EQ">
+          <CheckValue>ATC4CODE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPCM.QNAM.ATC4TERM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPCM.QNAM" Comparator="EQ">
+          <CheckValue>ATC4TERM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPCM.QNAM.CPREFCD">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPCM.QNAM" Comparator="EQ">
+          <CheckValue>CPREFCD</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPCM.QNAM.PDDREAS">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPCM.QNAM" Comparator="EQ">
+          <CheckValue>PDDREAS</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPCM.QNAM.PDRESP">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPCM.QNAM" Comparator="EQ">
+          <CheckValue>PDRESP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPDM.QNAM.RACE1">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM" Comparator="EQ">
+          <CheckValue>RACE1</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPDM.QNAM.RACE2">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM" Comparator="EQ">
+          <CheckValue>RACE2</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPDM.QNAM.RACE3">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM" Comparator="EQ">
+          <CheckValue>RACE3</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPDM.QNAM.RACEOTH">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM" Comparator="EQ">
+          <CheckValue>RACEOTH</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPDM.QNAM.RAND">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM" Comparator="EQ">
+          <CheckValue>RAND</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPDM.QNAM.RANDNO">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM" Comparator="EQ">
+          <CheckValue>RANDNO</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPDM.QNAM.SAFETY">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM" Comparator="EQ">
+          <CheckValue>SAFETY</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPEG.QNAM.EGCLSIG">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPEG.QNAM" Comparator="EQ">
+          <CheckValue>EGCLSIG</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPEX.QNAM.SMNO">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPEX.QNAM" Comparator="EQ">
+          <CheckValue>SMNO</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPLB.QNAM.LBCLSIG">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPLB.QNAM" Comparator="EQ">
+          <CheckValue>LBCLSIG</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPQS.QNAM.RTRINIT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPQS.QNAM" Comparator="EQ">
+          <CheckValue>RTRINIT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.SUPPVS.QNAM.VSCLSIG">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.SUPPVS.QNAM" Comparator="EQ">
+          <CheckValue>VSCLSIG</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.ADDON">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>ADDON</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.AGEMAX">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>AGEMAX</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.AGEMIN">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>AGEMIN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.AGESPAN">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>AGESPAN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.AGEU">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>AGEU</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.DOSE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>DOSE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.DOSFRQ">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>DOSFRQ</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.DOSU">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>DOSU</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.LENGTH">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>LENGTH</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.OBJPRIM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>OBJPRIM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.OBJSEC">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>OBJSEC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.PLANSUB">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>PLANSUB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.RANDOM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>RANDOM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.ROUTE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>ROUTE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.SEXPOP">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>SEXPOP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.SPONSOR">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>SPONSOR</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.TBLIND">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>TBLIND</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.TCNTRL">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>TCNTRL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.TINDTP">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>TINDTP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.TITLE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>TITLE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.TPHASE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>TPHASE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.TRT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>TRT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS.TSPARMCD.TTYPE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD" Comparator="EQ">
+          <CheckValue>TTYPE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.DIABP">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>DIABP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.FRMSIZE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>FRMSIZE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.HEIGHT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>HEIGHT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.PULSE">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>PULSE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.SYSBP">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>SYSBP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.WEIGHT">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>WEIGHT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.HEIGHT.[DM].COUNTRY.CMETRIC" def:CommentOID="COM.SUBJECTDATA-JOIN-DM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>HEIGHT</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.DM.COUNTRY" Comparator="IN">
+          <CheckValue>CAN</CheckValue>
+          <CheckValue>MEX</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.HEIGHT.[DM].COUNTRY.CNMETRIC" def:CommentOID="COM.SUBJECTDATA-JOIN-DM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>HEIGHT</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.DM.COUNTRY" Comparator="EQ">
+          <CheckValue>USA</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.WEIGHT.[DM].COUNTRY.CMETRIC" def:CommentOID="COM.SUBJECTDATA-JOIN-DM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>WEIGHT</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.DM.COUNTRY" Comparator="IN">
+          <CheckValue>CAN</CheckValue>
+          <CheckValue>MEX</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.VS.VSTESTCD.WEIGHT.[DM].COUNTRY.CNMETRIC" def:CommentOID="COM.SUBJECTDATA-JOIN-DM">
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD" Comparator="EQ">
+          <CheckValue>WEIGHT</CheckValue>
+        </RangeCheck>
+        <RangeCheck SoftHard="Soft" def:ItemOID="IT.DM.COUNTRY" Comparator="EQ">
+          <CheckValue>USA</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+
+
+      <!-- ************************************************************************************ -->
+      <!-- ItemGroupDef Definitions Section (Datasets and and first set of variable properties) -->
+      <!-- ************************************************************************************ -->
+
+      <!-- Dataset Definition (TA) -->
+      <ItemGroupDef OID="IG.TA"
+        Domain="TA"
+        Name="TA"
+        Repeating="No"
+        IsReferenceData="Yes"
+        SASDatasetName="TA"
+        Purpose="Tabulation"
+        def:Structure="One record per planned Element per Arm"
+        def:Class="TRIAL DESIGN"
+        def:ArchiveLocationID="LF.TA">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Arms</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.TA.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TA.ARMCD" OrderNumber="3" Mandatory="Yes" KeySequence="2"/>
+        <ItemRef ItemOID="IT.TA.ARM" OrderNumber="4" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TA.TAETORD" OrderNumber="5" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.TA.ETCD" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TA.ELEMENT" OrderNumber="7" Mandatory="No"/>
+        <ItemRef ItemOID="IT.TA.TABRANCH" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.TA.TATRANS" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.TA.EPOCH" OrderNumber="10" Mandatory="Yes"/>
+        <def:leaf ID="LF.TA" xlink:href="ta.xpt">
+          <def:title>ta.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (TE) -->
+      <ItemGroupDef OID="IG.TE"
+        Domain="TE"
+        Name="TE"
+        Repeating="No"
+        IsReferenceData="Yes"
+        SASDatasetName="TE"
+        Purpose="Tabulation"
+        def:Structure="One record per planned Element"
+        def:Class="TRIAL DESIGN"
+        def:ArchiveLocationID="LF.TE">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Elements</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.TE.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TE.ETCD" OrderNumber="3" Mandatory="Yes" KeySequence="2"/>
+        <ItemRef ItemOID="IT.TE.ELEMENT" OrderNumber="4" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TE.TESTRL" OrderNumber="5" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TE.TEDUR" OrderNumber="6" Mandatory="No"/>
+        <def:leaf ID="LF.TE" xlink:href="te.xpt">
+          <def:title>te.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (TI) -->
+      <ItemGroupDef OID="IG.TI"
+        Domain="TI"
+        Name="TI"
+        Repeating="No"
+        IsReferenceData="Yes"
+        SASDatasetName="TI"
+        Purpose="Tabulation"
+        def:Structure="One record per I/E criterion"
+        def:Class="TRIAL DESIGN"
+        def:ArchiveLocationID="LF.TI">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Inclusion/Exclusion Criteria</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.TI.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TI.IETESTCD" OrderNumber="3" Mandatory="Yes" KeySequence="2"/>
+        <ItemRef ItemOID="IT.TI.IETEST" OrderNumber="4" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TI.IECAT" OrderNumber="5" Mandatory="Yes"/>
+        <def:leaf ID="LF.TI" xlink:href="ti.xpt">
+          <def:title>ti.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (TS) -->
+      <ItemGroupDef OID="IG.TS"
+        Domain="TS"
+        Name="TS"
+        Repeating="No"
+        IsReferenceData="Yes"
+        SASDatasetName="TS"
+        Purpose="Tabulation"
+        def:Structure="One record per trial summary parameter value"
+        def:Class="TRIAL DESIGN"
+        def:ArchiveLocationID="LF.TS">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Summary</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.TS.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TS.TSSEQ" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.TSSEQ"/>
+        <ItemRef ItemOID="IT.TS.TSPARMCD" OrderNumber="4" Mandatory="Yes" KeySequence="2"/>
+        <ItemRef ItemOID="IT.TS.TSPARM" OrderNumber="5" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TS.TSVAL" OrderNumber="6" Mandatory="Yes"/>
+        <def:leaf ID="LF.TS" xlink:href="ts.xpt">
+          <def:title>ts.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (TV) -->
+      <ItemGroupDef OID="IG.TV"
+        Domain="TV"
+        Name="TV"
+        Repeating="No"
+        IsReferenceData="Yes"
+        SASDatasetName="TV"
+        Purpose="Tabulation"
+        def:Structure="One record per planned Visit per Arm"
+        def:Class="TRIAL DESIGN"
+        def:ArchiveLocationID="LF.TV">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Visits</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.TV.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.TV.VISITNUM" OrderNumber="3" Mandatory="Yes" KeySequence="2"/>
+        <ItemRef ItemOID="IT.TV.VISIT" OrderNumber="4" Mandatory="No"/>
+        <ItemRef ItemOID="IT.TV.VISITDY" OrderNumber="5" Mandatory="No"/>
+        <ItemRef ItemOID="IT.TV.ARMCD" OrderNumber="6" Mandatory="No" KeySequence="3"/>
+        <ItemRef ItemOID="IT.TV.TVSTRL" OrderNumber="7" Mandatory="Yes"/>
+        <def:leaf ID="LF.TV" xlink:href="tv.xpt">
+          <def:title>tv.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (DM) -->
+      <ItemGroupDef OID="IG.DM"
+        Domain="DM"
+        Name="DM"
+        Repeating="No"
+        IsReferenceData="No"
+        SASDatasetName="DM"
+        Purpose="Tabulation"
+        def:Structure="One record per subject"
+        def:Class="SPECIAL PURPOSE"
+        def:CommentOID="COM.DOMAIN.DM"
+        def:ArchiveLocationID="LF.DM">
+        <Description>
+          <TranslatedText xml:lang="en">Demographics</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.DM.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.DM.SUBJID" OrderNumber="4" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.DM.RFSTDTC" OrderNumber="5" Mandatory="No" MethodOID="MT.RFSTDTC"/>
+        <ItemRef ItemOID="IT.DM.RFENDTC" OrderNumber="6" Mandatory="No" MethodOID="MT.RFENDTC"/>
+        <ItemRef ItemOID="IT.DM.SITEID" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.DM.BRTHDTC" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.DM.AGE" OrderNumber="9" Mandatory="Yes" MethodOID="MT.AGE"/>
+        <ItemRef ItemOID="IT.DM.AGEU" OrderNumber="10" Mandatory="No"/>
+        <ItemRef ItemOID="IT.DM.SEX" OrderNumber="11" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.DM.RACE" OrderNumber="12" Mandatory="No"/>
+        <ItemRef ItemOID="IT.DM.ETHNIC" OrderNumber="13" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.DM.ARMCD" OrderNumber="14" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.DM.ARM" OrderNumber="15" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.DM.COUNTRY" OrderNumber="16" Mandatory="Yes"/>
+        <def:leaf ID="LF.DM" xlink:href="dm.xpt">
+          <def:title>dm.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SE) -->
+      <ItemGroupDef OID="IG.SE"
+        Domain="SE"
+        Name="SE"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SE"
+        Purpose="Tabulation"
+        def:Structure="One record per actual Element per subject"
+        def:Class="SPECIAL PURPOSE"
+        def:ArchiveLocationID="LF.SE">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Elements</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.SE.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SE.SESEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.SE.ETCD" OrderNumber="5" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SE.ELEMENT" OrderNumber="6" Mandatory="No"/>
+        <ItemRef ItemOID="IT.SE.SESTDTC" OrderNumber="7" Mandatory="Yes" KeySequence="3" MethodOID="MT.SESTDTC"/>
+        <ItemRef ItemOID="IT.SE.SEENDTC" OrderNumber="8" Mandatory="No" KeySequence="4" MethodOID="MT.SEENDTC"/>
+        <ItemRef ItemOID="IT.SE.TAETORD" OrderNumber="9" Mandatory="No" KeySequence="5"/>
+        <def:leaf ID="LF.SE" xlink:href="se.xpt">
+          <def:title>se.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SV) -->
+      <ItemGroupDef OID="IG.SV"
+        Domain="SV"
+        Name="SV"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SV"
+        Purpose="Tabulation"
+        def:Structure="One record per actual visit per subject"
+        def:Class="SPECIAL PURPOSE"
+        def:ArchiveLocationID="LF.SV">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Visits</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.SV.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SV.VISITNUM" OrderNumber="4" Mandatory="Yes" KeySequence="4" MethodOID="MT.SV.VISITNUM"/>
+        <ItemRef ItemOID="IT.SV.VISIT" OrderNumber="5" Mandatory="No" MethodOID="MT.SV.VISIT"/>
+        <ItemRef ItemOID="IT.SV.VISITDY" OrderNumber="6" Mandatory="No"/>
+        <ItemRef ItemOID="IT.SV.SVSTDTC" OrderNumber="7" Mandatory="No" KeySequence="3" MethodOID="MT.SVSTDTC"/>
+        <ItemRef ItemOID="IT.SV.SVENDTC" OrderNumber="8" Mandatory="No" MethodOID="MT.SVENDTC"/>
+        <ItemRef ItemOID="IT.SV.SVSTDY" OrderNumber="9" Mandatory="No" MethodOID="MT.SVSTDY"/>
+        <def:leaf ID="LF.SV" xlink:href="sv.xpt">
+          <def:title>sv.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (CM) -->
+      <ItemGroupDef OID="IG.CM"
+        Domain="CM"
+        Name="CM"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="CM"
+        Purpose="Tabulation"
+        def:Structure="One record per recorded medication occurrence or constant-dosing interval per subject"
+        def:Class="INTERVENTIONS"
+        def:ArchiveLocationID="LF.CM">
+        <Description>
+          <TranslatedText xml:lang="en">Concomitant Medications</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.CM.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.CM.CMSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.CM.CMTRT" OrderNumber="5" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.CM.CMMODIFY" OrderNumber="6" Mandatory="No"/>
+        <ItemRef ItemOID="IT.CM.CMDECOD" OrderNumber="7" Mandatory="No"/>
+        <ItemRef ItemOID="IT.CM.CMCAT" OrderNumber="8" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.CM.CMINDC" OrderNumber="9" Mandatory="No" KeySequence="9"/>
+        <ItemRef ItemOID="IT.CM.CMCLAS" OrderNumber="10" Mandatory="No"/>
+        <ItemRef ItemOID="IT.CM.CMCLASCD" OrderNumber="11" Mandatory="No"/>
+        <ItemRef ItemOID="IT.CM.CMDOSTXT" OrderNumber="12" Mandatory="No" KeySequence="7"/>
+        <ItemRef ItemOID="IT.CM.CMDOSU" OrderNumber="13" Mandatory="No" KeySequence="8"/>
+        <ItemRef ItemOID="IT.CM.CMDOSFRQ" OrderNumber="14" Mandatory="No" KeySequence="10"/>
+        <ItemRef ItemOID="IT.CM.CMROUTE" OrderNumber="15" Mandatory="No"/>
+        <ItemRef ItemOID="IT.CM.CMSTDTC" OrderNumber="16" Mandatory="No" KeySequence="3"/>
+        <ItemRef ItemOID="IT.CM.CMENDTC" OrderNumber="17" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.CM.CMSTDY" OrderNumber="18" Mandatory="No" MethodOID="MT.CMSTDY"/>
+        <ItemRef ItemOID="IT.CM.CMENDY" OrderNumber="19" Mandatory="No" MethodOID="MT.CMENDY"/>
+        <ItemRef ItemOID="IT.CM.CMENRF" OrderNumber="20" Mandatory="No"/>
+        <def:leaf ID="LF.CM" xlink:href="cm.xpt">
+          <def:title>cm.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (EX) -->
+      <ItemGroupDef OID="IG.EX"
+        Domain="EX"
+        Name="EX"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="EX"
+        Purpose="Tabulation"
+        def:Structure="One record per constant dosing interval per subject"
+        def:Class="INTERVENTIONS"
+        def:ArchiveLocationID="LF.EX">
+        <Description>
+          <TranslatedText xml:lang="en">Exposure</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.EX.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.EX.EXSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.EX.EXTRT" OrderNumber="5" Mandatory="Yes" KeySequence="5" MethodOID="MT.EXTRT"/>
+        <ItemRef ItemOID="IT.EX.EXDOSE" OrderNumber="6" Mandatory="No" KeySequence="6" MethodOID="MT.EXDOSE"/>
+        <ItemRef ItemOID="IT.EX.EXDOSU" OrderNumber="7" Mandatory="No" MethodOID="MT.EXDOSU"/>
+        <ItemRef ItemOID="IT.EX.EXDOSFRM" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EX.EXSTDTC" OrderNumber="9" Mandatory="No" KeySequence="3"/>
+        <ItemRef ItemOID="IT.EX.EXENDTC" OrderNumber="10" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.EX.EXSTDY" OrderNumber="11" Mandatory="No" MethodOID="MT.EXSTDY"/>
+        <ItemRef ItemOID="IT.EX.EXENDY" OrderNumber="12" Mandatory="No" MethodOID="MT.EXENDY"/>
+        <def:leaf ID="LF.EX" xlink:href="ex.xpt">
+          <def:title>ex.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (AE) -->
+      <ItemGroupDef OID="IG.AE"
+        Domain="AE"
+        Name="AE"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="AE"
+        Purpose="Tabulation"
+        def:Structure="One record per adverse event per subject"
+        def:Class="EVENTS"
+        def:ArchiveLocationID="LF.AE">
+        <Description>
+          <TranslatedText xml:lang="en">Adverse Events</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.AE.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.AE.AESEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.AE.AESPID" OrderNumber="5" Mandatory="No"/>
+        <ItemRef ItemOID="IT.AE.AETERM" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEMODIFY" OrderNumber="7" Mandatory="No"/>
+        <ItemRef ItemOID="IT.AE.AEDECOD" OrderNumber="8" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.AE.AEBODSYS" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.AE.AESEV" OrderNumber="10" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.AE.AESER" OrderNumber="11" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEACN" OrderNumber="12" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEREL" OrderNumber="13" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.AE.AESTDTC" OrderNumber="14" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.AE.AEENDTC" OrderNumber="15" Mandatory="No"/>
+        <ItemRef ItemOID="IT.AE.AESTDY" OrderNumber="16" Mandatory="No" MethodOID="MT.AESTDY"/>
+        <ItemRef ItemOID="IT.AE.AEENDY" OrderNumber="17" Mandatory="No" MethodOID="MT.AEENDY"/>
+        <ItemRef ItemOID="IT.AE.AEENRF" OrderNumber="18" Mandatory="No"/>
+        <def:leaf ID="LF.AE" xlink:href="ae.xpt">
+          <def:title>ae.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (DS) -->
+      <ItemGroupDef OID="IG.DS"
+        Domain="DS"
+        Name="DS"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="DS"
+        Purpose="Tabulation"
+        def:Structure="One record per disposition status or protocol milestone per subject"
+        def:Class="EVENTS"
+        def:ArchiveLocationID="LF.DS">
+        <Description>
+          <TranslatedText xml:lang="en">Disposition</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.DS.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.DS.DSSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.DS.DSTERM" OrderNumber="5" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.DS.DSDECOD" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.DS.DSCAT" OrderNumber="7" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.DS.EPOCH" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.DS.DSSTDTC" OrderNumber="9" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.DS.DSSTDY" OrderNumber="10" Mandatory="No" KeySequence="3" MethodOID="MT.DSSTDY"/>
+        <def:leaf ID="LF.DS" xlink:href="ds.xpt">
+          <def:title>ds.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (MH) -->
+      <ItemGroupDef OID="IG.MH"
+        Domain="MH"
+        Name="MH"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="MH"
+        Purpose="Tabulation"
+        def:Structure="One record per medical history event per subject"
+        def:Class="EVENTS"
+        def:ArchiveLocationID="LF.MH">
+        <Description>
+          <TranslatedText xml:lang="en">Medical History</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.MH.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.MH.MHSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.MH.MHTERM" OrderNumber="5" Mandatory="Yes" KeySequence="4"/>
+        <ItemRef ItemOID="IT.MH.MHCAT" OrderNumber="6" Mandatory="No" KeySequence="3"/>
+        <ItemRef ItemOID="IT.MH.MHPRESP" OrderNumber="7" Mandatory="No"/>
+        <ItemRef ItemOID="IT.MH.MHOCCUR" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.MH.MHBODSYS" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.MH.MHDTC" OrderNumber="10" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.MH.MHSTDTC" OrderNumber="11" Mandatory="No" KeySequence="6"/>
+        <ItemRef ItemOID="IT.MH.MHENRF" OrderNumber="12" Mandatory="No"/>
+        <def:leaf ID="LF.MH" xlink:href="mh.xpt">
+          <def:title>mh.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (DA) -->
+      <ItemGroupDef OID="IG.DA"
+        Domain="DA"
+        Name="DA"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="DA"
+        Purpose="Tabulation"
+        def:Structure="One record per drug accountability finding per subject"
+        def:Class="FINDINGS"
+        def:ArchiveLocationID="LF.DA">
+        <Description>
+          <TranslatedText xml:lang="en">Drug Accountability</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.DA.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.DA.DASEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.DA.DATESTCD" OrderNumber="5" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.DA.DATEST" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.DA.DAORRES" OrderNumber="7" Mandatory="No"/>
+        <ItemRef ItemOID="IT.DA.DAORRESU" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.DA.DASTRESC" OrderNumber="9" Mandatory="No" MethodOID="MT.DASTRESC"/>
+        <ItemRef ItemOID="IT.DA.DASTRESN" OrderNumber="10" Mandatory="No" MethodOID="MT.DASTRESN"/>
+        <ItemRef ItemOID="IT.DA.DASTRESU" OrderNumber="11" Mandatory="No" MethodOID="MT.DASTRESU"/>
+        <ItemRef ItemOID="IT.DA.VISITNUM" OrderNumber="12" Mandatory="No" MethodOID="MT.DA.VISITNUM"/>
+        <ItemRef ItemOID="IT.DA.VISIT" OrderNumber="13" Mandatory="No"/>
+        <ItemRef ItemOID="IT.DA.VISITDY" OrderNumber="14" Mandatory="No"/>
+        <ItemRef ItemOID="IT.DA.DADTC" OrderNumber="15" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.DA.DADY" OrderNumber="16" Mandatory="No" MethodOID="MT.DADY"/>
+        <def:leaf ID="LF.DA" xlink:href="da.xpt">
+          <def:title>da.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (EG) -->
+      <ItemGroupDef OID="IG.EG"
+        Domain="EG"
+        Name="EG"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="EG"
+        Purpose="Tabulation"
+        def:Structure="One record per ECG observation per visit per subject"
+        def:Class="FINDINGS"
+        def:ArchiveLocationID="LF.EG">
+        <Description>
+          <TranslatedText xml:lang="en">ECG Test Results</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.EG.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.EG.EGSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.EG.EGSPID" OrderNumber="5" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EG.EGTESTCD" OrderNumber="6" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.EG.EGTEST" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.EG.EGPOS" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EG.EGORRES" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EG.EGORRESU" OrderNumber="10" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EG.EGSTRESC" OrderNumber="11" Mandatory="No" MethodOID="MT.EGSTRESC"/>
+        <ItemRef ItemOID="IT.EG.EGSTRESN" OrderNumber="12" Mandatory="No" MethodOID="MT.EGSTRESN"/>
+        <ItemRef ItemOID="IT.EG.EGSTRESU" OrderNumber="13" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EG.EGBLFL" OrderNumber="14" Mandatory="No" MethodOID="MT.EGBLFL"/>
+        <ItemRef ItemOID="IT.EG.EGDRVFL" OrderNumber="15" Mandatory="No" MethodOID="MT.EGDRVFL"/>
+        <ItemRef ItemOID="IT.EG.EGEVAL" OrderNumber="16" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EG.VISITNUM" OrderNumber="17" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.EG.VISIT" OrderNumber="18" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EG.VISITDY" OrderNumber="19" Mandatory="No"/>
+        <ItemRef ItemOID="IT.EG.EGDTC" OrderNumber="20" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.EG.EGDY" OrderNumber="21" Mandatory="No" MethodOID="MT.EGDY"/>
+        <def:leaf ID="LF.EG" xlink:href="eg.xpt">
+          <def:title>eg.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (IE) -->
+      <ItemGroupDef OID="IG.IE"
+        Domain="IE"
+        Name="IE"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="IE"
+        Purpose="Tabulation"
+        def:Structure="One record per inclusion/exclusion criterion not met per subject"
+        def:Class="FINDINGS"
+        def:ArchiveLocationID="LF.IE">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Criteria Not Met</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.IE.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.IE.IESEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.IE.IETESTCD" OrderNumber="5" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.IE.IETEST" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.IE.IECAT" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.IE.IEORRES" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.IE.IESTRESC" OrderNumber="9" Mandatory="Yes" MethodOID="MT.IESTRESC"/>
+        <ItemRef ItemOID="IT.IE.VISITNUM" OrderNumber="10" Mandatory="No"/>
+        <ItemRef ItemOID="IT.IE.VISIT" OrderNumber="11" Mandatory="No"/>
+        <ItemRef ItemOID="IT.IE.IEDTC" OrderNumber="12" Mandatory="No"/>
+        <def:leaf ID="LF.IE" xlink:href="ie.xpt">
+          <def:title>ie.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (LB) -->
+      <ItemGroupDef OID="IG.LB"
+        Domain="LB"
+        Name="LB"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="LB"
+        Purpose="Tabulation"
+        def:Structure="One record per analyte per visit per subject"
+        def:Class="FINDINGS"
+        def:ArchiveLocationID="LF.LB">
+        <Description>
+          <TranslatedText xml:lang="en">Laboratory Tests Results</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.LB.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.LB.LBSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.LB.LBREFID" OrderNumber="5" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBTESTCD" OrderNumber="6" Mandatory="Yes" KeySequence="5"/>
+        <ItemRef ItemOID="IT.LB.LBTEST" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.LB.LBCAT" OrderNumber="8" Mandatory="No" KeySequence="3"/>
+        <ItemRef ItemOID="IT.LB.LBORRES" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBORRESU" OrderNumber="10" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBORNRLO" OrderNumber="11" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBORNRHI" OrderNumber="12" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBSTRESC" OrderNumber="13" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBSTRESN" OrderNumber="14" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBSTRESU" OrderNumber="15" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBSTNRLO" OrderNumber="16" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBSTNRHI" OrderNumber="17" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBSTNRC" OrderNumber="18" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBNRIND" OrderNumber="19" Mandatory="No" MethodOID="MT.LBNRIND"/>
+        <ItemRef ItemOID="IT.LB.LBSPEC" OrderNumber="20" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBMETHOD" OrderNumber="21" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.LB.LBBLFL" OrderNumber="22" Mandatory="No" MethodOID="MT.LBBLFL"/>
+        <ItemRef ItemOID="IT.LB.LBFAST" OrderNumber="23" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.VISITNUM" OrderNumber="24" Mandatory="No" KeySequence="7"/>
+        <ItemRef ItemOID="IT.LB.VISIT" OrderNumber="25" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.VISITDY" OrderNumber="26" Mandatory="No"/>
+        <ItemRef ItemOID="IT.LB.LBDTC" OrderNumber="27" Mandatory="No" KeySequence="6"/>
+        <ItemRef ItemOID="IT.LB.LBDY" OrderNumber="28" Mandatory="No" MethodOID="MT.LBDY"/>
+        <def:leaf ID="LF.LB" xlink:href="lb.xpt">
+          <def:title>lb.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (PE) -->
+      <ItemGroupDef OID="IG.PE"
+        Domain="PE"
+        Name="PE"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="PE"
+        Purpose="Tabulation"
+        def:Structure="One record per body system or abnormality per visit per subject"
+        def:Class="FINDINGS"
+        def:ArchiveLocationID="LF.PE">
+        <Description>
+          <TranslatedText xml:lang="en">Physical Examination</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.PE.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.PE.PESEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.PE.PETESTCD" OrderNumber="5" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.PE.PETEST" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.PE.PEORRES" OrderNumber="7" Mandatory="No"/>
+        <ItemRef ItemOID="IT.PE.PESTRESC" OrderNumber="8" Mandatory="No" MethodOID="MT.PESTRESC"/>
+        <ItemRef ItemOID="IT.PE.VISITNUM" OrderNumber="9" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.PE.VISIT" OrderNumber="10" Mandatory="No"/>
+        <ItemRef ItemOID="IT.PE.VISITDY" OrderNumber="11" Mandatory="No"/>
+        <ItemRef ItemOID="IT.PE.PEDTC" OrderNumber="12" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.PE.PEDY" OrderNumber="13" Mandatory="No" MethodOID="MT.PEDY"/>
+        <def:leaf ID="LF.PE" xlink:href="pe.xpt">
+          <def:title>pe.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (QSCG) -->
+      <ItemGroupDef OID="IG.QSCG"
+        Domain="QS"
+        Name="QSCG"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="QSCG"
+        Purpose="Tabulation"
+        def:Structure="One record per questionnaire per question per visit per subject"
+        def:Class="FINDINGS"
+        def:CommentOID="COM.DOMAIN.QS"
+        def:ArchiveLocationID="LF.QSCG">
+        <Description>
+          <TranslatedText xml:lang="en">Questionnaire-QSCG</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.QS.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.QS.QSSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.QS.QSTESTCD" OrderNumber="5" Mandatory="Yes" KeySequence="4"/>
+        <ItemRef ItemOID="IT.QS.QSTEST" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.QS.QSCAT" OrderNumber="7" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.QS.QSORRES" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.QSSTRESC" OrderNumber="10" Mandatory="No" MethodOID="MT.QSSTRESC"/>
+        <ItemRef ItemOID="IT.QS.QSSTRESN" OrderNumber="11" Mandatory="No" MethodOID="MT.QSSTRESN"/>
+        <ItemRef ItemOID="IT.QS.VISITNUM" OrderNumber="13" Mandatory="No" KeySequence="6"/>
+        <ItemRef ItemOID="IT.QS.VISIT" OrderNumber="14" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.VISITDY" OrderNumber="15" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.QSDTC" OrderNumber="16" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.QS.QSDY" OrderNumber="17" Mandatory="No" MethodOID="MT.QSDY"/>
+        <Alias Context="DomainDescription" Name="Questionnaires"/>
+        <def:leaf ID="LF.QSCG" xlink:href="qscg.xpt">
+          <def:title>qscg.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (QSCS) -->
+      <ItemGroupDef OID="IG.QSCS"
+        Domain="QS"
+        Name="QSCS"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="QSCS"
+        Purpose="Tabulation"
+        def:Structure="One record per questionnaire per question per visit per subject"
+        def:Class="FINDINGS"
+        def:CommentOID="COM.DOMAIN.QS"
+        def:ArchiveLocationID="LF.QSCS">
+        <Description>
+          <TranslatedText xml:lang="en">Questionnaire-QSCS</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.QS.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.QS.QSSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.QS.QSTESTCD" OrderNumber="5" Mandatory="Yes" KeySequence="4"/>
+        <ItemRef ItemOID="IT.QS.QSTEST" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.QS.QSCAT" OrderNumber="7" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.QS.QSSCAT" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.QSORRES" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.QSSTRESC" OrderNumber="10" Mandatory="No" MethodOID="MT.QSSTRESC"/>
+        <ItemRef ItemOID="IT.QS.QSSTRESN" OrderNumber="11" Mandatory="No" MethodOID="MT.QSSTRESN"/>
+        <ItemRef ItemOID="IT.QS.QSBLFL" OrderNumber="12" Mandatory="No" MethodOID="MT.QSBLFL"/>
+        <ItemRef ItemOID="IT.QS.VISITNUM" OrderNumber="13" Mandatory="No" KeySequence="6"/>
+        <ItemRef ItemOID="IT.QS.VISIT" OrderNumber="14" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.VISITDY" OrderNumber="15" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.QSDTC" OrderNumber="16" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.QS.QSDY" OrderNumber="17" Mandatory="No" MethodOID="MT.QSDY"/>
+        <ItemRef ItemOID="IT.QS.QSEVLINT" OrderNumber="18" Mandatory="No"/>
+        <Alias Context="DomainDescription" Name="Questionnaires"/>
+        <def:leaf ID="LF.QSCS" xlink:href="qscs.xpt">
+          <def:title>qscs.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (QSMM) -->
+      <ItemGroupDef OID="IG.QSMM"
+        Domain="QS"
+        Name="QSMM"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="QSMM"
+        Purpose="Tabulation"
+        def:Structure="One record per questionnaire per question per visit per subject"
+        def:Class="FINDINGS"
+        def:CommentOID="COM.DOMAIN.QS"
+        def:ArchiveLocationID="LF.QSMM">
+        <Description>
+          <TranslatedText xml:lang="en">Questionnaire-QSMM</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.QS.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.QS.QSSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.QS.QSTESTCD" OrderNumber="5" Mandatory="Yes" KeySequence="4"/>
+        <ItemRef ItemOID="IT.QS.QSTEST" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.QS.QSCAT" OrderNumber="7" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.QS.QSORRES" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.QSSTRESC" OrderNumber="10" Mandatory="No" MethodOID="MT.QSSTRESC"/>
+        <ItemRef ItemOID="IT.QS.QSSTRESN" OrderNumber="11" Mandatory="No" MethodOID="MT.QSSTRESN"/>
+        <ItemRef ItemOID="IT.QS.QSBLFL" OrderNumber="12" Mandatory="No" MethodOID="MT.QSBLFL"/>
+        <ItemRef ItemOID="IT.QS.VISITNUM" OrderNumber="13" Mandatory="No" KeySequence="6"/>
+        <ItemRef ItemOID="IT.QS.VISIT" OrderNumber="14" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.VISITDY" OrderNumber="15" Mandatory="No"/>
+        <ItemRef ItemOID="IT.QS.QSDTC" OrderNumber="16" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.QS.QSDY" OrderNumber="17" Mandatory="No" MethodOID="MT.QSDY"/>
+        <Alias Context="DomainDescription" Name="Questionnaires"/>
+        <def:leaf ID="LF.QSMM" xlink:href="qsmm.xpt">
+          <def:title>qsmm.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SC) -->
+      <ItemGroupDef OID="IG.SC"
+        Domain="SC"
+        Name="SC"
+        Repeating="No"
+        IsReferenceData="No"
+        SASDatasetName="SC"
+        Purpose="Tabulation"
+        def:Structure="One record per characteristic per subject"
+        def:Class="FINDINGS"
+        def:ArchiveLocationID="LF.SC">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Characteristics</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.SC.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SC.SCSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.SC.SCTESTCD" OrderNumber="5" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.SC.SCTEST" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SC.SCORRES" OrderNumber="7" Mandatory="No"/>
+        <ItemRef ItemOID="IT.SC.SCSTRESC" OrderNumber="8" Mandatory="No" MethodOID="MT.SCSTRESC"/>
+        <ItemRef ItemOID="IT.SC.SCDTC" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.SC.SCDY" OrderNumber="10" Mandatory="No" MethodOID="MT.SCDY"/>
+        <def:leaf ID="LF.SC" xlink:href="sc.xpt">
+          <def:title>sc.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (VS) -->
+      <ItemGroupDef OID="IG.VS"
+        Domain="VS"
+        Name="VS"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="VS"
+        Purpose="Tabulation"
+        def:Structure="One record per vital sign measurement per visit per subject"
+        def:Class="FINDINGS"
+        def:ArchiveLocationID="LF.VS">
+        <Description>
+          <TranslatedText xml:lang="en">Vital Signs</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.VS.DOMAIN" OrderNumber="2" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="2" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.VS.VSSEQ" OrderNumber="4" Mandatory="Yes" MethodOID="MT.SEQ"/>
+        <ItemRef ItemOID="IT.VS.VSTESTCD" OrderNumber="5" Mandatory="Yes" KeySequence="3"/>
+        <ItemRef ItemOID="IT.VS.VSTEST" OrderNumber="6" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.VS.VSPOS" OrderNumber="7" Mandatory="No" KeySequence="6"/>
+        <ItemRef ItemOID="IT.VS.VSORRES" OrderNumber="8" Mandatory="No"/>
+        <ItemRef ItemOID="IT.VS.VSORRESU" OrderNumber="9" Mandatory="No"/>
+        <ItemRef ItemOID="IT.VS.VSSTRESC" OrderNumber="10" Mandatory="No" MethodOID="MT.VSSTRESC"/>
+        <ItemRef ItemOID="IT.VS.VSSTRESN" OrderNumber="11" Mandatory="No" MethodOID="MT.VSSTRESN"/>
+        <ItemRef ItemOID="IT.VS.VSSTRESU" OrderNumber="12" Mandatory="No"/>
+        <ItemRef ItemOID="IT.VS.VSBLFL" OrderNumber="13" Mandatory="No" MethodOID="MT.VSBLFL"/>
+        <ItemRef ItemOID="IT.VS.VISITNUM" OrderNumber="14" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.VS.VISIT" OrderNumber="15" Mandatory="No"/>
+        <ItemRef ItemOID="IT.VS.VISITDY" OrderNumber="16" Mandatory="No"/>
+        <ItemRef ItemOID="IT.VS.VSDTC" OrderNumber="17" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.VS.VSDY" OrderNumber="18" Mandatory="No" MethodOID="MT.VSDY"/>
+        <def:leaf ID="LF.VS" xlink:href="vs.xpt">
+          <def:title>vs.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (RELREC) -->
+      <ItemGroupDef OID="IG.RELREC"
+        Domain="RELREC"
+        Name="RELREC"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="RELREC"
+        Purpose="Tabulation"
+        def:Structure="One record per related record, group of records or dataset"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.RELREC">
+        <Description>
+          <TranslatedText xml:lang="en">Related Records</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="No" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.RELREC.IDVAR" OrderNumber="4" Mandatory="Yes" KeySequence="4"/>
+        <ItemRef ItemOID="IT.RELREC.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.RELREC.RELTYPE" OrderNumber="6" Mandatory="No"/>
+        <ItemRef ItemOID="IT.RELREC.RELID" OrderNumber="7" Mandatory="Yes" KeySequence="6" MethodOID="MT.RELID"/>
+        <def:leaf ID="LF.RELREC" xlink:href="relrec.xpt">
+          <def:title>relrec.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPAE) -->
+      <ItemGroupDef OID="IG.SUPPAE"
+        Domain="SUPPAE"
+        Name="SUPPAE"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPAE"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPAE">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for AE</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPAE.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPAE.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPAE.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPAE.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPAE.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPAE.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPAE.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPAE" xlink:href="suppae.xpt">
+          <def:title>suppae.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPCM) -->
+      <ItemGroupDef OID="IG.SUPPCM"
+        Domain="SUPPCM"
+        Name="SUPPCM"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPCM"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPCM">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for CM</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPCM.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPCM.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPCM.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPCM.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPCM.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPCM.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPCM.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPCM" xlink:href="suppcm.xpt">
+          <def:title>suppcm.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPDM) -->
+      <ItemGroupDef OID="IG.SUPPDM"
+        Domain="SUPPDM"
+        Name="SUPPDM"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPDM"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPDM">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for DM</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPDM.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPDM.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPDM.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPDM.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPDM.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPDM.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPDM" xlink:href="suppdm.xpt">
+          <def:title>suppdm.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPEG) -->
+      <ItemGroupDef OID="IG.SUPPEG"
+        Domain="SUPPEG"
+        Name="SUPPEG"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPEG"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPEG">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for EG</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPEG.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPEG.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPEG.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPEG.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPEG.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPEG.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPEG.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPEG" xlink:href="suppeg.xpt">
+          <def:title>suppeg.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPEX) -->
+      <ItemGroupDef OID="IG.SUPPEX"
+        Domain="SUPPEX"
+        Name="SUPPEX"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPEX"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPEX">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for EX</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPEX.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPEX.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPEX.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPEX.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPEX.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPEX.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPEX.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPEX" xlink:href="suppex.xpt">
+          <def:title>suppex.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPLB) -->
+      <ItemGroupDef OID="IG.SUPPLB"
+        Domain="SUPPLB"
+        Name="SUPPLB"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPLB"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPLB">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for LB</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPLB.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPLB.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPLB.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPLB.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPLB.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPLB.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPLB.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPLB" xlink:href="supplb.xpt">
+          <def:title>supplb.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPQSCG) -->
+      <ItemGroupDef OID="IG.SUPPQSCG"
+        Domain="SUPPQSCG"
+        Name="SUPPQSCG"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPQSCG"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPQSCG">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for QSCG</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPQS.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPQS.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPQS.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPQS.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPQSCG" xlink:href="suppqscg.xpt">
+          <def:title>suppqscg.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPQSCS) -->
+      <ItemGroupDef OID="IG.SUPPQSCS"
+        Domain="SUPPQSCS"
+        Name="SUPPQSCS"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPQSCS"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPQSCS">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for QSCS</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPQS.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPQS.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPQS.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPQS.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPQSCS" xlink:href="suppqscs.xpt">
+          <def:title>suppqscs.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPQSMM) -->
+      <ItemGroupDef OID="IG.SUPPQSMM"
+        Domain="SUPPQSMM"
+        Name="SUPPQSMM"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPQSMM"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPQSMM">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for QSMM</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPQS.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPQS.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPQS.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPQS.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPQS.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPQSMM" xlink:href="suppqsmm.xpt">
+          <def:title>suppqsmm.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPVS) -->
+      <ItemGroupDef OID="IG.SUPPVS"
+        Domain="SUPPVS"
+        Name="SUPPVS"
+        Repeating="Yes"
+        IsReferenceData="No"
+        SASDatasetName="SUPPVS"
+        Purpose="Tabulation"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        def:Class="RELATIONSHIP"
+        def:ArchiveLocationID="LF.SUPPVS">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for VS</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.STUDYID" OrderNumber="1" Mandatory="Yes" KeySequence="1"/>
+        <ItemRef ItemOID="IT.RDOMAIN" OrderNumber="2" Mandatory="Yes" KeySequence="2" MethodOID="MT.RDOMAIN"/>
+        <ItemRef ItemOID="IT.USUBJID" OrderNumber="3" Mandatory="Yes" KeySequence="3" MethodOID="MT.USUBJID"/>
+        <ItemRef ItemOID="IT.SUPPVS.IDVAR" OrderNumber="4" Mandatory="No" KeySequence="4"/>
+        <ItemRef ItemOID="IT.SUPPVS.IDVARVAL" OrderNumber="5" Mandatory="No" KeySequence="5"/>
+        <ItemRef ItemOID="IT.SUPPVS.QNAM" OrderNumber="6" Mandatory="Yes" KeySequence="6"/>
+        <ItemRef ItemOID="IT.SUPPVS.QLABEL" OrderNumber="7" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPVS.QVAL" OrderNumber="8" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPVS.QORIG" OrderNumber="9" Mandatory="Yes"/>
+        <ItemRef ItemOID="IT.SUPPVS.QEVAL" OrderNumber="10" Mandatory="No"/>
+        <def:leaf ID="LF.SUPPVS" xlink:href="suppvs.xpt">
+          <def:title>suppvs.xpt</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+
+
+      <!-- **************************************************************************** -->
+      <!-- ItemDef Definitions Section (Variables and Value List, remaining properties) -->
+      <!-- **************************************************************************** -->
+
+      <ItemDef OID="IT.AE.AEACN" Name="AEACN" DataType="text" Length="30" SASFieldName="AEACN">
+        <Description>
+          <TranslatedText xml:lang="en">Action Taken with Study Treatment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ACN"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEBODSYS" Name="AEBODSYS" DataType="text" Length="52" SASFieldName="AEBODSYS">
+        <Description>
+          <TranslatedText xml:lang="en">Body System or Organ Class</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AEDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEDECOD" Name="AEDECOD" DataType="text" Length="18" SASFieldName="AEDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">Dictionary-Derived Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AEDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEENDTC" Name="AEENDTC" DataType="date" SASFieldName="AEENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEENDY" Name="AEENDY" DataType="integer" Length="3" SASFieldName="AEENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEENRF" Name="AEENRF" DataType="text" Length="5" SASFieldName="AEENRF">
+        <Description>
+          <TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AEENRF"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEMODIFY" Name="AEMODIFY" DataType="text" Length="9" SASFieldName="AEMODIFY">
+        <Description>
+          <TranslatedText xml:lang="en">Modified Reported Term</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEREL" Name="AEREL" DataType="text" Length="16" SASFieldName="AEREL">
+        <Description>
+          <TranslatedText xml:lang="en">Causality</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AEREL"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESEQ" Name="AESEQ" DataType="integer" Length="1" SASFieldName="AESEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESER" Name="AESER" DataType="text" Length="1" SASFieldName="AESER">
+        <Description>
+          <TranslatedText xml:lang="en">Serious Event</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESEV" Name="AESEV" DataType="text" Length="8" SASFieldName="AESEV">
+        <Description>
+          <TranslatedText xml:lang="en">Severity/Intensity</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AESEV"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESPID" Name="AESPID" DataType="text" Length="4" SASFieldName="AESPID">
+        <Description>
+          <TranslatedText xml:lang="en">Sponsor-Defined Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESTDTC" Name="AESTDTC" DataType="date" SASFieldName="AESTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESTDY" Name="AESTDY" DataType="integer" Length="3" SASFieldName="AESTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AETERM" Name="AETERM" DataType="text" Length="25" SASFieldName="AETERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AE.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMCAT" Name="CMCAT" DataType="text" Length="36" SASFieldName="CMCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category for Medication</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CMCAT"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9 22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMCLAS" Name="CMCLAS" DataType="text" Length="45" SASFieldName="CMCLAS"
+        def:CommentOID="COM.CMCLAS">
+        <Description>
+          <TranslatedText xml:lang="en">Medication Class</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DRUGDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMCLASCD" Name="CMCLASCD" DataType="text" Length="3" SASFieldName="CMCLASCD"
+        def:CommentOID="COM.CMCLASCD">
+        <Description>
+          <TranslatedText xml:lang="en">Medication Class Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DRUGDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMDECOD" Name="CMDECOD" DataType="text" Length="30" SASFieldName="CMDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">Standardized Medication Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DRUGDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMDOSFRQ" Name="CMDOSFRQ" DataType="text" Length="5" SASFieldName="CMDOSFRQ">
+        <Description>
+          <TranslatedText xml:lang="en">Dosing Frequency per Interval</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FREQ"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMDOSTXT" Name="CMDOSTXT" DataType="text" Length="4" SASFieldName="CMDOSTXT">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Description</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9 22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMDOSU" Name="CMDOSU" DataType="text" Length="6" SASFieldName="CMDOSU">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CMUNIT"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9 22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMENDTC" Name="CMENDTC" DataType="date" SASFieldName="CMENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Medication</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9 22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMENDY" Name="CMENDY" DataType="integer" Length="4" SASFieldName="CMENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Medication</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMENRF" Name="CMENRF" DataType="text" Length="6" SASFieldName="CMENRF">
+        <Description>
+          <TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CMENRF"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMINDC" Name="CMINDC" DataType="text" Length="27" SASFieldName="CMINDC">
+        <Description>
+          <TranslatedText xml:lang="en">Indication</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9 22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMMODIFY" Name="CMMODIFY" DataType="text" Length="23" SASFieldName="CMMODIFY">
+        <Description>
+          <TranslatedText xml:lang="en">Modified Reported Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMROUTE" Name="CMROUTE" DataType="text" Length="12" SASFieldName="CMROUTE"
+        def:CommentOID="COM.CMROUTE">
+        <Description>
+          <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ROUTE"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMSEQ" Name="CMSEQ" DataType="integer" Length="2" SASFieldName="CMSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMSTDTC" Name="CMSTDTC" DataType="date" SASFieldName="CMSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Medication</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9 22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMSTDY" Name="CMSTDY" DataType="integer" Length="6" SASFieldName="CMSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Medication</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMTRT" Name="CMTRT" DataType="text" Length="23" SASFieldName="CMTRT">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Name of Drug, Med, or Therapy</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9 22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CM.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DADTC" Name="DADTC" DataType="date" SASFieldName="DADTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Accountability Assessment</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DADY" Name="DADY" DataType="integer" Length="3" SASFieldName="DADY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Accountability Assessment</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DAORRES" Name="DAORRES" DataType="text" Length="2" SASFieldName="DAORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Assessment Result in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.DA.DAORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DAORRES.DISPAMT" Name="DA.DISPAMT" DataType="integer" Length="2" SASFieldName="DISPAMT">
+        <Description>
+          <TranslatedText xml:lang="en">Dispensed Amount</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DAORRES.RETAMT" Name="DA.RETAMT" DataType="integer" Length="2" SASFieldName="RETAMT">
+        <Description>
+          <TranslatedText xml:lang="en">Returned Amount</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DAORRESU" Name="DAORRESU" DataType="text" Length="7" SASFieldName="DAORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DASEQ" Name="DASEQ" DataType="integer" Length="1" SASFieldName="DASEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DASTRESC" Name="DASTRESC" DataType="text" Length="2" SASFieldName="DASTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Assessment Result in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DASTRESN" Name="DASTRESN" DataType="integer" Length="2" SASFieldName="DASTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DASTRESU" Name="DASTRESU" DataType="text" Length="7" SASFieldName="DASTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Assessment Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DATEST" Name="DATEST" DataType="text" Length="25" SASFieldName="DATEST">
+        <Description>
+          <TranslatedText xml:lang="en">Name of Accountability Assessment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DATEST"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DATESTCD" Name="DATESTCD" DataType="text" Length="7" SASFieldName="DATESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Short Name of Accountability Assessment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DATESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DA.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.VISIT" Name="VISIT" DataType="text" Length="8" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.VISITDY" Name="VISITDY" DataType="integer" Length="3" SASFieldName="VISITDY">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.DA.VISITNUM" Name="VISITNUM" DataType="integer" Length="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.AGE" Name="AGE" DataType="integer" Length="2" SASFieldName="AGE">
+        <Description>
+          <TranslatedText xml:lang="en">Age</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.AGEU" Name="AGEU" DataType="text" Length="5" SASFieldName="AGEU"
+        def:CommentOID="COM.AGEU">
+        <Description>
+          <TranslatedText xml:lang="en">Age Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ARM" Name="ARM" DataType="text" Length="20" SASFieldName="ARM"
+        def:CommentOID="COM.ARM">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARM"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ARMCD" Name="ARMCD" DataType="text" Length="8" SASFieldName="ARMCD"
+        def:CommentOID="COM.ARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARMCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.BRTHDTC" Name="BRTHDTC" DataType="date" SASFieldName="BRTHDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Birth</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.COUNTRY" Name="COUNTRY" DataType="text" Length="3" SASFieldName="COUNTRY">
+        <Description>
+          <TranslatedText xml:lang="en">Country</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ISO3166"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DM.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ETHNIC" Name="ETHNIC" DataType="text" Length="22" SASFieldName="ETHNIC">
+        <Description>
+          <TranslatedText xml:lang="en">Ethnicity</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ETHNIC"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RACE" Name="RACE" DataType="text" Length="40" SASFieldName="RACE">
+        <Description>
+          <TranslatedText xml:lang="en">Race</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RFENDTC" Name="RFENDTC" DataType="date" SASFieldName="RFENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Reference End Date/Time</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RFSTDTC" Name="RFSTDTC" DataType="date" SASFieldName="RFSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Reference Start Date/Time</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.SEX" Name="SEX" DataType="text" Length="1" SASFieldName="SEX">
+        <Description>
+          <TranslatedText xml:lang="en">Sex</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SEX"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.SITEID" Name="SITEID" DataType="text" Length="3" SASFieldName="SITEID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Site Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="3" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.SUBJID" Name="SUBJID" DataType="text" Length="6" SASFieldName="SUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Identifier for the Study</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="3" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DS.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSCAT" Name="DSCAT" DataType="text" Length="18" SASFieldName="DSCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category for Disposition Event</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DSCAT"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSDECOD" Name="DSDECOD" DataType="text" Length="21" SASFieldName="DSDECOD"
+        def:CommentOID="COM.DSDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">Standardized Disposition Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NCOMPLT"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6 16 18" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSSEQ" Name="DSSEQ" DataType="integer" Length="1" SASFieldName="DSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSSTDTC" Name="DSSTDTC" DataType="date" SASFieldName="DSSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Disposition Event</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6 16 18" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSSTDY" Name="DSSTDY" DataType="integer" Length="3" SASFieldName="DSSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Disposition Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSTERM" Name="DSTERM" DataType="text" Length="34" SASFieldName="DSTERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Disposition Event</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TREASFF"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6 16 18" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EG.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGBLFL" Name="EGBLFL" DataType="text" Length="1" SASFieldName="EGBLFL">
+        <Description>
+          <TranslatedText xml:lang="en">Baseline Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGDRVFL" Name="EGDRVFL" DataType="text" Length="1" SASFieldName="EGDRVFL">
+        <Description>
+          <TranslatedText xml:lang="en">Derived Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGDTC" Name="EGDTC" DataType="date" SASFieldName="EGDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of ECG</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGDY" Name="EGDY" DataType="integer" Length="3" SASFieldName="EGDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of ECG</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGEVAL" Name="EGEVAL" DataType="text" Length="12" SASFieldName="EGEVAL"
+        def:CommentOID="COM.EGEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGORRES" Name="EGORRES" DataType="text" Length="15" SASFieldName="EGORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.EG.EGORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGORRES.INTP" Name="EG.INTP.ORRES" DataType="text" Length="8" SASFieldName="INTPOR">
+        <Description>
+          <TranslatedText xml:lang="en">Interpretation: Original Results</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NABCLIN"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGORRES.PRMEAN" Name="EG.PRMEAN.ORRES" DataType="integer" Length="3" SASFieldName="PRMEANOR">
+        <Description>
+          <TranslatedText xml:lang="en">Summary (Mean) PR Duration (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGORRES.QRSDUR" Name="EG.QRSDUR.ORRES" DataType="integer" Length="3" SASFieldName="QRSDUROR">
+        <Description>
+          <TranslatedText xml:lang="en">Summary (Mean) QRS Duration (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGORRES.QTMEAN" Name="EG.QTMEAN.ORRES" DataType="integer" Length="3" SASFieldName="QTMEANOR">
+        <Description>
+          <TranslatedText xml:lang="en">Summary (Mean) QT Duration (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGORRES.VRMEAN" Name="EG.VRMEAN.ORRES" DataType="integer" Length="2" SASFieldName="VRMEANOR">
+        <Description>
+          <TranslatedText xml:lang="en">Summary (Mean) Ventricular Rate (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGORRESU" Name="EGORRESU" DataType="text" Length="4" SASFieldName="EGORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EGRESU"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGPOS" Name="EGPOS" DataType="text" Length="6" SASFieldName="EGPOS"
+        def:CommentOID="COM.EGPOS">
+        <Description>
+          <TranslatedText xml:lang="en">ECG Position of Subject</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGSEQ" Name="EGSEQ" DataType="integer" Length="2" SASFieldName="EGSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGSPID" Name="EGSPID" DataType="text" Length="6" SASFieldName="EGSPID"
+        def:CommentOID="COM.EGSPID">
+        <Description>
+          <TranslatedText xml:lang="en">Sponsor-Defined Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGSTRESC" Name="EGSTRESC" DataType="text" Length="15" SASFieldName="EGSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+        <def:ValueListRef ValueListOID="VL.EG.EGSTRESC"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGSTRESC.QTCB" Name="EG.QTCB.STRES" DataType="float" Length="5" SignificantDigits="1" def:DisplayFormat="5.1" SASFieldName="QTCBSR">
+        <Description>
+          <TranslatedText xml:lang="en">QTcB - Bazett's Correction Formula</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGSTRESC.QTCF" Name="EG.QTCF.STRES" DataType="float" Length="5" SignificantDigits="1" def:DisplayFormat="5.1" SASFieldName="QTCFSR">
+        <Description>
+          <TranslatedText xml:lang="en">QTcF - Fridericia's Correction Formula</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGSTRESN" Name="EGSTRESN" DataType="float" Length="5" SignificantDigits="1" def:DisplayFormat="5.1" SASFieldName="EGSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGSTRESU" Name="EGSTRESU" DataType="text" Length="9" SASFieldName="EGSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EGRESU"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGTEST" Name="EGTEST" DataType="text" Length="40" SASFieldName="EGTEST">
+        <Description>
+          <TranslatedText xml:lang="en">ECG Test or Examination Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EGTEST"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EG.EGTESTCD" Name="EGTESTCD" DataType="text" Length="6" SASFieldName="EGTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">ECG Test or Examination Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EGTESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.VISIT" Name="VISIT" DataType="text" Length="7" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.VISITDY" Name="VISITDY" DataType="integer" Length="3" SASFieldName="VISITDY">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.EG.VISITNUM" Name="VISITNUM" DataType="integer" Length="2" SASFieldName="VISITNUM"
+        def:CommentOID="COM.EG.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EX.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXDOSE" Name="EXDOSE" DataType="integer" Length="2" SASFieldName="EXDOSE">
+        <Description>
+          <TranslatedText xml:lang="en">Dose per Administration</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXDOSFRM" Name="EXDOSFRM" DataType="text" Length="7" SASFieldName="EXDOSFRM">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Form</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FRM"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="20" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXDOSU" Name="EXDOSU" DataType="text" Length="2" SASFieldName="EXDOSU">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXENDTC" Name="EXENDTC" DataType="date" SASFieldName="EXENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="20" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXENDY" Name="EXENDY" DataType="integer" Length="2" SASFieldName="EXENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXSEQ" Name="EXSEQ" DataType="integer" Length="1" SASFieldName="EXSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXSTDTC" Name="EXSTDTC" DataType="date" SASFieldName="EXSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="20" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXSTDY" Name="EXSTDY" DataType="integer" Length="2" SASFieldName="EXSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXTRT" Name="EXTRT" DataType="text" Length="20" SASFieldName="EXTRT">
+        <Description>
+          <TranslatedText xml:lang="en">Name of Actual Treatment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EXTRT"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IE.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IECAT" Name="IECAT" DataType="text" Length="9" SASFieldName="IECAT">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Category</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="4" LastPage="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEDTC" Name="IEDTC" DataType="date" SASFieldName="IEDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="4" LastPage="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEORRES" Name="IEORRES" DataType="text" Length="1" SASFieldName="IEORRES">
+        <Description>
+          <TranslatedText xml:lang="en">I/E Criterion Original Result</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="4" LastPage="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.IE.IEORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEORRES.EXCL01" Name="EXCL01" DataType="text" Length="200" SASFieldName="EXCL01">
+        <Description>
+          <TranslatedText xml:lang="en">Is pregnant, nursing, or planning to become pregnant within 6 months of last study treatment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NYNA"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEORRES.EXCL02" Name="EXCL02" DataType="text" Length="200" SASFieldName="EXCL02">
+        <Description>
+          <TranslatedText xml:lang="en">Is unable or unwilling to undergo multiple venipunctures</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NYNA"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEORRES.EXCL03" Name="EXCL03" DataType="text" Length="200" SASFieldName="EXCL03">
+        <Description>
+          <TranslatedText xml:lang="en">Is known to have had a substance abuse (drug or alcohol) problem within the previous 3 years</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NYNA"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEORRES.INCL01" Name="INCL01" DataType="text" Length="200" SASFieldName="INCL01">
+        <Description>
+          <TranslatedText xml:lang="en">Is age 18 - 85</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NYNA"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="4" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEORRES.INCL02" Name="INCL02" DataType="text" Length="200" SASFieldName="INCL02">
+        <Description>
+          <TranslatedText xml:lang="en">Has Xyz disease of at least 10 weeks duration confirmed by biopsy</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NYNA"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="4" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEORRES.INCL03" Name="INCL03" DataType="text" Length="200" SASFieldName="INCL03">
+        <Description>
+          <TranslatedText xml:lang="en">Did not respond to a standard course of medication Abc</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NYNA"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="4" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IESEQ" Name="IESEQ" DataType="integer" Length="1" SASFieldName="IESEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IESTRESC" Name="IESTRESC" DataType="text" Length="1" SASFieldName="IESTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">I/E Criterion Result in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IETEST" Name="IETEST" DataType="text" Length="54" SASFieldName="IETEST">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IETEST"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="4" LastPage="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IETESTCD" Name="IETESTCD" DataType="text" Length="6" SASFieldName="IETESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IETESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.VISIT" Name="VISIT" DataType="text" Length="6" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.VISITNUM" Name="VISITNUM" DataType="integer" Length="1" SASFieldName="VISITNUM"
+        def:CommentOID="COM.IE.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LB.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBBLFL" Name="LBBLFL" DataType="text" Length="1" SASFieldName="LBBLFL">
+        <Description>
+          <TranslatedText xml:lang="en">Baseline Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBCAT" Name="LBCAT" DataType="text" Length="10" SASFieldName="LBCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category for Lab Test</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBDTC" Name="LBDTC" DataType="datetime" SASFieldName="LBDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Specimen Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBDY" Name="LBDY" DataType="integer" Length="3" SASFieldName="LBDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Specimen Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBFAST" Name="LBFAST" DataType="text" Length="1" SASFieldName="LBFAST">
+        <Description>
+          <TranslatedText xml:lang="en">Fasting Status</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBMETHOD" Name="LBMETHOD" DataType="text" Length="8" SASFieldName="LBMETHOD">
+        <Description>
+          <TranslatedText xml:lang="en">Method of Test or Examination</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.METHOD"/>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBNRIND" Name="LBNRIND" DataType="text" Length="20" SASFieldName="LBNRIND">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Indicator</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NRIND"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORNRHI" Name="LBORNRHI" DataType="text" Length="8" SASFieldName="LBORNRHI">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Upper Limit in Orig Unit</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORNRLO" Name="LBORNRLO" DataType="text" Length="8" SASFieldName="LBORNRLO">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Lower Limit in Orig Unit</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES" Name="LBORRES" DataType="text" Length="8" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+        <def:ValueListRef ValueListOID="VL.LB.LBORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.BILI.LBCAT.CHEMISTRY.LBSPEC.BLOOD" Name="BILI" DataType="float" Length="3" SignificantDigits="1" SASFieldName="BILI">
+        <Description>
+          <TranslatedText xml:lang="en">Bilirubin</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.BUN.LBCAT.CHEMISTRY.LBSPEC.BLOOD" Name="BUN" DataType="float" Length="4" SignificantDigits="2" SASFieldName="BUN">
+        <Description>
+          <TranslatedText xml:lang="en">Blood Urea Nitrogen</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.GLUC.LBCAT.CHEMISTRY.LBSPEC.BLOOD" Name="GLUC" DataType="float" Length="3" SignificantDigits="1" SASFieldName="GLUC">
+        <Description>
+          <TranslatedText xml:lang="en">Glucose</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.GLUC.LBCAT.URINALYSIS.LBSPEC.URINE.LBMETHOD.DIPSTICK" Name="GLUC" DataType="text" Length="8" SASFieldName="GLUC">
+        <Description>
+          <TranslatedText xml:lang="en">Glucose</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.GLUC.LBCAT.URINALYSIS.LBSPEC.URINE.LBMETHOD.QUANT" Name="GLUC" DataType="text" Length="8" SASFieldName="GLUC">
+        <Description>
+          <TranslatedText xml:lang="en">Glucose</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.HCT.LBCAT.HEMATOLOGY.LBSPEC.BLOOD" Name="HCT" DataType="float" Length="4" SignificantDigits="2" SASFieldName="HCT">
+        <Description>
+          <TranslatedText xml:lang="en">Hematocrit</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.HGB.LBCAT.HEMATOLOGY.LBSPEC.BLOOD" Name="HGB" DataType="float" Length="4" SignificantDigits="2" SASFieldName="HGB">
+        <Description>
+          <TranslatedText xml:lang="en">Hemoglobin</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.LYM.LBCAT.HEMATOLOGY.LBSPEC.BLOOD" Name="LYM" DataType="float" Length="4" SignificantDigits="2" SASFieldName="LYM">
+        <Description>
+          <TranslatedText xml:lang="en">Lymphocytes</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.OCCBLD.LBCAT.URINALYSIS.LBSPEC.URINE" Name="OCCBLD" DataType="text" Length="8" SASFieldName="OCCBLD">
+        <Description>
+          <TranslatedText xml:lang="en">Occult Blood</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.PH.LBCAT.URINALYSIS.LBSPEC.URINE" Name="PH" DataType="float" Length="3" SignificantDigits="2" SASFieldName="PH">
+        <Description>
+          <TranslatedText xml:lang="en">pH</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.VITB12.LBCAT.CHEMISTRY.LBSPEC.SERUM" Name="VITB12" DataType="integer" Length="3" SASFieldName="VITB12">
+        <Description>
+          <TranslatedText xml:lang="en">Vitamin B12</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.VITB9.LBCAT.CHEMISTRY.LBSPEC.BLOOD" Name="VITB9" DataType="float" Length="5" SignificantDigits="1" SASFieldName="VITB9">
+        <Description>
+          <TranslatedText xml:lang="en">Vitamin B9</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU" Name="LBORRESU" DataType="text" Length="7" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LBRESU"/>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBREFID" Name="LBREFID" DataType="text" Length="7" SASFieldName="LBREFID"
+        def:CommentOID="COM.LBREFID">
+        <Description>
+          <TranslatedText xml:lang="en">Specimen ID</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSEQ" Name="LBSEQ" DataType="integer" Length="2" SASFieldName="LBSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSPEC" Name="LBSPEC" DataType="text" Length="5" SASFieldName="LBSPEC">
+        <Description>
+          <TranslatedText xml:lang="en">Specimen Type</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SPECTYPE"/>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTNRC" Name="LBSTNRC" DataType="text" Length="19" SASFieldName="LBSTNRC">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range for Char Rslt-Std Units</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTNRHI" Name="LBSTNRHI" DataType="float" Length="4" SignificantDigits="2" def:DisplayFormat="4.2" SASFieldName="LBSTNRHI">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Upper Limit-Std Units</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTNRLO" Name="LBSTNRLO" DataType="float" Length="4" SignificantDigits="2" def:DisplayFormat="4.2" SASFieldName="LBSTNRLO">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Lower Limit-Std Units</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC" Name="LBSTRESC" DataType="text" Length="8" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESN" Name="LBSTRESN" DataType="float" Length="5" SignificantDigits="2" def:DisplayFormat="5.2" SASFieldName="LBSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU" Name="LBSTRESU" DataType="text" Length="7" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBTEST" Name="LBTEST" DataType="text" Length="22" SASFieldName="LBTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Test or Examination Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LBTEST"/>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBTESTCD" Name="LBTESTCD" DataType="text" Length="7" SASFieldName="LBTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Test or Examination Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LBTESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.VISIT" Name="VISIT" DataType="text" Length="7" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.VISITDY" Name="VISITDY" DataType="integer" Length="3" SASFieldName="VISITDY">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.VISITNUM" Name="VISITNUM" DataType="integer" Length="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="eDT"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MH.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHBODSYS" Name="MHBODSYS" DataType="text" Length="23" SASFieldName="MHBODSYS"
+        def:CommentOID="COM.MHBODSYS">
+        <Description>
+          <TranslatedText xml:lang="en">Body System or Organ Class</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MHBODSYS"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHCAT" Name="MHCAT" DataType="text" Length="28" SASFieldName="MHCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category for Medical History</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MHCAT"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="7" LastPage="8" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHDTC" Name="MHDTC" DataType="date" SASFieldName="MHDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of History Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="7" LastPage="8" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHENRF" Name="MHENRF" DataType="text" Length="30" SASFieldName="MHENRF"
+        def:CommentOID="COM.MHENRF">
+        <Description>
+          <TranslatedText xml:lang="en">End Relative to Reference Period</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MHENRF"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="8" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHOCCUR" Name="MHOCCUR" DataType="text" Length="2" SASFieldName="MHOCCUR">
+        <Description>
+          <TranslatedText xml:lang="en">Medical History Occurrence</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHPRESP" Name="MHPRESP" DataType="text" Length="2" SASFieldName="MHPRESP">
+        <Description>
+          <TranslatedText xml:lang="en">Medical History Event Pre-Specified</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHSEQ" Name="MHSEQ" DataType="integer" Length="1" SASFieldName="MHSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHSTDTC" Name="MHSTDTC" DataType="date" SASFieldName="MHSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Medical History Event</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="7" LastPage="8" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHTERM" Name="MHTERM" DataType="text" Length="169" SASFieldName="MHTERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Medical History</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="7" LastPage="8" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PE.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEDTC" Name="PEDTC" DataType="date" SASFieldName="PEDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Examination</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEDY" Name="PEDY" DataType="integer" Length="3" SASFieldName="PEDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Examination</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES" Name="PEORRES" DataType="text" Length="36" SASFieldName="PEORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Verbatim Examination Finding</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.PE.PEORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE01" Name="PE01" DataType="text" Length="16" SASFieldName="PE01">
+        <Description>
+          <TranslatedText xml:lang="en">Appearance/Skin</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE02" Name="PE02" DataType="text" Length="6" SASFieldName="PE02">
+        <Description>
+          <TranslatedText xml:lang="en">Head/Neck (Including Thyroid)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE03" Name="PE03" DataType="text" Length="13" SASFieldName="PE03">
+        <Description>
+          <TranslatedText xml:lang="en">Eyes-Ears-Nose-Throat</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE04" Name="PE04" DataType="text" Length="20" SASFieldName="PE04">
+        <Description>
+          <TranslatedText xml:lang="en">Cardiovascular</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE05" Name="PE05" DataType="text" Length="6" SASFieldName="PE05">
+        <Description>
+          <TranslatedText xml:lang="en">Pulmonary</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE06" Name="PE06" DataType="text" Length="6" SASFieldName="PE06">
+        <Description>
+          <TranslatedText xml:lang="en">Abdomen</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE07" Name="PE07" DataType="text" Length="26" SASFieldName="PE07">
+        <Description>
+          <TranslatedText xml:lang="en">Neurological</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE08" Name="PE08" DataType="text" Length="6" SASFieldName="PE08">
+        <Description>
+          <TranslatedText xml:lang="en">Musculoskeletal</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PEORRES.PE09" Name="PE09" DataType="text" Length="19" SASFieldName="PE09">
+        <Description>
+          <TranslatedText xml:lang="en">Other</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PESEQ" Name="PESEQ" DataType="integer" Length="2" SASFieldName="PESEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PESTRESC" Name="PESTRESC" DataType="text" Length="26" SASFieldName="PESTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PETEST" Name="PETEST" DataType="text" Length="29" SASFieldName="PETEST">
+        <Description>
+          <TranslatedText xml:lang="en">Body System Examined</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PETEST"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="10" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.PE.PETESTCD" Name="PETESTCD" DataType="text" Length="4" SASFieldName="PETESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Body System Examined Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PETESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.PE.VISIT" Name="VISIT" DataType="text" Length="7" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.PE.VISITDY" Name="VISITDY" DataType="integer" Length="3" SASFieldName="VISITDY">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.PE.VISITNUM" Name="VISITNUM" DataType="integer" Length="2" SASFieldName="VISITNUM"
+        def:CommentOID="COM.PE.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.QS.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSBLFL" Name="QSBLFL" DataType="text" Length="1" SASFieldName="QSBLFL">
+        <Description>
+          <TranslatedText xml:lang="en">Baseline Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSCAT" Name="QSCAT" DataType="text" Length="50" SASFieldName="QSCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category of Question</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSDTC" Name="QSDTC" DataType="date" SASFieldName="QSDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Finding</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSDY" Name="QSDY" DataType="integer" Length="3" SASFieldName="QSDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Finding</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSEVLINT" Name="QSEVLINT" DataType="text" Length="20" SASFieldName="QSEVLINT">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluation Interval</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES" Name="QSORRES" DataType="text" Length="20" SASFieldName="QSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.QS.QSORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CGIGLOB" Name="CGIGLOB" DataType="integer" Length="1" SASFieldName="CGIGLOB">
+        <Description>
+          <TranslatedText xml:lang="en">Global Improvement</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CGIIMP_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD01" Name="CSDD01" DataType="integer" Length="1" SASFieldName="CSDD01">
+        <Description>
+          <TranslatedText xml:lang="en">Anxiety</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD02" Name="CSDD02" DataType="integer" Length="1" SASFieldName="CSDD02">
+        <Description>
+          <TranslatedText xml:lang="en">Sadness</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD03" Name="CSDD03" DataType="integer" Length="1" SASFieldName="CSDD03">
+        <Description>
+          <TranslatedText xml:lang="en">Lack of Reactivity to Pleasant Events</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD04" Name="CSDD04" DataType="integer" Length="1" SASFieldName="CSDD04">
+        <Description>
+          <TranslatedText xml:lang="en">Irritability</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD05" Name="CSDD05" DataType="integer" Length="1" SASFieldName="CSDD05">
+        <Description>
+          <TranslatedText xml:lang="en">Agitation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD06" Name="CSDD06" DataType="integer" Length="1" SASFieldName="CSDD06">
+        <Description>
+          <TranslatedText xml:lang="en">Retardation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD07" Name="CSDD07" DataType="integer" Length="1" SASFieldName="CSDD07">
+        <Description>
+          <TranslatedText xml:lang="en">Multiple Physical Complaints</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD08" Name="CSDD08" DataType="integer" Length="1" SASFieldName="CSDD08">
+        <Description>
+          <TranslatedText xml:lang="en">Loss of Interest</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD09" Name="CSDD09" DataType="integer" Length="1" SASFieldName="CSDD09">
+        <Description>
+          <TranslatedText xml:lang="en">Appetite Loss</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD10" Name="CSDD10" DataType="integer" Length="1" SASFieldName="CSDD10">
+        <Description>
+          <TranslatedText xml:lang="en">Weight Loss</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD11" Name="CSDD11" DataType="integer" Length="1" SASFieldName="CSDD11">
+        <Description>
+          <TranslatedText xml:lang="en">Lack of Energy</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD12" Name="CSDD12" DataType="integer" Length="1" SASFieldName="CSDD12">
+        <Description>
+          <TranslatedText xml:lang="en">Diurnal Variation of Mood</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD13" Name="CSDD13" DataType="integer" Length="1" SASFieldName="CSDD13">
+        <Description>
+          <TranslatedText xml:lang="en">Difficulty Falling Asleep</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD14" Name="CSDD14" DataType="integer" Length="1" SASFieldName="CSDD14">
+        <Description>
+          <TranslatedText xml:lang="en">Multiple Awakenings During Sleep</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD15" Name="CSDD15" DataType="integer" Length="1" SASFieldName="CSDD15">
+        <Description>
+          <TranslatedText xml:lang="en">Early Morning Awakening</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD16" Name="CSDD16" DataType="integer" Length="1" SASFieldName="CSDD16">
+        <Description>
+          <TranslatedText xml:lang="en">Suicide</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD17" Name="CSDD17" DataType="integer" Length="1" SASFieldName="CSDD17">
+        <Description>
+          <TranslatedText xml:lang="en">Poor Self-Esteem</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD18" Name="CSDD18" DataType="integer" Length="1" SASFieldName="CSDD18">
+        <Description>
+          <TranslatedText xml:lang="en">Pessimism</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDD19" Name="CSDD19" DataType="integer" Length="1" SASFieldName="CSDD19">
+        <Description>
+          <TranslatedText xml:lang="en">Mood-Congruent Delusions</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.CUE_EXPF_X"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.CSDDTOT" Name="CSDDTOT" DataType="integer" Length="2" SASFieldName="CSDDTOT">
+        <Description>
+          <TranslatedText xml:lang="en">Total Score</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.MMSEA1" Name="MMSEA1" DataType="integer" Length="1" SASFieldName="MMSEA1">
+        <Description>
+          <TranslatedText xml:lang="en">Orientation time score</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.MMSEA2" Name="MMSEA2" DataType="integer" Length="1" SASFieldName="MMSEA2">
+        <Description>
+          <TranslatedText xml:lang="en">Orientation place score</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.MMSEB" Name="MMSEB" DataType="integer" Length="1" SASFieldName="MMSEB">
+        <Description>
+          <TranslatedText xml:lang="en">Registration</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.MMSEC" Name="MMSEC" DataType="integer" Length="1" SASFieldName="MMSEC">
+        <Description>
+          <TranslatedText xml:lang="en">Attention and Calculation</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.MMSED" Name="MMSED" DataType="integer" Length="1" SASFieldName="MMSED">
+        <Description>
+          <TranslatedText xml:lang="en">Recall</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.MMSEET" Name="MMSEET" DataType="integer" Length="1" SASFieldName="MMSEET">
+        <Description>
+          <TranslatedText xml:lang="en">Language</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSORRES.MMSETOT" Name="MMSETOT" DataType="integer" Length="2" SASFieldName="MMSETOT">
+        <Description>
+          <TranslatedText xml:lang="en">Total Score</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSSCAT" Name="QSSCAT" DataType="text" Length="40" SASFieldName="QSSCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Subcategory for Question</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="14" LastPage="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSSEQ" Name="QSSEQ" DataType="integer" Length="3" SASFieldName="QSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSSTRESC" Name="QSSTRESC" DataType="text" Length="2" SASFieldName="QSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSSTRESN" Name="QSSTRESN" DataType="integer" Length="2" SASFieldName="QSSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSTEST" Name="QSTEST" DataType="text" Length="37" SASFieldName="QSTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Question Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.QSTEST"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QS.QSTESTCD" Name="QSTESTCD" DataType="text" Length="7" SASFieldName="QSTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Question Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.QSTESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.VISIT" Name="VISIT" DataType="text" Length="8" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.VISITDY" Name="VISITDY" DataType="integer" Length="3" SASFieldName="VISITDY">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.QS.VISITNUM" Name="VISITNUM" DataType="integer" Length="2" SASFieldName="VISITNUM"
+        def:CommentOID="COM.QS.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.RDOMAIN" Name="RDOMAIN" DataType="text" Length="2" SASFieldName="RDOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Related Domain Abbreviation</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.IDVAR" Name="IDVAR" DataType="text" Length="8" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.IDVARVAL" Name="IDVARVAL" DataType="text" Length="2" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.RELID" Name="RELID" DataType="text" Length="10" SASFieldName="RELID">
+        <Description>
+          <TranslatedText xml:lang="en">Relationship Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.RELTYPE" Name="RELTYPE" DataType="text" Length="4" SASFieldName="RELTYPE"
+        def:CommentOID="COM.RELTYPE">
+        <Description>
+          <TranslatedText xml:lang="en">Relationship Type</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SC.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SC.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCDTC" Name="SCDTC" DataType="date" SASFieldName="SCDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCDY" Name="SCDY" DataType="integer" Length="3" SASFieldName="SCDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Examination</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCORRES" Name="SCORRES" DataType="text" Length="24" SASFieldName="SCORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="3 6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.SC.SCORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCORRES.EDLEVEL" Name="SC.EDLEVEL" DataType="text" Length="24" SASFieldName="EDLEVEL">
+        <Description>
+          <TranslatedText xml:lang="en">Education Level</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCORRES.MARISTAT" Name="SC.MARISTAT" DataType="text" Length="17" SASFieldName="MARISTAT">
+        <Description>
+          <TranslatedText xml:lang="en">Marital Status</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MARISTAT"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCORRES.SUBJINIT" Name="SC.SUBJINIT" DataType="text" Length="3" SASFieldName="SUBJINIT">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Initials</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="3" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCSEQ" Name="SCSEQ" DataType="integer" Length="1" SASFieldName="SCSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCSTRESC" Name="SCSTRESC" DataType="text" Length="24" SASFieldName="SCSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCTEST" Name="SCTEST" DataType="text" Length="16" SASFieldName="SCTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Characteristic</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SCTEST"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SC.SCTESTCD" Name="SCTESTCD" DataType="text" Length="8" SASFieldName="SCTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Characteristic Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SCTESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SE.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.ELEMENT" Name="ELEMENT" DataType="text" Length="40" SASFieldName="ELEMENT">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.ETCD" Name="ETCD" DataType="text" Length="7" SASFieldName="ETCD">
+        <Description>
+          <TranslatedText xml:lang="en">Element Code</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.SEENDTC" Name="SEENDTC" DataType="date" SASFieldName="SEENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.SESEQ" Name="SESEQ" DataType="integer" Length="1" SASFieldName="SESEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.SESTDTC" Name="SESTDTC" DataType="date" SASFieldName="SESTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.TAETORD" Name="TAETORD" DataType="integer" Length="1" SASFieldName="TAETORD">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Order of Elements within Arm</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.STUDYID" Name="STUDYID" DataType="text" Length="7" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.IDVAR" Name="IDVAR" DataType="text" Length="5" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.IDVARVAL" Name="IDVARVAL" DataType="text" Length="1" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QEVAL" Name="QEVAL" DataType="text" Length="30" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QLABEL" Name="QLABEL" DataType="text" Length="30" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QNAM" Name="QNAM" DataType="text" Length="7" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QORIG" Name="QORIG" DataType="text" Length="7" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QVAL" Name="QVAL" DataType="text" Length="60" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPAE.QVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QVAL.AETRTEM" Name="AETRTEM" DataType="text" Length="1" SASFieldName="AETRTEM">
+        <Description>
+          <TranslatedText xml:lang="en">Treatment Emergent Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QVAL.HLGT" Name="HLGT" DataType="text" Length="52" SASFieldName="HLGT">
+        <Description>
+          <TranslatedText xml:lang="en">High Level Group Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AEDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QVAL.HLT" Name="HLT" DataType="text" Length="60" SASFieldName="HLT">
+        <Description>
+          <TranslatedText xml:lang="en">High Level Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AEDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPAE.QVAL.LLT" Name="LLT" DataType="text" Length="18" SASFieldName="LLT">
+        <Description>
+          <TranslatedText xml:lang="en">Lowest Level Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AEDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.IDVAR" Name="IDVAR" DataType="text" Length="5" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.IDVARVAL" Name="IDVARVAL" DataType="text" Length="2" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QEVAL" Name="QEVAL" DataType="text" Length="30" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QLABEL" Name="QLABEL" DataType="text" Length="26" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QNAM" Name="QNAM" DataType="text" Length="8" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QORIG" Name="QORIG" DataType="text" Length="10" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QVAL" Name="QVAL" DataType="text" Length="43" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPCM.QVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QVAL.ATC4CODE" Name="ATC4CODE" DataType="text" Length="5" SASFieldName="ATC4CODE">
+        <Description>
+          <TranslatedText xml:lang="en">WHODRUG ATC Level 4 Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DRUGDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QVAL.ATC4TERM" Name="ATC4TERM" DataType="text" Length="43" SASFieldName="ATC4TERM">
+        <Description>
+          <TranslatedText xml:lang="en">ATC4 Drug Class Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DRUGDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QVAL.CPREFCD" Name="CPREFCD" DataType="text" Length="11" SASFieldName="CPREFCD">
+        <Description>
+          <TranslatedText xml:lang="en">WHODRUG Drug Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DRUGDICT_F"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QVAL.PDDREAS" Name="PDDREAS" DataType="text" Length="21" SASFieldName="PDDREAS">
+        <Description>
+          <TranslatedText xml:lang="en">Reason for Discontinuation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DDISCNTF"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPCM.QVAL.PDRESP" Name="PDRESP" DataType="text" Length="4" SASFieldName="PDRESP">
+        <Description>
+          <TranslatedText xml:lang="en">Response</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PSRESPF"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="9" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.IDVAR" Name="IDVAR" DataType="text" Length="1" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.IDVARVAL" Name="IDVARVAL" DataType="text" Length="1" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QEVAL" Name="QEVAL" DataType="text" Length="30" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QLABEL" Name="QLABEL" DataType="text" Length="26" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QNAM" Name="QNAM" DataType="text" Length="8" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QORIG" Name="QORIG" DataType="text" Length="11" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL" Name="QVAL" DataType="text" Length="30" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPDM.QVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.RACE1" Name="RACE1" DataType="text" Length="5" SASFieldName="RACE1">
+        <Description>
+          <TranslatedText xml:lang="en">Race 1</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.RACE2" Name="RACE2" DataType="text" Length="25" SASFieldName="RACE2">
+        <Description>
+          <TranslatedText xml:lang="en">Race 2</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.RACE3" Name="RACE3" DataType="text" Length="5" SASFieldName="RACE3">
+        <Description>
+          <TranslatedText xml:lang="en">Race 3</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.RACEOTH" Name="RACEOTH" DataType="text" Length="14" SASFieldName="RACEOTH">
+        <Description>
+          <TranslatedText xml:lang="en">Race, Other</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.RAND" Name="RAND" DataType="text" Length="1" SASFieldName="RAND">
+        <Description>
+          <TranslatedText xml:lang="en">Randomized Population Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="16" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.RANDNO" Name="RANDNO" DataType="text" Length="4" SASFieldName="RANDNO">
+        <Description>
+          <TranslatedText xml:lang="en">Randomization Number</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="16" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.SAFETY" Name="SAFETY" DataType="text" Length="1" SASFieldName="SAFETY">
+        <Description>
+          <TranslatedText xml:lang="en">Safety Population Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEG.IDVAR" Name="IDVAR" DataType="text" Length="5" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEG.IDVARVAL" Name="IDVARVAL" DataType="text" Length="2" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEG.QEVAL" Name="QEVAL" DataType="text" Length="30" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEG.QLABEL" Name="QLABEL" DataType="text" Length="36" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEG.QNAM" Name="QNAM" DataType="text" Length="7" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEG.QORIG" Name="QORIG" DataType="text" Length="7" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEG.QVAL" Name="QVAL" DataType="text" Length="2" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPEG.QVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEG.QVAL.EGCLSIG" Name="EGCLSIG" DataType="text" Length="1" SASFieldName="EGCLSIG">
+        <Description>
+          <TranslatedText xml:lang="en">Clinically Significant</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEX.IDVAR" Name="IDVAR" DataType="text" Length="5" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEX.IDVARVAL" Name="IDVARVAL" DataType="text" Length="1" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEX.QEVAL" Name="QEVAL" DataType="text" Length="30" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEX.QLABEL" Name="QLABEL" DataType="text" Length="25" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEX.QNAM" Name="QNAM" DataType="text" Length="4" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEX.QORIG" Name="QORIG" DataType="text" Length="11" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEX.QVAL" Name="QVAL" DataType="text" Length="2" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPEX.QVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEX.QVAL.SMNO" Name="SMNO" DataType="integer" Length="2" SASFieldName="SMNO">
+        <Description>
+          <TranslatedText xml:lang="en">Number of Tablets Per Day</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="20" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPLB.IDVAR" Name="IDVAR" DataType="text" Length="5" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPLB.IDVARVAL" Name="IDVARVAL" DataType="text" Length="2" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPLB.QEVAL" Name="QEVAL" DataType="text" Length="30" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPLB.QLABEL" Name="QLABEL" DataType="text" Length="36" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPLB.QNAM" Name="QNAM" DataType="text" Length="7" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPLB.QORIG" Name="QORIG" DataType="text" Length="7" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPLB.QVAL" Name="QVAL" DataType="text" Length="2" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPLB.QVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPLB.QVAL.LBCLSIG" Name="LBCLSIG" DataType="text" Length="1" SASFieldName="LBCLSIG">
+        <Description>
+          <TranslatedText xml:lang="en">Clinically Significant</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPQS.IDVAR" Name="IDVAR" DataType="text" Length="5" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPQS.IDVARVAL" Name="IDVARVAL" DataType="text" Length="50" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPQS.QEVAL" Name="QEVAL" DataType="text" Length="30" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPQS.QLABEL" Name="QLABEL" DataType="text" Length="36" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPQS.QNAM" Name="QNAM" DataType="text" Length="7" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPQS.QORIG" Name="QORIG" DataType="text" Length="7" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPQS.QVAL" Name="QVAL" DataType="text" Length="3" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPQS.QVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPQS.QVAL.RTRINIT" Name="RTRINIT" DataType="text" Length="3" SASFieldName="RTRINIT"
+        def:CommentOID="COM.SUPPQS.QVAL.RTRINIT">
+        <Description>
+          <TranslatedText xml:lang="en">Rater Initials</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="13 14 17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPVS.IDVAR" Name="IDVAR" DataType="text" Length="5" SASFieldName="IDVAR"
+        def:CommentOID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPVS.IDVARVAL" Name="IDVARVAL" DataType="text" Length="2" SASFieldName="IDVARVAL"
+        def:CommentOID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPVS.QEVAL" Name="QEVAL" DataType="text" Length="30" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPVS.QLABEL" Name="QLABEL" DataType="text" Length="36" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPVS.QNAM" Name="QNAM" DataType="text" Length="7" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPVS.QORIG" Name="QORIG" DataType="text" Length="7" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPVS.QVAL" Name="QVAL" DataType="text" Length="2" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPVS.QVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPVS.QVAL.VSCLSIG" Name="VSCLSIG" DataType="text" Length="1" SASFieldName="VSCLSIG">
+        <Description>
+          <TranslatedText xml:lang="en">Clinically Significant</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SV.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.SVENDTC" Name="SVENDTC" DataType="date" SASFieldName="SVENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.SVSTDTC" Name="SVSTDTC" DataType="date" SASFieldName="SVSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.SVSTDY" Name="SVSTDY" DataType="integer" Length="3" SASFieldName="SVSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.VISIT" Name="VISIT" DataType="text" Length="8" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.VISITDY" Name="VISITDY" DataType="integer" Length="3" SASFieldName="VISITDY">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.VISITNUM" Name="VISITNUM" DataType="integer" Length="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.ARM" Name="ARM" DataType="text" Length="20" SASFieldName="ARM">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARM"/>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.ARMCD" Name="ARMCD" DataType="text" Length="8" SASFieldName="ARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARMCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TA.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.ELEMENT" Name="ELEMENT" DataType="text" Length="40" SASFieldName="ELEMENT">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.EPOCH" Name="EPOCH" DataType="text" Length="30" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.ETCD" Name="ETCD" DataType="text" Length="8" SASFieldName="ETCD">
+        <Description>
+          <TranslatedText xml:lang="en">Element Code</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.TABRANCH" Name="TABRANCH" DataType="text" Length="35" SASFieldName="TABRANCH">
+        <Description>
+          <TranslatedText xml:lang="en">Branch</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.TAETORD" Name="TAETORD" DataType="integer" Length="1" SASFieldName="TAETORD">
+        <Description>
+          <TranslatedText xml:lang="en">Order of Element within Arm</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.TATRANS" Name="TATRANS" DataType="text" Length="1" SASFieldName="TATRANS">
+        <Description>
+          <TranslatedText xml:lang="en">Transition Rule</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TE.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.ELEMENT" Name="ELEMENT" DataType="text" Length="40" SASFieldName="ELEMENT">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.ETCD" Name="ETCD" DataType="text" Length="8" SASFieldName="ETCD">
+        <Description>
+          <TranslatedText xml:lang="en">Element Code</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.TEDUR" Name="TEDUR" DataType="text" Length="4" SASFieldName="TEDUR">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Duration of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.TESTRL" Name="TESTRL" DataType="text" Length="24" SASFieldName="TESTRL">
+        <Description>
+          <TranslatedText xml:lang="en">Rule for Start of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TI.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TI.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TI.IECAT" Name="IECAT" DataType="text" Length="9" SASFieldName="IECAT">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Category</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="4" LastPage="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.TI.IETEST" Name="IETEST" DataType="text" Length="92" SASFieldName="IETEST">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IETEST"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef FirstPage="4" LastPage="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.TI.IETESTCD" Name="IETESTCD" DataType="text" Length="6" SASFieldName="IETESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Incl/Excl Criterion Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IETESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TS.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSPARM" Name="TSPARM" DataType="text" Length="36" SASFieldName="TSPARM">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Summary Parameter</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TSPARM"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSPARMCD" Name="TSPARMCD" DataType="text" Length="8" SASFieldName="TSPARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Summary Parameter Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TSPARMCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSSEQ" Name="TSSEQ" DataType="integer" Length="1" SASFieldName="TSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL" Name="TSVAL" DataType="text" Length="57" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Parameter Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+        <def:ValueListRef ValueListOID="VL.TS.TSVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.ADDON" Name="ADDON" DataType="text" Length="57" SASFieldName="ADDON">
+        <Description>
+          <TranslatedText xml:lang="en">Added on to Existing Treatments</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.AGEMAX" Name="AGEMAX" DataType="integer" Length="2" SASFieldName="AGEMAX">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Maximum Age of Subjects</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.AGEMIN" Name="AGEMIN" DataType="integer" Length="2" SASFieldName="AGEMIN">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Minimum Age of Subjects</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.AGESPAN" Name="AGESPAN" DataType="text" Length="57" SASFieldName="AGESPAN">
+        <Description>
+          <TranslatedText xml:lang="en">Age Span</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.AGEU" Name="AGEU" DataType="text" Length="57" SASFieldName="AGEU">
+        <Description>
+          <TranslatedText xml:lang="en">Age Unit</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.DOSE" Name="DOSE" DataType="integer" Length="2" SASFieldName="DOSE">
+        <Description>
+          <TranslatedText xml:lang="en">Dose per Administration</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.DOSFRQ" Name="DOSFRQ" DataType="text" Length="57" SASFieldName="DOSFRQ">
+        <Description>
+          <TranslatedText xml:lang="en">Dosing Frequency</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.DOSU" Name="DOSU" DataType="text" Length="57" SASFieldName="DOSU">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.LENGTH" Name="LENGTH" DataType="text" Length="57" SASFieldName="LENGTH">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Length</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.OBJPRIM" Name="OBJPRIM" DataType="text" Length="57" SASFieldName="OBJPRIM">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Primary Objective</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.OBJSEC" Name="OBJSEC" DataType="text" Length="57" SASFieldName="OBJSEC">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Secondary Objective</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.PLANSUB" Name="PLANSUB" DataType="integer" Length="2" SASFieldName="PLANSUB">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Number of Subjects</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.RANDOM" Name="RANDOM" DataType="text" Length="57" SASFieldName="RANDOM">
+        <Description>
+          <TranslatedText xml:lang="en">Trial is Randomized</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.ROUTE" Name="ROUTE" DataType="text" Length="57" SASFieldName="ROUTE">
+        <Description>
+          <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.SEXPOP" Name="SEXPOP" DataType="text" Length="57" SASFieldName="SEXPOP">
+        <Description>
+          <TranslatedText xml:lang="en">Sex of Participants</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.SPONSOR" Name="SPONSOR" DataType="text" Length="57" SASFieldName="SPONSOR">
+        <Description>
+          <TranslatedText xml:lang="en">Clinical Study Sponsor</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.TBLIND" Name="TBLIND" DataType="text" Length="57" SASFieldName="TBLIND">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Blinding Schema</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.TCNTRL" Name="TCNTRL" DataType="text" Length="57" SASFieldName="TCNTRL">
+        <Description>
+          <TranslatedText xml:lang="en">Control Type</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.TINDTP" Name="TINDTP" DataType="text" Length="57" SASFieldName="TINDTP">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Indication Type</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.TITLE" Name="TITLE" DataType="text" Length="57" SASFieldName="TITLE">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Title</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.TPHASE" Name="TPHASE" DataType="text" Length="57" SASFieldName="TPHASE">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Phase Classification</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.TRT" Name="TRT" DataType="text" Length="57" SASFieldName="TRT">
+        <Description>
+          <TranslatedText xml:lang="en">Investigational Therapy or Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.TTYPE" Name="TTYPE" DataType="text" Length="57" SASFieldName="TTYPE">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Type</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.ARMCD" Name="ARMCD" DataType="text" Length="1" SASFieldName="ARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TV.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.TVSTRL" Name="TVSTRL" DataType="text" Length="30" SASFieldName="TVSTRL">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Start Rule</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.VISIT" Name="VISIT" DataType="text" Length="12" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.VISITDY" Name="VISITDY" DataType="integer" Length="3" SASFieldName="VISITDY">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.VISITNUM" Name="VISITNUM" DataType="integer" Length="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.USUBJID" Name="USUBJID" DataType="text" Length="14" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS.DOMAIN"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VISIT" Name="VISIT" DataType="text" Length="8" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VISITDY" Name="VISITDY" DataType="integer" Length="3" SASFieldName="VISITDY">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Study Day of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VISITNUM" Name="VISITNUM" DataType="integer" Length="2" SASFieldName="VISITNUM"
+        def:CommentOID="COM.VS.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSBLFL" Name="VSBLFL" DataType="text" Length="1" SASFieldName="VSBLFL">
+        <Description>
+          <TranslatedText xml:lang="en">Baseline Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY"/>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSDTC" Name="VSDTC" DataType="date" SASFieldName="VSDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Measurements</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSDY" Name="VSDY" DataType="integer" Length="3" SASFieldName="VSDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Vital Signs</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES" Name="VSORRES" DataType="text" Length="30" SASFieldName="VSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.VS.VSORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.DIABP" Name="VS.DIABPOR.ORRES" DataType="integer" Length="2" SASFieldName="DIABPOR">
+        <Description>
+          <TranslatedText xml:lang="en">Diastolic Blood Pressure (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.FRMSIZE" Name="VS.FRMSIZE.ORRES" DataType="text" Length="6" SASFieldName="FRMSZOR">
+        <Description>
+          <TranslatedText xml:lang="en">Body Frame Size (Orig U)</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SIZE"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.HEIGHT" Name="VS.HEIGHT.ORRES" DataType="float" Length="5" SignificantDigits="1" def:DisplayFormat="5.1" SASFieldName="HEIGHTOR">
+        <Description>
+          <TranslatedText xml:lang="en">Height (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.PULSE" Name="VS.PULSE.ORRES" DataType="integer" Length="2" SASFieldName="PULSEOR">
+        <Description>
+          <TranslatedText xml:lang="en">Pulse Rate (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.SYSBP" Name="VS.SYSBP.ORRES" DataType="integer" Length="3" SASFieldName="SYSBPOR">
+        <Description>
+          <TranslatedText xml:lang="en">Systolic Blood Pressure (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.WEIGHT" Name="VS.WEIGHT.ORRES" DataType="float" Length="4" SignificantDigits="1" def:DisplayFormat="5.1" SASFieldName="WEIGHTOR">
+        <Description>
+          <TranslatedText xml:lang="en">Weight (Orig U)</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU" Name="VSORRESU" DataType="text" Length="20" SASFieldName="VSORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.VS.VSORRESU"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSPOS" Name="VSPOS" DataType="text" Length="7" SASFieldName="VSPOS">
+        <Description>
+          <TranslatedText xml:lang="en">Vital Signs Position of Subject</TranslatedText>
+        </Description>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSEQ" Name="VSSEQ" DataType="integer" Length="2" SASFieldName="VSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESC" Name="VSSTRESC" DataType="text" Length="30" SASFieldName="VSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESN" Name="VSSTRESN" DataType="float" Length="5" SignificantDigits="1" def:DisplayFormat="5.1" SASFieldName="VSSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESU" Name="VSSTRESU" DataType="text" Length="9" SASFieldName="VSSTRESU"
+        def:CommentOID="COM.VSSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VSRESU"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.HEIGHT.DM.COUNTRY.CMETRIC" Name="VS.HEIGHT.UNITS" DataType="text" Length="5" SASFieldName="HEIGHTU"
+        def:CommentOID="COM.STUDY.DATA">
+        <Description>
+          <TranslatedText xml:lang="en">Height: Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UH_MC"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.HEIGHT.DM.COUNTRY.CNMETRIC" Name="VS.HEIGHT.UNITS" DataType="text" Length="5" SASFieldName="HEIGHTU">
+        <Description>
+          <TranslatedText xml:lang="en">Height: Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UH_NMC"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.WEIGHT.DM.COUNTRY.CMETRIC" Name="VS.HEIGHT.UNITS" DataType="text" Length="4" SASFieldName="WEIGHTU"
+        def:CommentOID="COM.STUDY.DATA">
+        <Description>
+          <TranslatedText xml:lang="en">Height: Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UW_MC"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.WEIGHT.DM.COUNTRY.CNMETRIC" Name="VS.HEIGHT.UNITS" DataType="text" Length="4" SASFieldName="WEIGHTU">
+        <Description>
+          <TranslatedText xml:lang="en">Height: Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UW_NMC"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSTEST" Name="VSTEST" DataType="text" Length="24" SASFieldName="VSTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Vital Signs Test Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VSTEST"/>
+        <def:Origin Type="CRF">
+          <def:DocumentRef leafID="LF.blankcrf">
+            <def:PDFPageRef PageRefs="11" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSTESTCD" Name="VSTESTCD" DataType="text" Length="20" SASFieldName="VSTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Vital Signs Test Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VSTESTCD"/>
+        <def:Origin Type="Assigned"/>
+      </ItemDef>
+
+
+      <!-- ******************************** -->
+      <!-- Code List Definitions Section    -->
+      <!-- ******************************** -->
+
+      <CodeList OID="CL.ACN" Name="Action Taken with Study Treatment" DataType="text">
+        <EnumeratedItem CodedValue="DOSE NOT CHANGED" OrderNumber="1">
+          <Alias Name="C49504" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="DOSE REDUCED" OrderNumber="2">
+          <Alias Name="C49505" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="DRUG INTERRUPTED" OrderNumber="3">
+          <Alias Name="C49501" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="DRUG WITHDRAWN" OrderNumber="4">
+          <Alias Name="C49502" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C66767" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.AE.DOMAIN" Name="Domain Abbreviation (AE)" DataType="text" SASFormatName="$AEDOMAI">
+        <CodeListItem CodedValue="AE">
+          <Decode>
+            <TranslatedText xml:lang="en">Adverse Events</TranslatedText>
+          </Decode>
+          <Alias Name="C49562" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.AEENRF" Name="Relation to Reference Period (AEENRF)" DataType="text">
+        <EnumeratedItem CodedValue="AFTER">
+          <Alias Name="C38008" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C66728" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.AEREL" Name="Causality" DataType="text">
+        <EnumeratedItem CodedValue="NOT RELATED"/>
+        <EnumeratedItem CodedValue="POSSIBLY RELATED"/>
+        <EnumeratedItem CodedValue="RELATED"/>
+      </CodeList>
+      <CodeList OID="CL.AESEV" Name="Severity/Intensity Scale for Adverse Events" DataType="text" SASFormatName="$AESEV">
+        <CodeListItem CodedValue="MILD" Rank="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Grade 1</TranslatedText>
+          </Decode>
+          <Alias Name="C41338" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MODERATE" Rank="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Grade 2</TranslatedText>
+          </Decode>
+          <Alias Name="C41339" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SEVERE" Rank="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Grade 3</TranslatedText>
+          </Decode>
+          <Alias Name="C41340" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66769" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.ARM" Name="Description of Planned Arm" DataType="text">
+        <EnumeratedItem CodedValue="Miracle Drug 10 mg"/>
+        <EnumeratedItem CodedValue="Miracle Drug 20 mg"/>
+        <EnumeratedItem CodedValue="Placebo"/>
+        <EnumeratedItem CodedValue="Screen Failure"/>
+      </CodeList>
+      <CodeList OID="CL.ARMCD" Name="Planned Arm Code" DataType="text" SASFormatName="$ARMCD">
+        <CodeListItem CodedValue="PLACEBO" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Placebo</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="SCRNFAIL" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Screen Failure</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="WONDER10" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Miracle Drug 10 mg</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="WONDER20" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Miracle Drug 20 mg</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.CGIIMP_X" Name="Global Improvement" DataType="integer" SASFormatName="CGIIMP_X">
+        <CodeListItem CodedValue="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Very much improved</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Much Improved</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Minimally Improved</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4">
+          <Decode>
+            <TranslatedText xml:lang="en">No change</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Minimally worse</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Much worse</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="7">
+          <Decode>
+            <TranslatedText xml:lang="en">Very much worse</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.CM.DOMAIN" Name="Domain Abbreviation (CM)" DataType="text" SASFormatName="$CMDOMAI">
+        <CodeListItem CodedValue="CM">
+          <Decode>
+            <TranslatedText xml:lang="en">Concomitant Meds</TranslatedText>
+          </Decode>
+          <Alias Name="C49568" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.CMCAT" Name="Category for Medication" DataType="text">
+        <EnumeratedItem CodedValue="CONCOMITANT MEDICATIONS"/>
+        <EnumeratedItem CodedValue="PSYCHOTROPHIC DRUG TREATMENT HISTORY"/>
+      </CodeList>
+      <CodeList OID="CL.CMENRF" Name="Relation to Reference Period (CMENRF)" DataType="text">
+        <EnumeratedItem CodedValue="AFTER">
+          <Alias Name="C38008" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C66728" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.CMUNIT" Name="Unit (CM)" DataType="text">
+        <EnumeratedItem CodedValue="CAPSULE" OrderNumber="1">
+          <Alias Name="C48480" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="IU" OrderNumber="2">
+          <Alias Name="C48579" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Other" OrderNumber="13" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="TABLET" OrderNumber="3">
+          <Alias Name="C48542" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="VIAL" OrderNumber="4">
+          <Alias Name="C48551" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="g" OrderNumber="5">
+          <Alias Name="C48155" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="mL" OrderNumber="6">
+          <Alias Name="C28254" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="mL/hr" OrderNumber="7" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="mL/kg" OrderNumber="8">
+          <Alias Name="C67411" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="mg" OrderNumber="9">
+          <Alias Name="C28253" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="mg/kg" OrderNumber="10">
+          <Alias Name="C67401" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="ug" OrderNumber="11">
+          <Alias Name="C48152" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="ug/kg" OrderNumber="12">
+          <Alias Name="C67396" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C71620" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.CUE_EXPF_X" Name="CUE_EXPF_X" DataType="integer" SASFormatName="CUE_EXPF">
+        <CodeListItem CodedValue="0">
+          <Decode>
+            <TranslatedText xml:lang="en">Absent</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Mild or Intermittent</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Severe</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.DA.DOMAIN" Name="Domain Abbreviation (DA)" DataType="text" SASFormatName="$DADOMAI">
+        <CodeListItem CodedValue="DA">
+          <Decode>
+            <TranslatedText xml:lang="en">Drug Accountability</TranslatedText>
+          </Decode>
+          <Alias Name="C49578" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.DATEST" Name="Drug Accountability Test Name" DataType="text">
+        <EnumeratedItem CodedValue="Dispensed Amount" OrderNumber="1">
+          <Alias Name="C78721" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Returned Amount" OrderNumber="2">
+          <Alias Name="C78722" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C78731" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.DATESTCD" Name="Drug Accountability Test Code" DataType="text" SASFormatName="$DATESTC">
+        <CodeListItem CodedValue="DISPAMT">
+          <Decode>
+            <TranslatedText xml:lang="en">Dispensed Amount</TranslatedText>
+          </Decode>
+          <Alias Name="C78721" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RETAMT">
+          <Decode>
+            <TranslatedText xml:lang="en">Returned Amount</TranslatedText>
+          </Decode>
+          <Alias Name="C78722" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C78732" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.DDISCNTF" Name="Reason for Discontinuation" DataType="text">
+        <EnumeratedItem CodedValue="ADVERSE EVENT" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="INSUFFICIENT RESPONSE" OrderNumber="3"/>
+        <EnumeratedItem CodedValue="ONGOING" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="OTHER" OrderNumber="5"/>
+        <EnumeratedItem CodedValue="SATISFACTORY RESPONSE" OrderNumber="4"/>
+      </CodeList>
+      <CodeList OID="CL.DM.DOMAIN" Name="Domain Abbreviation (DM)" DataType="text" SASFormatName="$DMDOMAI">
+        <CodeListItem CodedValue="DM">
+          <Decode>
+            <TranslatedText xml:lang="en">Demographics</TranslatedText>
+          </Decode>
+          <Alias Name="C49572" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.DS.DOMAIN" Name="Domain Abbreviation (DS)" DataType="text" SASFormatName="$DSDOMAI">
+        <CodeListItem CodedValue="DS">
+          <Decode>
+            <TranslatedText xml:lang="en">Disposition</TranslatedText>
+          </Decode>
+          <Alias Name="C49576" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.DSCAT" Name="Category for Disposition Event" DataType="text" SASFormatName="$DSCAT">
+        <CodeListItem CodedValue="DISPOSITION EVENT">
+          <Decode>
+            <TranslatedText xml:lang="en">Disposition Event</TranslatedText>
+          </Decode>
+          <Alias Name="C74590" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PROTOCOL MILESTONE">
+          <Decode>
+            <TranslatedText xml:lang="en">Protocol Milestone</TranslatedText>
+          </Decode>
+          <Alias Name="C74588" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C74558" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.EG.DOMAIN" Name="Domain Abbreviation (EG)" DataType="text" SASFormatName="$EGDOMAI">
+        <CodeListItem CodedValue="EG">
+          <Decode>
+            <TranslatedText xml:lang="en">Electrocardiogram</TranslatedText>
+          </Decode>
+          <Alias Name="C49626" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.EGRESU" Name="Unit (EGRESU)" DataType="text" SASFormatName="$EGRESU">
+        <CodeListItem CodedValue="BEATS/MIN">
+          <Decode>
+            <TranslatedText xml:lang="en">Beats per Minute</TranslatedText>
+          </Decode>
+          <Alias Name="C49673" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="msec">
+          <Decode>
+            <TranslatedText xml:lang="en">Millisecond</TranslatedText>
+          </Decode>
+          <Alias Name="C41140" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C71620" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.EGTEST" Name="ECG Test Name" DataType="text">
+        <EnumeratedItem CodedValue="Interpretation">
+          <Alias Name="C41255" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="QTcB - Bazett's Correction Formula">
+          <Alias Name="C62112" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="QTcF - Fridericia's Correction Formula">
+          <Alias Name="C62113" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Summary (Mean) PR Duration">
+          <Alias Name="C62086" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Summary (Mean) QRS Duration">
+          <Alias Name="C62087" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Summary (Mean) QT Duration">
+          <Alias Name="C62089" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Summary (Mean) Ventricular Rate">
+          <Alias Name="C62152" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C71152" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.EGTESTCD" Name="ECG Test Code" DataType="text" SASFormatName="$EGTESTC">
+        <CodeListItem CodedValue="INTP">
+          <Decode>
+            <TranslatedText xml:lang="en">Interpretation</TranslatedText>
+          </Decode>
+          <Alias Name="C41255" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PRMEAN">
+          <Decode>
+            <TranslatedText xml:lang="en">Summary (Mean) PR Duration</TranslatedText>
+          </Decode>
+          <Alias Name="C62086" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="QRSDUR">
+          <Decode>
+            <TranslatedText xml:lang="en">Summary (Mean) QRS Duration</TranslatedText>
+          </Decode>
+          <Alias Name="C62087" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="QTCB">
+          <Decode>
+            <TranslatedText xml:lang="en">QTcB - Bazett's Correction Formula</TranslatedText>
+          </Decode>
+          <Alias Name="C62112" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="QTCF">
+          <Decode>
+            <TranslatedText xml:lang="en">QTcF - Fridericia's Correction Formula</TranslatedText>
+          </Decode>
+          <Alias Name="C62113" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="QTMEAN">
+          <Decode>
+            <TranslatedText xml:lang="en">Summary (Mean) QT Duration</TranslatedText>
+          </Decode>
+          <Alias Name="C62089" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="VRMEAN">
+          <Decode>
+            <TranslatedText xml:lang="en">Summary (Mean) Ventricular Rate</TranslatedText>
+          </Decode>
+          <Alias Name="C62152" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C71153" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.EPOCH" Name="Epoch" DataType="text">
+        <EnumeratedItem CodedValue="SCREEN" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="TREATMENT">
+          <Alias Name="C49236" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C99079" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.ETHNIC" Name="Ethnic Group" DataType="text">
+        <EnumeratedItem CodedValue="HISPANIC OR LATINO">
+          <Alias Name="C17459" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="NOT HISPANIC OR LATINO">
+          <Alias Name="C41222" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C66790" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.EX.DOMAIN" Name="Domain Abbreviation (EX)" DataType="text" SASFormatName="$EXDOMAI">
+        <CodeListItem CodedValue="EX">
+          <Decode>
+            <TranslatedText xml:lang="en">Exposure</TranslatedText>
+          </Decode>
+          <Alias Name="C49587" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.EXTRT" Name="Treatment" DataType="text">
+        <EnumeratedItem CodedValue="Miracle Drug"/>
+        <EnumeratedItem CodedValue="Placebo"/>
+      </CodeList>
+      <CodeList OID="CL.FREQ" Name="Frequency" DataType="text" SASFormatName="$FREQ">
+        <CodeListItem CodedValue="BID">
+          <Decode>
+            <TranslatedText xml:lang="en">BD</TranslatedText>
+          </Decode>
+          <Alias Name="C64496" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ONCE">
+          <Decode>
+            <TranslatedText xml:lang="en">Once</TranslatedText>
+          </Decode>
+          <Alias Name="C64576" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OTHER">
+          <Decode>
+            <TranslatedText xml:lang="en">Other</TranslatedText>
+          </Decode>
+          <Alias Name="C17649" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PRN">
+          <Decode>
+            <TranslatedText xml:lang="en">As needed</TranslatedText>
+          </Decode>
+          <Alias Name="C64499" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="Q24H">
+          <Decode>
+            <TranslatedText xml:lang="en">Every 24 hours</TranslatedText>
+          </Decode>
+          <Alias Name="C64515" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="QID">
+          <Decode>
+            <TranslatedText xml:lang="en">4 times per day</TranslatedText>
+          </Decode>
+          <Alias Name="C64530" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="QOD">
+          <Decode>
+            <TranslatedText xml:lang="en">Every other day</TranslatedText>
+          </Decode>
+          <Alias Name="C64525" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="QS">
+          <Decode>
+            <TranslatedText xml:lang="en">Every week</TranslatedText>
+          </Decode>
+          <Alias Name="C67069" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TID">
+          <Decode>
+            <TranslatedText xml:lang="en">3 times per day</TranslatedText>
+          </Decode>
+          <Alias Name="C64527" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C71113" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.FRM" Name="Pharmaceutical Dosage Form" DataType="text" SASFormatName="$FRM">
+        <CodeListItem CodedValue="TABLET">
+          <Decode>
+            <TranslatedText xml:lang="en">tab</TranslatedText>
+          </Decode>
+          <Alias Name="C42998" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66726" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.IE.DOMAIN" Name="Domain Abbreviation (IE)" DataType="text" SASFormatName="$IEDOMAI">
+        <CodeListItem CodedValue="IE">
+          <Decode>
+            <TranslatedText xml:lang="en">Inclusion/Exclusion</TranslatedText>
+          </Decode>
+          <Alias Name="C61536" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.IETEST" Name="IE Tests" DataType="text">
+        <EnumeratedItem CodedValue="Did not respond to a standard course of medication Abc"/>
+        <EnumeratedItem CodedValue="Has Xyz disease of at least 10 weeks duration confirmed by biopsy"/>
+        <EnumeratedItem CodedValue="Is age 18 - 85"/>
+        <EnumeratedItem CodedValue="Is known to have had a substance abuse (drug or alcohol) problem within the previous 3 years"/>
+        <EnumeratedItem CodedValue="Is pregnant, nursing, or planning to become pregnant within 6 months of last study treatment"/>
+        <EnumeratedItem CodedValue="Is unable or unwilling to undergo multiple venipunctures"/>
+      </CodeList>
+      <CodeList OID="CL.IETESTCD" Name="IE Test Codes" DataType="text" SASFormatName="$IETESTC">
+        <CodeListItem CodedValue="EXCL01">
+          <Decode>
+            <TranslatedText xml:lang="en">Is pregnant, nursing, or planning to become pregnant within 6 months of last study
+treatment</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL02">
+          <Decode>
+            <TranslatedText xml:lang="en">Is unable or unwilling to undergo multiple venipunctures</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL03">
+          <Decode>
+            <TranslatedText xml:lang="en">Is known to have had a substance abuse (drug or alcohol) problem within the previous 3
+years</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL01">
+          <Decode>
+            <TranslatedText xml:lang="en">Is age 18 - 85</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL02">
+          <Decode>
+            <TranslatedText xml:lang="en">Has Xyz disease of at least 10 weeks duration confirmed by biopsy</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL03">
+          <Decode>
+            <TranslatedText xml:lang="en">Did not respond to a standard course of medication Abc</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.LB.DOMAIN" Name="Domain Abbreviation (LB)" DataType="text" SASFormatName="$LBDOMAI">
+        <CodeListItem CodedValue="LB">
+          <Decode>
+            <TranslatedText xml:lang="en">Laboratory Data</TranslatedText>
+          </Decode>
+          <Alias Name="C49592" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.LBRESU" Name="Unit (LBRESU)" DataType="text">
+        <EnumeratedItem CodedValue="%">
+          <Alias Name="C25613" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="X10^9/L" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="g/dL">
+          <Alias Name="C64783" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="mg/dL">
+          <Alias Name="C67015" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="ng/dL">
+          <Alias Name="C67326" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="pg/mL" def:ExtendedValue="Yes"/>
+        <Alias Name="C71620" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.LBTEST" Name="Laboratory Test Name" DataType="text">
+        <EnumeratedItem CodedValue="Bilirubin">
+          <Alias Name="C38037" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Blood Urea Nitrogen">
+          <Alias Name="C61019" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Glucose">
+          <Alias Name="C41376" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Hematocrit">
+          <Alias Name="C64796" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Hemoglobin">
+          <Alias Name="C64848" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Lymphocytes">
+          <Alias Name="C51949" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Occult Blood">
+          <Alias Name="C74686" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Vitamin B12">
+          <Alias Name="C64817" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Vitamin B9">
+          <Alias Name="C74676" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="pH">
+          <Alias Name="C45997" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C67154" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.LBTESTCD" Name="Laboratory Test Code" DataType="text" SASFormatName="$LBTESTC">
+        <CodeListItem CodedValue="BILI">
+          <Decode>
+            <TranslatedText xml:lang="en">Bilirubin</TranslatedText>
+          </Decode>
+          <Alias Name="C38037" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="BUN">
+          <Decode>
+            <TranslatedText xml:lang="en">Blood Urea Nitrogen</TranslatedText>
+          </Decode>
+          <Alias Name="C61019" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="GLUC">
+          <Decode>
+            <TranslatedText xml:lang="en">Glucose</TranslatedText>
+          </Decode>
+          <Alias Name="C41376" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HCT">
+          <Decode>
+            <TranslatedText xml:lang="en">Hematocrit</TranslatedText>
+          </Decode>
+          <Alias Name="C64796" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HGB">
+          <Decode>
+            <TranslatedText xml:lang="en">Hemoglobin</TranslatedText>
+          </Decode>
+          <Alias Name="C64848" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="LYM">
+          <Decode>
+            <TranslatedText xml:lang="en">Lymphocytes</TranslatedText>
+          </Decode>
+          <Alias Name="C51949" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OCCBLD">
+          <Decode>
+            <TranslatedText xml:lang="en">Occult Blood</TranslatedText>
+          </Decode>
+          <Alias Name="C74686" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PH">
+          <Decode>
+            <TranslatedText xml:lang="en">pH</TranslatedText>
+          </Decode>
+          <Alias Name="C45997" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="VITB12">
+          <Decode>
+            <TranslatedText xml:lang="en">Vitamin B12</TranslatedText>
+          </Decode>
+          <Alias Name="C64817" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="VITB9">
+          <Decode>
+            <TranslatedText xml:lang="en">Vitamin B9</TranslatedText>
+          </Decode>
+          <Alias Name="C74676" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C65047" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.MARISTAT" Name="Marital Status" DataType="text">
+        <EnumeratedItem CodedValue="DIVORCED">
+          <Alias Name="C51776" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="DOMESTIC PARTNER">
+          <Alias Name="C53262" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="LEGALLY SEPARATED">
+          <Alias Name="C51777" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="MARRIED">
+          <Alias Name="C51773" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="NEVER MARRIED">
+          <Alias Name="C51774" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="WIDOWED">
+          <Alias Name="C51775" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C76348" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.METHOD" Name="Method" DataType="text">
+        <EnumeratedItem CodedValue="DIPSTICK" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="QUANT" def:ExtendedValue="Yes"/>
+        <Alias Name="C85492" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.MH.DOMAIN" Name="Domain Abbreviation (MH)" DataType="text" SASFormatName="$MHDOMAI">
+        <CodeListItem CodedValue="MH">
+          <Decode>
+            <TranslatedText xml:lang="en">Medical History</TranslatedText>
+          </Decode>
+          <Alias Name="C49603" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.MHBODSYS" Name="Body System or Organ Class" DataType="text">
+        <EnumeratedItem CodedValue="Endocrine-Metabolic"/>
+        <EnumeratedItem CodedValue="Eyes-Ears-Nose-Throat"/>
+        <EnumeratedItem CodedValue="Genitourinary"/>
+        <EnumeratedItem CodedValue="Musculoskeletal"/>
+        <EnumeratedItem CodedValue="Neurological"/>
+      </CodeList>
+      <CodeList OID="CL.MHCAT" Name="Category for Medical History" DataType="text">
+        <EnumeratedItem CodedValue="MEDICAL AND SURGICAL HISTORY"/>
+        <EnumeratedItem CodedValue="PSYCHIATRIC HISTORY"/>
+      </CodeList>
+      <CodeList OID="CL.MHENRF" Name="Relation to Reference Period (MHENRF)" DataType="text">
+        <EnumeratedItem CodedValue="BEFORE">
+          <Alias Name="C25629" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="DURING/AFTER">
+          <Alias Name="C49640" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C66728" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.NABCLIN" Name="Interpretation: Original Results" DataType="text">
+        <EnumeratedItem CodedValue="ABNORMAL"/>
+        <EnumeratedItem CodedValue="NORMAL"/>
+      </CodeList>
+      <CodeList OID="CL.NCOMPLT" Name="Completion/Reason for Non-Completion" DataType="text">
+        <EnumeratedItem CodedValue="ADVERSE EVENT">
+          <Alias Name="C41331" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="COMPLETED">
+          <Alias Name="C25250" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="INFORMED CONSENT" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="LACK OF EFFICACY">
+          <Alias Name="C48226" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="LOST TO FOLLOW-UP">
+          <Alias Name="C48227" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHYSICIAN DECISION">
+          <Alias Name="C48250" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PROTOCOL VIOLATION">
+          <Alias Name="C48251" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="RANDOMIZED" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="SCREEN FAILURE">
+          <Alias Name="C49628" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="WITHDRAWAL BY SUBJECT">
+          <Alias Name="C49634" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C66727" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.NRIND" Name="Reference Range Indicator" DataType="text">
+        <EnumeratedItem CodedValue="ABNORMAL">
+          <Alias Name="C78802" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HIGH">
+          <Alias Name="C78800" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="LOW">
+          <Alias Name="C78801" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="NORMAL">
+          <Alias Name="C78727" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C78736" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.NY" Name="No Yes Response Subset" DataType="text" SASFormatName="$NY">
+        <CodeListItem CodedValue="N">
+          <Decode>
+            <TranslatedText xml:lang="en">No</TranslatedText>
+          </Decode>
+          <Alias Name="C49487" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="U">
+          <Decode>
+            <TranslatedText xml:lang="en">Unknown</TranslatedText>
+          </Decode>
+          <Alias Name="C17998" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="Y">
+          <Decode>
+            <TranslatedText xml:lang="en">Yes</TranslatedText>
+          </Decode>
+          <Alias Name="C49488" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66742" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.NYNA" Name="No Yes Response" DataType="text" SASFormatName="$NYNA">
+        <CodeListItem CodedValue="N">
+          <Decode>
+            <TranslatedText xml:lang="en">No</TranslatedText>
+          </Decode>
+          <Alias Name="C49487" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NA">
+          <Decode>
+            <TranslatedText xml:lang="en">Not Applicable</TranslatedText>
+          </Decode>
+          <Alias Name="C48660" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="Y">
+          <Decode>
+            <TranslatedText xml:lang="en">Yes</TranslatedText>
+          </Decode>
+          <Alias Name="C49488" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66742" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.PE.DOMAIN" Name="Domain Abbreviation (PE)" DataType="text" SASFormatName="$PEDOMAI">
+        <CodeListItem CodedValue="PE">
+          <Decode>
+            <TranslatedText xml:lang="en">Physical Exam</TranslatedText>
+          </Decode>
+          <Alias Name="C49608" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.PETEST" Name="PE Tests" DataType="text">
+        <EnumeratedItem CodedValue="Abdomen" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Appearance/Skin" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Cardiovascular" OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Eyes-Ears-Nose-Throat" OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Head/Neck (Including Thyroid)" OrderNumber="5"/>
+        <EnumeratedItem CodedValue="Musculoskeletal" OrderNumber="6"/>
+        <EnumeratedItem CodedValue="Neurological" OrderNumber="7"/>
+        <EnumeratedItem CodedValue="Other" OrderNumber="9"/>
+        <EnumeratedItem CodedValue="Pulmonary" OrderNumber="8"/>
+      </CodeList>
+      <CodeList OID="CL.PETESTCD" Name="PE Test Codes" DataType="text" SASFormatName="$PETESTC">
+        <CodeListItem CodedValue="PE01">
+          <Decode>
+            <TranslatedText xml:lang="en">Appearance/Skin</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PE02">
+          <Decode>
+            <TranslatedText xml:lang="en">Head/Neck (Including Thyroid)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PE03">
+          <Decode>
+            <TranslatedText xml:lang="en">Eyes-Ears-Nose-Throat</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PE04">
+          <Decode>
+            <TranslatedText xml:lang="en">Cardiovascular</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PE05">
+          <Decode>
+            <TranslatedText xml:lang="en">Pulmonary</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PE06">
+          <Decode>
+            <TranslatedText xml:lang="en">Abdomen</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PE07">
+          <Decode>
+            <TranslatedText xml:lang="en">Neurological</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PE08">
+          <Decode>
+            <TranslatedText xml:lang="en">Musculoskeletal</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PE09">
+          <Decode>
+            <TranslatedText xml:lang="en">Other</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.PSRESPF" Name="PSRESPF" DataType="text">
+        <EnumeratedItem CodedValue="GOOD"/>
+        <EnumeratedItem CodedValue="NO CHANGE"/>
+        <EnumeratedItem CodedValue="POOR"/>
+      </CodeList>
+      <CodeList OID="CL.QS.DOMAIN" Name="Domain Abbreviation (QS)" DataType="text" SASFormatName="$QSDOMAI">
+        <CodeListItem CodedValue="QS">
+          <Decode>
+            <TranslatedText xml:lang="en">Questionnaires</TranslatedText>
+          </Decode>
+          <Alias Name="C49609" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.QSTEST" Name="QS Tests" DataType="text">
+        <EnumeratedItem CodedValue="Agitation"/>
+        <EnumeratedItem CodedValue="Anxiety"/>
+        <EnumeratedItem CodedValue="Appetite Loss"/>
+        <EnumeratedItem CodedValue="Attention and Calculation"/>
+        <EnumeratedItem CodedValue="Difficulty Falling Asleep"/>
+        <EnumeratedItem CodedValue="Diurnal Variation of Mood"/>
+        <EnumeratedItem CodedValue="Early Morning Awakening"/>
+        <EnumeratedItem CodedValue="Global Improvement"/>
+        <EnumeratedItem CodedValue="Irritability"/>
+        <EnumeratedItem CodedValue="Lack of Energy"/>
+        <EnumeratedItem CodedValue="Lack of Reactivity to Pleasant Events"/>
+        <EnumeratedItem CodedValue="Language"/>
+        <EnumeratedItem CodedValue="Loss of Interest"/>
+        <EnumeratedItem CodedValue="Mood-Congruent Delusions"/>
+        <EnumeratedItem CodedValue="Multiple Awakenings During Sleep"/>
+        <EnumeratedItem CodedValue="Multiple Physical Complaints"/>
+        <EnumeratedItem CodedValue="Orientation place score"/>
+        <EnumeratedItem CodedValue="Orientation time score"/>
+        <EnumeratedItem CodedValue="Pessimism"/>
+        <EnumeratedItem CodedValue="Poor Self-Esteem"/>
+        <EnumeratedItem CodedValue="Recall"/>
+        <EnumeratedItem CodedValue="Registration"/>
+        <EnumeratedItem CodedValue="Retardation"/>
+        <EnumeratedItem CodedValue="Sadness"/>
+        <EnumeratedItem CodedValue="Suicide"/>
+        <EnumeratedItem CodedValue="Total Score"/>
+        <EnumeratedItem CodedValue="Weight Loss"/>
+      </CodeList>
+      <CodeList OID="CL.QSTESTCD" Name="QS Test Codes" DataType="text" SASFormatName="$QSTESTC">
+        <CodeListItem CodedValue="CGIGLOB">
+          <Decode>
+            <TranslatedText xml:lang="en">Global Improvement</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD01">
+          <Decode>
+            <TranslatedText xml:lang="en">Anxiety</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD02">
+          <Decode>
+            <TranslatedText xml:lang="en">Sadness</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD03">
+          <Decode>
+            <TranslatedText xml:lang="en">Lack of Reactivity to Pleasant Events</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD04">
+          <Decode>
+            <TranslatedText xml:lang="en">Irritability</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD05">
+          <Decode>
+            <TranslatedText xml:lang="en">Agitation</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD06">
+          <Decode>
+            <TranslatedText xml:lang="en">Retardation</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD07">
+          <Decode>
+            <TranslatedText xml:lang="en">Multiple Physical Complaints</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD08">
+          <Decode>
+            <TranslatedText xml:lang="en">Loss of Interest</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD09">
+          <Decode>
+            <TranslatedText xml:lang="en">Appetite Loss</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD10">
+          <Decode>
+            <TranslatedText xml:lang="en">Weight Loss</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD11">
+          <Decode>
+            <TranslatedText xml:lang="en">Lack of Energy</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD12">
+          <Decode>
+            <TranslatedText xml:lang="en">Diurnal Variation of Mood</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD13">
+          <Decode>
+            <TranslatedText xml:lang="en">Difficulty Falling Asleep</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD14">
+          <Decode>
+            <TranslatedText xml:lang="en">Multiple Awakenings During Sleep</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD15">
+          <Decode>
+            <TranslatedText xml:lang="en">Early Morning Awakening</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD16">
+          <Decode>
+            <TranslatedText xml:lang="en">Suicide</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD17">
+          <Decode>
+            <TranslatedText xml:lang="en">Poor Self-Esteem</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD18">
+          <Decode>
+            <TranslatedText xml:lang="en">Pessimism</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDD19">
+          <Decode>
+            <TranslatedText xml:lang="en">Mood-Congruent Delusions</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="CSDDTOT">
+          <Decode>
+            <TranslatedText xml:lang="en">Total Score</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="MMSEA1">
+          <Decode>
+            <TranslatedText xml:lang="en">Orientation time score</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="MMSEA2">
+          <Decode>
+            <TranslatedText xml:lang="en">Orientation place score</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="MMSEB">
+          <Decode>
+            <TranslatedText xml:lang="en">Registration</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="MMSEC">
+          <Decode>
+            <TranslatedText xml:lang="en">Attention and Calculation</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="MMSED">
+          <Decode>
+            <TranslatedText xml:lang="en">Recall</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="MMSEET">
+          <Decode>
+            <TranslatedText xml:lang="en">Language</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="MMSETOT">
+          <Decode>
+            <TranslatedText xml:lang="en">Total Score</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.RACE" Name="Race" DataType="text">
+        <EnumeratedItem CodedValue="AMERICAN INDIAN OR ALASKA NATIVE" OrderNumber="2">
+          <Alias Name="C41259" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="ASIAN" OrderNumber="4">
+          <Alias Name="C41260" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="BLACK OR AFRICAN AMERICAN" OrderNumber="3">
+          <Alias Name="C16352" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="MULTIPLE" OrderNumber="7" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER" OrderNumber="5">
+          <Alias Name="C41219" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="OTHER" OrderNumber="6" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="WHITE" OrderNumber="1">
+          <Alias Name="C41261" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C74457" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.ROUTE" Name="Route of Administration" DataType="text">
+        <EnumeratedItem CodedValue="INTRAMUSCULAR" OrderNumber="3">
+          <Alias Name="C28161" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="INTRASINAL" OrderNumber="8">
+          <Alias Name="C38262" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="INTRAVENOUS" OrderNumber="4">
+          <Alias Name="C38276" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="NASAL" OrderNumber="7">
+          <Alias Name="C38284" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="ORAL" OrderNumber="1">
+          <Alias Name="C38288" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="OTHER" OrderNumber="9">
+          <Alias Name="C38290" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="RECTAL" OrderNumber="5">
+          <Alias Name="C38295" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SUBCUTANEOUS" OrderNumber="2">
+          <Alias Name="C38299" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="TOPICAL" OrderNumber="6">
+          <Alias Name="C38304" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C66729" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.SC.DOMAIN" Name="Domain Abbreviation (SC)" DataType="text" SASFormatName="$SCDOMAI">
+        <CodeListItem CodedValue="SC">
+          <Decode>
+            <TranslatedText xml:lang="en">Subject Characteristics</TranslatedText>
+          </Decode>
+          <Alias Name="C49610" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.SCTEST" Name="SC Tests" DataType="text">
+        <EnumeratedItem CodedValue="Education Level">
+          <Alias Name="C17953" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Marital Status">
+          <Alias Name="C25188" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Subject Initials" def:ExtendedValue="Yes"/>
+        <Alias Name="C103330" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.SCTESTCD" Name="Subject Characteristic Code (SCTESTCD)" DataType="text" SASFormatName="$SCTESTC">
+        <CodeListItem CodedValue="EDLEVEL">
+          <Decode>
+            <TranslatedText xml:lang="en">Education Level</TranslatedText>
+          </Decode>
+          <Alias Name="C17953" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MARISTAT">
+          <Decode>
+            <TranslatedText xml:lang="en">Marital Status</TranslatedText>
+          </Decode>
+          <Alias Name="C25188" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SUBJINIT" def:ExtendedValue="Yes">
+          <Decode>
+            <TranslatedText xml:lang="en">Subject Initials</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <Alias Name="C74559" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.SE.DOMAIN" Name="Domain Abbreviation (SE)" DataType="text" SASFormatName="$SEDOMAI">
+        <CodeListItem CodedValue="SE">
+          <Decode>
+            <TranslatedText xml:lang="en">Subject Element</TranslatedText>
+          </Decode>
+          <Alias Name="C49616" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.SEX" Name="Sex" DataType="text" SASFormatName="$SEX">
+        <CodeListItem CodedValue="F">
+          <Decode>
+            <TranslatedText xml:lang="en">Female</TranslatedText>
+          </Decode>
+          <Alias Name="C16576" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="M">
+          <Decode>
+            <TranslatedText xml:lang="en">Male</TranslatedText>
+          </Decode>
+          <Alias Name="C20197" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="U">
+          <Decode>
+            <TranslatedText xml:lang="en">Unknown</TranslatedText>
+          </Decode>
+          <Alias Name="C17998" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66731" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.SIZE" Name="Size" DataType="text">
+        <EnumeratedItem CodedValue="LARGE" Rank="3">
+          <Alias Name="C49508" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="MEDIUM" Rank="2">
+          <Alias Name="C49507" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SMALL" Rank="1">
+          <Alias Name="C25376" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C66733" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.SPECTYPE" Name="Specimen Type" DataType="text">
+        <EnumeratedItem CodedValue="BLOOD">
+          <Alias Name="C12434" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SERUM">
+          <Alias Name="C13325" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="URINE">
+          <Alias Name="C13283" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C78734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.SV.DOMAIN" Name="Domain Abbreviation (SV)" DataType="text" SASFormatName="$SVDOMAI">
+        <CodeListItem CodedValue="SV">
+          <Decode>
+            <TranslatedText xml:lang="en">Subject Visits</TranslatedText>
+          </Decode>
+          <Alias Name="C49617" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.TA.DOMAIN" Name="Domain Abbreviation (TA)" DataType="text" SASFormatName="$TADOMAI">
+        <CodeListItem CodedValue="TA">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Arms</TranslatedText>
+          </Decode>
+          <Alias Name="C49618" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.TE.DOMAIN" Name="Domain Abbreviation (TE)" DataType="text" SASFormatName="$TEDOMAI">
+        <CodeListItem CodedValue="TE">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Elements</TranslatedText>
+          </Decode>
+          <Alias Name="C49619" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.TI.DOMAIN" Name="Domain Abbreviation (TI)" DataType="text" SASFormatName="$TIDOMAI">
+        <CodeListItem CodedValue="TI">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Inclusion/Exclusion Criteria</TranslatedText>
+          </Decode>
+          <Alias Name="C49620" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.TREASFF" Name="Reported Term for the Disposition Record" DataType="text">
+        <EnumeratedItem CodedValue="COMPLETED"/>
+        <EnumeratedItem CodedValue="DID NOT MEET INCLUSION CRITERIA #3"/>
+        <EnumeratedItem CodedValue="DISCONTINUED DUE TO ADVERSE EVENT"/>
+        <EnumeratedItem CodedValue="DISCONTINUED DUE TO CONSENT WITHDRAWEL"/>
+        <EnumeratedItem CodedValue="DISCONTINUED DUE TO LACK OF THERAPEUTIC RESPONSE"/>
+        <EnumeratedItem CodedValue="DISCONTINUED DUE TO LOST TO FOLLOW UP"/>
+        <EnumeratedItem CodedValue="DISCONTINUED DUE TO SPONSOR/INVESTIGATOR DECISION"/>
+        <EnumeratedItem CodedValue="INFORMED CONSENT OBTAINED"/>
+        <EnumeratedItem CodedValue="PATIENT DID NOT MEET INCLUSION/EXCLUSION CRITERIA AT SCREENING"/>
+        <EnumeratedItem CodedValue="PROTOCOL VIOLATION"/>
+        <EnumeratedItem CodedValue="RANDOMIZED"/>
+      </CodeList>
+      <CodeList OID="CL.TS.DOMAIN" Name="Domain Abbreviation (TS)" DataType="text" SASFormatName="$TSDOMAI">
+        <CodeListItem CodedValue="TS">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Summary</TranslatedText>
+          </Decode>
+          <Alias Name="C53483" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.TSPARM" Name="Trial Summary Parameter Test Name" DataType="text">
+        <EnumeratedItem CodedValue="Added on to Existing Treatments">
+          <Alias Name="C49703" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Age Span">
+          <Alias Name="C20587" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Age Unit" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="Clinical Study Sponsor">
+          <Alias Name="C70793" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Control Type">
+          <Alias Name="C49647" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Dose Units">
+          <Alias Name="C73558" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Dose per Administration">
+          <Alias Name="C25488" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Dosing Frequency">
+          <Alias Name="C89081" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Investigational Therapy or Treatment">
+          <Alias Name="C41161" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Planned Maximum Age of Subjects">
+          <Alias Name="C49694" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Planned Minimum Age of Subjects">
+          <Alias Name="C49693" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Planned Number of Subjects">
+          <Alias Name="C49692" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Route of Administration">
+          <Alias Name="C38114" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Sex of Participants">
+          <Alias Name="C49696" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Blinding Schema">
+          <Alias Name="C49658" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Indication Type">
+          <Alias Name="C49652" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Length">
+          <Alias Name="C49697" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Phase Classification">
+          <Alias Name="C48281" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Primary Objective">
+          <Alias Name="C85826" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Secondary Objective">
+          <Alias Name="C85827" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Title">
+          <Alias Name="C49802" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Type">
+          <Alias Name="C49660" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial is Randomized">
+          <Alias Name="C25196" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C67152" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.TSPARMCD" Name="Trial Summary Parameter Test Code" DataType="text" SASFormatName="$TSPARMC">
+        <CodeListItem CodedValue="ADDON">
+          <Decode>
+            <TranslatedText xml:lang="en">Added on to Existing Treatments</TranslatedText>
+          </Decode>
+          <Alias Name="C49703" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AGEMAX">
+          <Decode>
+            <TranslatedText xml:lang="en">Planned Maximum Age of Subjects</TranslatedText>
+          </Decode>
+          <Alias Name="C49694" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AGEMIN">
+          <Decode>
+            <TranslatedText xml:lang="en">Planned Minimum Age of Subjects</TranslatedText>
+          </Decode>
+          <Alias Name="C49693" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AGESPAN">
+          <Decode>
+            <TranslatedText xml:lang="en">Age Span</TranslatedText>
+          </Decode>
+          <Alias Name="C20587" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AGEU" def:ExtendedValue="Yes">
+          <Decode>
+            <TranslatedText xml:lang="en">Age Unit</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSE">
+          <Decode>
+            <TranslatedText xml:lang="en">Dose per Administration</TranslatedText>
+          </Decode>
+          <Alias Name="C25488" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSFRQ">
+          <Decode>
+            <TranslatedText xml:lang="en">Dosing Frequency</TranslatedText>
+          </Decode>
+          <Alias Name="C89081" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSU">
+          <Decode>
+            <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+          </Decode>
+          <Alias Name="C73558" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="LENGTH">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Length</TranslatedText>
+          </Decode>
+          <Alias Name="C49697" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OBJPRIM">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Primary Objective</TranslatedText>
+          </Decode>
+          <Alias Name="C85826" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OBJSEC">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Secondary Objective</TranslatedText>
+          </Decode>
+          <Alias Name="C85827" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PLANSUB">
+          <Decode>
+            <TranslatedText xml:lang="en">Planned Number of Subjects</TranslatedText>
+          </Decode>
+          <Alias Name="C49692" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RANDOM">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial is Randomized</TranslatedText>
+          </Decode>
+          <Alias Name="C25196" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ROUTE">
+          <Decode>
+            <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+          </Decode>
+          <Alias Name="C38114" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SEXPOP">
+          <Decode>
+            <TranslatedText xml:lang="en">Sex of Participants</TranslatedText>
+          </Decode>
+          <Alias Name="C49696" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SPONSOR">
+          <Decode>
+            <TranslatedText xml:lang="en">Clinical Study Sponsor</TranslatedText>
+          </Decode>
+          <Alias Name="C70793" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TBLIND">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Blinding Schema</TranslatedText>
+          </Decode>
+          <Alias Name="C49658" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TCNTRL">
+          <Decode>
+            <TranslatedText xml:lang="en">Control Type</TranslatedText>
+          </Decode>
+          <Alias Name="C49647" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TINDTP">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Indication Type</TranslatedText>
+          </Decode>
+          <Alias Name="C49652" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TITLE">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Title</TranslatedText>
+          </Decode>
+          <Alias Name="C49802" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TPHASE">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Phase Classification</TranslatedText>
+          </Decode>
+          <Alias Name="C48281" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TRT">
+          <Decode>
+            <TranslatedText xml:lang="en">Investigational Therapy or Treatment</TranslatedText>
+          </Decode>
+          <Alias Name="C41161" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TTYPE">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Type</TranslatedText>
+          </Decode>
+          <Alias Name="C49660" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66738" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.TV.DOMAIN" Name="Domain Abbreviation (TV)" DataType="text" SASFormatName="$TVDOMAI">
+        <CodeListItem CodedValue="TV">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Visits</TranslatedText>
+          </Decode>
+          <Alias Name="C49621" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.UH_MC" Name="Unit (UH_MC)" DataType="text" SASFormatName="$UH_MC">
+        <CodeListItem CodedValue="cm">
+          <Decode>
+            <TranslatedText xml:lang="en">Centimeter</TranslatedText>
+          </Decode>
+          <Alias Name="C49668" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C71620" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.UH_NMC" Name="Unit (UH_NMC)" DataType="text" SASFormatName="$UH_NMC">
+        <CodeListItem CodedValue="IN">
+          <Decode>
+            <TranslatedText xml:lang="en">Inch</TranslatedText>
+          </Decode>
+          <Alias Name="C48500" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C71620" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.UW_MC" Name="Unit (UW_MC)" DataType="text" SASFormatName="$UW_MC">
+        <CodeListItem CodedValue="kg">
+          <Decode>
+            <TranslatedText xml:lang="en">Kilogram</TranslatedText>
+          </Decode>
+          <Alias Name="C28252" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C71620" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.UW_NMC" Name="Unit (UW_NMC)" DataType="text" SASFormatName="$UW_NMC">
+        <CodeListItem CodedValue="LB">
+          <Decode>
+            <TranslatedText xml:lang="en">Pound</TranslatedText>
+          </Decode>
+          <Alias Name="C48531" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C71620" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.VS.DOMAIN" Name="Domain Abbreviation (VS)" DataType="text" SASFormatName="$VSDOMAI">
+        <CodeListItem CodedValue="VS">
+          <Decode>
+            <TranslatedText xml:lang="en">Vital Signs</TranslatedText>
+          </Decode>
+          <Alias Name="C49622" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66734" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.VSRESU" Name="Units for Vital Signs Results" DataType="text" SASFormatName="$VSRESU">
+        <CodeListItem CodedValue="BEATS/MIN">
+          <Decode>
+            <TranslatedText xml:lang="en">Beats per Minute</TranslatedText>
+          </Decode>
+          <Alias Name="C49673" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="cm">
+          <Decode>
+            <TranslatedText xml:lang="en">Centimeter</TranslatedText>
+          </Decode>
+          <Alias Name="C49668" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="kg">
+          <Decode>
+            <TranslatedText xml:lang="en">Kilogram</TranslatedText>
+          </Decode>
+          <Alias Name="C28252" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="mmHg">
+          <Decode>
+            <TranslatedText xml:lang="en">Millimeter of Mercury</TranslatedText>
+          </Decode>
+          <Alias Name="C49670" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66770" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.VSTEST" Name="Vital Signs Test Name" DataType="text">
+        <EnumeratedItem CodedValue="Body Frame Size">
+          <Alias Name="C49680" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Diastolic Blood Pressure">
+          <Alias Name="C25299" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Height">
+          <Alias Name="C25347" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Pulse Rate">
+          <Alias Name="C49676" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Systolic Blood Pressure">
+          <Alias Name="C25298" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Weight">
+          <Alias Name="C25208" Context="nci:ExtCodeID"/>
+        </EnumeratedItem>
+        <Alias Name="C67153" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.VSTESTCD" Name="Vital Signs Test Code" DataType="text" SASFormatName="$VSTESTC">
+        <CodeListItem CodedValue="DIABP">
+          <Decode>
+            <TranslatedText xml:lang="en">Diastolic Blood Pressure</TranslatedText>
+          </Decode>
+          <Alias Name="C25299" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="FRMSIZE">
+          <Decode>
+            <TranslatedText xml:lang="en">Body Frame Size</TranslatedText>
+          </Decode>
+          <Alias Name="C49680" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HEIGHT">
+          <Decode>
+            <TranslatedText xml:lang="en">Height</TranslatedText>
+          </Decode>
+          <Alias Name="C25347" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PULSE">
+          <Decode>
+            <TranslatedText xml:lang="en">Pulse Rate</TranslatedText>
+          </Decode>
+          <Alias Name="C49676" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SYSBP">
+          <Decode>
+            <TranslatedText xml:lang="en">Systolic Blood Pressure</TranslatedText>
+          </Decode>
+          <Alias Name="C25298" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="WEIGHT">
+          <Decode>
+            <TranslatedText xml:lang="en">Weight</TranslatedText>
+          </Decode>
+          <Alias Name="C25208" Context="nci:ExtCodeID"/>
+        </CodeListItem>
+        <Alias Name="C66741" Context="nci:ExtCodeID"/>
+      </CodeList>
+      <CodeList OID="CL.AEDICT_F" Name="Adverse Event Dictionary" DataType="text">
+        <ExternalCodeList Dictionary="MEDDRA" Version="8.0"/>
+      </CodeList>
+      <CodeList OID="CL.DRUGDICT_F" Name="Drug Dictionary" DataType="text">
+        <ExternalCodeList Dictionary="WHODRUG" Version="200204"/>
+      </CodeList>
+      <CodeList OID="CL.ISO3166" Name="ISO3166" DataType="text">
+        <ExternalCodeList Dictionary="ISO3166" Version=" "/>
+      </CodeList>
+
+
+      <!-- ******************************** -->
+      <!-- Methods Definitions Section      -->
+      <!-- ******************************** -->
+
+      <MethodDef OID="MT.AEENDY" Name="Algorithm to derive AEENDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">AEENDY = AEENDTC -RFSTDTC+1 if AEENDTC is on or after RFSTDTC. AEENDTC - RFSTDTC if AEENDTC
+precedes RFSTDTC</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.AESTDY" Name="Algorithm to derive AESTDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">AESTDY = AESTDTC - RFSTDTC+1 if AESTDTC is on or after RFSTDTC. AESTDTC - RFSTDTC if
+AESTDTC precedes RFSTDTC</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.AETRTEM" Name="Algorithm to derive the AETRTEM flag" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">AETRTEM = "Y" if Adverse Event was not present prior to the RFSTDTC, or it was present
+prior to the RFSTDTC but increased in severity during the treatment period. Null otherwise.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <!-- Method Definition: Algorithm included or expanded in an external file -->
+      <MethodDef OID="MT.AGE" Name="Algorithm to derive AGE" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Age at Screening Date (Screening Date - Birth date). For the complete algorithm see the
+referenced external document.</TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ComplexAlgorithms">
+          <def:PDFPageRef PageRefs="DM" Type="NamedDestination"/>
+        </def:DocumentRef>
+      </MethodDef>
+      <MethodDef OID="MT.CLSIG" Name="Algorithm to derive CLSIG" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Only created if value qualifies as potentially clinically significant high or low based on
+the high and low ranges specified in the Statistical Analysis Plan.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.CMENDY" Name="Algorithm to derive CMENDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">CMENDY = CMENDTC - RFSTDTC +1 if CMENDTC is on or after RFSTDTC. CMENDTC - RFSTDTC if
+CMENDTC precedes RFSTDTC</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.CMSTDY" Name="Algorithm to derive CMSTDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">CMSTDY = CMSTDTC - RFSTDTC +1 if CMSTDTC is on or after RFSTDTC. CMSTDTC - RFSTDTC if
+CMSTDTC precedes RFSTDTC</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DA.VISITNUM" Name="Algorithm to derive DA.VISITNUM" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Derived from DADTC and SVSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DADY" Name="Algorithm to derive DADY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">DADY = DADTC - RFSTDTC+1 if DADTC is on or after RFSTDTC. DADTC - RFSTDTC if DADTC precedes
+RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DASTRESC" Name="Algorithm to derive DASTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">DASTRESC = DAORRES</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DASTRESN" Name="Algorithm to derive DASTRESN" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">DASTRESN = numeric value of DAORRES, when DAORRES contains numeric data.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DASTRESU" Name="Algorithm to derive DASTRESU" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">DASTRESU = DAORRESU</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DSSTDY" Name="Algorithm to derive DSSTDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">DSSTDY = DSSTDTC - RFSTDTC+1 if DSSTDTC is on or after RFSTDTC. DSSTDTC - RFSTDTC if
+DSSTDTC precedes RFSTDTC. Null if RFSTDTC is Null.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EGBLFL" Name="Algorithm to derive EGBLFL" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Safety subjects only: EGBLFL = "Y" for last record with non Null EGORRES on or before the
+first dose date (RFSTDTC). Null otherwise</TranslatedText>
+        </Description>
+      </MethodDef>
+      <!-- Method Definition: Algorithm included or expanded in an external file -->
+      <MethodDef OID="MT.EGDRVFL" Name="Algorithm to derive EGDRVFL" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">EGDRVFL = "Y" for derived EGTESTCDs QTCB and QTCF. Null otherwise.</TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ComplexAlgorithms">
+          <def:PDFPageRef PageRefs="EG" Type="NamedDestination"/>
+        </def:DocumentRef>
+      </MethodDef>
+      <MethodDef OID="MT.EGDY" Name="Algorithm to derive EGDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">EGDY = EGDTC-RFSTDTC+1 if EGDTC is on or after RFTSDTC. EGDTC - RFSTDTC if EGDTC precedes
+RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EGSTRESC" Name="Algorithm to derive EGSTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Data collected in non-standard units is converted using standard conversion factors to
+standard units.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EGSTRESN" Name="Algorithm to derive EGSTRESN" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">EGSTRESN = numeric value of EGSTRESC, when EGSTRESC contains numeric data.
+          </TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EXDOSE" Name="Algorithm to derive EXDOSE" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If ARMCD=WONDER10 then EXDOSE = Number of Tablets per Day (QVAL where QNAM=SMNO) * 10. If
+ARMCD=WONDER20 then EXDOSE = Number of Tablets per Day (QVAL where QNAM=SMNO) * 20. If ARMCD=PLACEBO then EXDOSE = 0.
+          </TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EXDOSU" Name="Algorithm to derive EXDOSU" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Derived from ARM, ARMCD - equal to mg</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EXENDY" Name="Algorithm to derive EXENDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">EXENDY = EXENDTC-RFSTDTC+1 if EXENDTC is on or after RFSTDTC. EXENDTC - RFSTDTC if EXENDTC
+precedes RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EXSTDY" Name="Algorithm to derive EXSTDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">EXSTDY = EXSTDTC - RFSTDTC+1 if EXSTDTC is on or after RFSTDTC. EXSTDTC - RFSTDTC if
+EXSTDTC precedes RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EXTRT" Name="Algorithm to derive EXTRT" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Derived from ARM, ARMCD</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.IESTRESC" Name="Algorithm to derive IESTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">IESTRESC = IEORRES</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.LBBLFL" Name="Algorithm to derive LBBLFL" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Safety subjects only: LBBLFL = "Y" for last record with non Null LBORRES on or before the
+first dose date (RFSTDTC). Null otherwise.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.LBDY" Name="Algorithm to derive LBDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">LBDY = LBDTC-RFSTDTC+1 if LBDTC is on or after RFSTDTC. LBDTC - RFSTDTC if LBDTC precedes
+RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.LBNRIND" Name="Algorithm to derive LBNRIND" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Indicator based upon standard results and ranges.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.PEDY" Name="Algorithm to derive PEDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">PEDY = PEDTC-RFSTDTC+1 if PEDTC is on or after RFSTDTC. PEDTC - RFSTDTC if PEDTC precedes
+RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.PESTRESC" Name="Algorithm to derive PESTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">PESTRESC = PEORRES</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.QSBLFL" Name="Algorithm to derive QSBLFL" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Safety subjects only: QSBLFL = "Y" for last record with non Null QSORRES on or before the
+first dose date (RFSTDTC). Null otherwise.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.QSDY" Name="Algorithm to derive QSDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">QSDY= QSDTC-RFSTDTC+1 if QSDTC is on or after RFSTDTC. QSDTC - RFSTDTC if QSDTC precedes
+RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.QSSTRESC" Name="Algorithm to derive QSSTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If questionnaire result is a numerically relevant code then code stored here; else
+character result equal to QSORRES. Character results contain mixed case data.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.QSSTRESN" Name="Algorithm to derive QSSTRESN" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">When QSORRES is numeric then QSSTRESN equal to numeric result</TranslatedText>
+        </Description>
+      </MethodDef>
+      <!-- Method Definition: Algorithm included or expanded in an external file -->
+      <MethodDef OID="MT.QTCB" Name="Algorithm to derive QTCB" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">QTcB = QT interval / square root of (60 / heart rate). For the complete algorithm see the
+referenced external document.</TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ComplexAlgorithms">
+          <def:PDFPageRef PageRefs="EG" Type="NamedDestination"/>
+        </def:DocumentRef>
+      </MethodDef>
+      <!-- Method Definition: Algorithm included or expanded in an external file -->
+      <MethodDef OID="MT.QTCF" Name="Algorithm to derive QTCF" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">QTcF = QT interval / cubic root of (60 / heart rate). For the complete algorithm see the
+referenced external document.</TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ComplexAlgorithms">
+          <def:PDFPageRef PageRefs="EG" Type="NamedDestination"/>
+        </def:DocumentRef>
+      </MethodDef>
+      <MethodDef OID="MT.RDOMAIN" Name="Algorithm to derive RDOMAIN" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Domain abbreviation from where data originated.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RELID" Name="Algorithm to derive RELID" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">All records for the same USUBJID with the same RELID are considered related.
+          </TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RFENDTC" Name="Algorithm to derive RFENDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">RFENDTC = termination date, for safety subjects. Null for screen failures.
+          </TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RFSTDTC" Name="Algorithm to derive RFSTDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">RFSTDTC = first date/time of study drug, for safety subject. Null for screen failures.
+          </TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SAFETY" Name="Algorithm to derive the SAFETY population flag" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">SAFETY = "Y" for randomized subjects who took at least one dose study medication. Null
+otherwise.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SCDY" Name="Algorithm to derive SCDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">SCDY = SCDTC-RFSTDTC+1 if SCDTC is on or after RFSTDTC. SCDTC - RFSTDTC if SCDTC precedes
+RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SCSTRESC" Name="Algorithm to derive SCSTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">SCSTRESC = SCORRES</TranslatedText>
+        </Description>
+      </MethodDef>
+      <!-- Method Definition: Algorithm included or expanded in an external file -->
+      <MethodDef OID="MT.SEENDTC" Name="Algorithm to derive SEENDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If Element = SCREEN, derived from SVENDTC where VISIT = SCREENING. If Element = EOS,
+derived from DS where DSCAT = DISPOSITION EVENT or from the latest EXENDTC from EX whichever is later. For treatment Elements,
+derived from last EXENDTC for the element. For the complete algorithm see the referenced external document.</TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ComplexAlgorithms">
+          <def:PDFPageRef PageRefs="SE" Type="NamedDestination"/>
+        </def:DocumentRef>
+      </MethodDef>
+      <MethodDef OID="MT.SEQ" Name="Algorithm to derive SEQ" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Sequential number identifying records within each USUBJID in the domain.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <!-- Method Definition: Algorithm included or expanded in an external file -->
+      <MethodDef OID="MT.SESTDTC" Name="Algorithm to derive SESTDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If Element = SCREEN, derived from SVSTDTC where VISIT = SCREENING or from DS where DSDECOD
+= 'INFORMED CONSENT', whichever is earliest. If Element = EOS, derived from DS where DSCAT = DISPOSITION EVENT. For treatment
+Elements, derived from first EXSTDTC for the element. For the complete algorithm see the referenced external document.
+          </TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ComplexAlgorithms">
+          <def:PDFPageRef PageRefs="SE" Type="NamedDestination"/>
+        </def:DocumentRef>
+      </MethodDef>
+      <MethodDef OID="MT.SV.VISIT" Name="Algorithm to derive SV.VISIT" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Derived from visit-based subject-level domains</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SV.VISITNUM" Name="Algorithm to derive VISITNUM" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Derived from visit-based subject-level domains</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SVENDTC" Name="Algorithm to derive SVENDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">SVENDTC = SVSTDTC</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SVSTDTC" Name="Algorithm to derive SVSTDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Derived from visit-based subject-level domains</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SVSTDY" Name="Algorithm to derive SVSTDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">SVSTDY = SVSTDTC-RFSTDTC+1 if SVSTDTC is on or after RFSTDTC. SVSTDTC - RFSTDTC if SVSTDTC
+precedes RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.TSSEQ" Name="Algorithm to derive TSSEQ" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Sequential number identifying records within each TSPARM in the domain.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.USUBJID" Name="Algorithm to derive USUBJID" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Concatenation of STUDYID and SUBJID</TranslatedText>
+        </Description>
+        <FormalExpression Context="SAS 9.0 or later, as part of a data step assignment or proc sql select and update statements.">
+          catx(".",STUDYID,SUBJID)
+        </FormalExpression>
+      </MethodDef>
+      <MethodDef OID="MT.VSBLFL" Name="Algorithm to derive VSBLFL" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Safety subjects only: VSBLFL = "Y" for last record with non Null VSORRES on or before the
+first dose date (RFSTDTC). Null otherwise.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.VSDY" Name="Algorithm to derive VSDY" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">VSDY = VSDTC-RFSTDTC+1 if VSDTC is on or after RFSTDTC. VSDTC - RFSTDTC if VSDTC precedes
+RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.VSSTRESC" Name="Algorithm to derive VSSTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Data collected in non-standard units (i.e. lbs, inches) is converted using standard
+conversion factors to standard units (kg, cm).</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.VSSTRESN" Name="Algorithm to derive VSSTRESN" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">VSSTRESN = numeric value of VSSTRESC, when VSSTRESC contains numeric data.
+          </TranslatedText>
+        </Description>
+      </MethodDef>
+
+
+      <!-- ******************************** -->
+      <!-- Comments Definitions Section     -->
+      <!-- ******************************** -->
+
+      <def:CommentDef OID="COM.AGEU">
+        <Description>
+          <TranslatedText xml:lang="en">Defaulted to YEARS</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.ARM">
+        <Description>
+          <TranslatedText xml:lang="en">Assigned from TA.ARM based on ARMCD.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <!-- Comment Definition: Long Comment, included in a PDF file -->
+      <def:CommentDef OID="COM.ARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Assigned based on Randomization Number. See Note 2.1</TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ReviewersGuide"/>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.CMCLAS">
+        <Description>
+          <TranslatedText xml:lang="en">Coded to ATC level 3 Term based on CMINDC</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.CMCLASCD">
+        <Description>
+          <TranslatedText xml:lang="en">Coded to ATC level 3 Code based on CMINDC</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.CMROUTE">
+        <Description>
+          <TranslatedText xml:lang="en">Free text from CRF mapped to CDISC CT</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <!-- Comment Definition: Long Comment, included in a PDF file -->
+      <def:CommentDef OID="COM.DOMAIN.DM">
+        <Description>
+          <TranslatedText xml:lang="en">See Reviewer's Guide, Section 2.1 Demographics</TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ReviewersGuide">
+          <def:PDFPageRef PageRefs="section2.1" Type="NamedDestination"/>
+        </def:DocumentRef>
+      </def:CommentDef>
+      <!-- Comment Definition: Long Comment, included in a PDF file -->
+      <def:CommentDef OID="COM.DOMAIN.QS">
+        <Description>
+          <TranslatedText xml:lang="en">QS is submitted as a split dataset. The split was done based on QSCAT as QSCG (CLINICAL
+GLOBAL IMPRESSIONS), QSCS (CORNELL SCALE FOR DEPRESSION INDEMENTIA) and QSMM (MINI MENTAL STATE EXAMINATION). See additional
+documentation in the Reviewer's Guide, Split Datasets Section.</TranslatedText>
+        </Description>
+        <def:DocumentRef leafID="LF.ReviewersGuide"/>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.DSDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">CRF controlled terminology was mapped to match CDISC controlled terminology.
+          </TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.EG.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Assigned from the TV domain based on the VISIT</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.EGEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Equal to INVESTIGATOR for CRF data</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.EGPOS">
+        <Description>
+          <TranslatedText xml:lang="en">Equal to SUPINE</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.EGSPID">
+        <Description>
+          <TranslatedText xml:lang="en">ECG parameter ordering variable</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Name of the variables for the related records.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Value of identifying variable described in IDVAR.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.IE.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Assigned from the TV domain based on the VISIT</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.LBREFID">
+        <Description>
+          <TranslatedText xml:lang="en">Accession number</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.MHBODSYS">
+        <Description>
+          <TranslatedText xml:lang="en">Assigned for Medical History but not Psychiatric History</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.MHENRF">
+        <Description>
+          <TranslatedText xml:lang="en">CRF controlled terminology was mapped to match CDISC controlled terminology.
+          </TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.PE.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Assigned from the TV domain based on the VISIT</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.QS.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Assigned from the TV domain based on the VISIT</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.RELTYPE">
+        <Description>
+          <TranslatedText xml:lang="en">All values are null since this is used only when identifying a dataset-level relationship.
+          </TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.STUDY.DATA">
+        <Description>
+          <TranslatedText xml:lang="en">The data submitted only includes subjects in the USA since other sites did not enroll any
+subjects.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.SUBJECTDATA-JOIN-DM">
+        <Description>
+          <TranslatedText xml:lang="en">Join any Subject Level dataset with the Demographics dataset based on
+[IG.datasetname]IT.USUBJID = [IG.DM]IT.USUBJID, assuming 'IG.datasetname' is the OID of the ItemGroupDef that defines the
+subject-level dataset to be joined with the Demographics dataset.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.SUPPQS.QVAL.RTRINIT">
+        <Description>
+          <TranslatedText xml:lang="en">QSMM-CRF Page 13; QSCS-CRF Pages 14; QSCG-CRF Page 17</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.VS.VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Assigned from the TV domain based on the VISIT</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.VSSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Standard units consistent with CDISC controlled terminology</TranslatedText>
+        </Description>
+      </def:CommentDef>
+
+
+      <!-- ******************************** -->
+      <!-- Leafs Definitions Section        -->
+      <!-- ******************************** -->
+
+      <def:leaf ID="LF.blankcrf" xlink:href="blankcrf.pdf">
+        <def:title>Annotated Case Report Form</def:title>
+      </def:leaf>
+
+      <def:leaf ID="LF.ReviewersGuide" xlink:href="reviewersguide.pdf">
+        <def:title>Reviewers Guide</def:title>
+      </def:leaf>
+
+      <def:leaf ID="LF.ComplexAlgorithms" xlink:href="complexalgorithms.pdf">
+        <def:title>Complex Algorithms</def:title>
+      </def:leaf>
+ 
+
+    <!-- ***********************************     -->
+    <!-- End of Metadata Definitions Section     -->
+    <!-- ***********************************     -->
+
+    </MetaDataVersion>
+  </Study>
+</ODM>

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -11,10 +11,6 @@ from cdisc_rules_engine.exceptions.custom_exceptions import (
 )
 from cdisc_rules_engine.services.define_xml_reader import DefineXMLReader
 
-test_define_2_0_file_path: str = (
-    f"{os.path.dirname(__file__)}/../resources/test_defineV20-SDTM.xml"
-)
-
 test_define_file_path: str = (
     f"{os.path.dirname(__file__)}/../resources/test_defineV22-SDTM.xml"
 )
@@ -144,26 +140,6 @@ def test_extract_variable_metadata():
 @pytest.mark.parametrize(
     "define_file_path, domain_name, define_variable_name, expected",
     [
-        # TODO: support define 2.0
-        # https://github.com/cdisc-org/cdisc-rules-engine/issues/390
-        # (
-        #     test_define_2_0_file_path,
-        #     "AE",
-        #     "AEACN",
-        #     True,
-        # ),
-        # (
-        #     test_define_2_0_file_path,
-        #     "AE",
-        #     "AEBODSYS",
-        #     False,
-        # ),
-        # (
-        #     test_define_2_0_file_path,
-        #     "LB",
-        #     "LBCAT",
-        #     False,
-        # ),
         (
             test_define_file_path,
             "AE",

--- a/tests/unit/test_operations/test_variable_is_null.py
+++ b/tests/unit/test_operations/test_variable_is_null.py
@@ -34,7 +34,7 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
         ),
         (
             pd.DataFrame.from_dict({"BCVAR": ["A", "B", "C"]}),
-            None,
+            True,
         ),
     ],
 )

--- a/tests/unit/test_operations/test_variable_is_null.py
+++ b/tests/unit/test_operations/test_variable_is_null.py
@@ -1,0 +1,53 @@
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.operations.variable_is_null import VariableIsNull
+from cdisc_rules_engine.models.operation_params import OperationParams
+import pandas as pd
+import pytest
+from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+from cdisc_rules_engine.services.data_services.data_service_factory import (
+    DataServiceFactory,
+)
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            pd.DataFrame.from_dict({"AEVAR": ["A", "B", "C"]}),
+            False,
+        ),
+        (
+            pd.DataFrame.from_dict({"AEVAR": [1, 2, 3]}),
+            False,
+        ),
+        (
+            pd.DataFrame.from_dict({"AEVAR": ["", None, "C"]}),
+            False,
+        ),
+        (
+            pd.DataFrame.from_dict({"AEVAR": [None, None, 3]}),
+            False,
+        ),
+        (
+            pd.DataFrame.from_dict({"AEVAR": ["", None]}),
+            True,
+        ),
+        (
+            pd.DataFrame.from_dict({"BCVAR": ["A", "B", "C"]}),
+            None,
+        ),
+    ],
+)
+def test_variable_is_null(data, expected, operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    operation_params.dataframe = data
+    operation_params.target = "--VAR"
+    operation_params.domain = "AE"
+    result = VariableIsNull(
+        operation_params, pd.DataFrame.copy(data), cache, data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        assert val == expected


### PR DESCRIPTION
I deviated slightly from the issue by creating `variable_is_null` instead of `is_not_null` to reduce confusing double negatives.
I renamed the Rule Type from `Define-XML` to `Define Item Metadata Check` to more closely parallel the `Define Item Group Metadata Check`. Currently, no rules existed with the `Define-XML` rule type.
Note that this has been tested for define 2.1, but not define 2.0. Test cases have been added and commented out for define 2.0. Refer to #390 to support define 2.0.

To test, run the test cases.
You can also create a rule using the source issue logic and a define.xml 2.1 file to test the full rule.