### PR TITLE
Deploy tester on push to main

### DIFF
--- a/.github/workflows/rule-tester.yml
+++ b/.github/workflows/rule-tester.yml
@@ -3,6 +3,9 @@
 # Note: the 'AZURE_SP' secret is required to be added into GitHub Secrets. See this blog post for details: https://samlearnsazure.blog/2019/12/13/github-actions/
 name: Deploy Azure Rule Tester Endpoint
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 env:
   ResourceGroup: cdisc-library-shared


### PR DESCRIPTION
This can be tested when PR is merged to main. After merged to main, this action should be triggered automatically:
https://github.com/cdisc-org/cdisc-rules-engine/actions/workflows/rule-tester.yml
Also on that page, there should still be a dropdown to run the workflow manually.