### PR TITLE
Define Cross Check - HasNoData and VariableIsNull

### DIFF
--- a/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
@@ -19,6 +19,7 @@ class DefineVariablesDatasetBuilder(BaseDatasetBuilder):
         "define_variable_allowed_terms",
         "define_variable_origin_type",
         "define_variable_is_collected",
+        "define_variable_has_no_data",
         """
         # get Define XML metadata for domain and use it as a rule comparator
         variable_metadata: List[dict] = self.get_define_xml_variables_metadata()

--- a/cdisc_rules_engine/operations/variable_is_null.py
+++ b/cdisc_rules_engine/operations/variable_is_null.py
@@ -3,8 +3,10 @@ from cdisc_rules_engine.operations.base_operation import BaseOperation
 
 class VariableIsNull(BaseOperation):
     def _execute_operation(self):
+        # Always get the content dataframe. Similar to variable_exists check
+        dataframe = self.data_service.get_dataset(self.params.dataset_path)
         target_variable = self.params.target.replace("--", self.params.domain, 1)
-        if target_variable not in self.params.dataframe:
+        if target_variable not in dataframe:
             return True
-        series = self.params.dataframe[target_variable]
+        series = dataframe[target_variable]
         return series.mask(series == "").isnull().all()

--- a/cdisc_rules_engine/operations/variable_is_null.py
+++ b/cdisc_rules_engine/operations/variable_is_null.py
@@ -1,11 +1,26 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
+import pandas as pd
 
 
 class VariableIsNull(BaseOperation):
     def _execute_operation(self):
         # Always get the content dataframe. Similar to variable_exists check
         dataframe = self.data_service.get_dataset(self.params.dataset_path)
-        target_variable = self.params.target.replace("--", self.params.domain, 1)
+        if self.params.target.startswith("define_variable"):
+            # Handle checks against define metadata
+            target_column = self.params.dataframe[self.params.target]
+            result = [
+                self._is_target_variable_null(dataframe, value)
+                for value in target_column
+            ]
+            return pd.Series(result)
+        else:
+            target_variable = self.params.target.replace("--", self.params.domain, 1)
+            return self._is_target_variable_null(dataframe, target_variable)
+
+    def _is_target_variable_null(
+        self, dataframe: pd.DataFrame, target_variable: str
+    ) -> bool:
         if target_variable not in dataframe:
             return True
         series = dataframe[target_variable]

--- a/cdisc_rules_engine/services/define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml_reader.py
@@ -224,7 +224,7 @@ class DefineXMLReader:
             "define_variable_format": "",
             "define_variable_allowed_terms": [],
             "define_variable_origin_type": "",
-            "define_variable_has_no_data": "No",
+            "define_variable_has_no_data": "",
         }
         if itemdef:
             data["define_variable_name"] = itemdef.Name
@@ -250,7 +250,7 @@ class DefineXMLReader:
                 )
             if itemdef.Origin:
                 data["define_variable_origin_type"] = self._get_origin_type(itemdef)
-            data["define_variable_has_no_data"] = itemref.HasNoData or "No"
+            data["define_variable_has_no_data"] = itemref.HasNoData
 
         return data
 

--- a/cdisc_rules_engine/services/define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml_reader.py
@@ -224,6 +224,7 @@ class DefineXMLReader:
             "define_variable_format": "",
             "define_variable_allowed_terms": [],
             "define_variable_origin_type": "",
+            "define_variable_has_no_data": "No",
         }
         if itemdef:
             data["define_variable_name"] = itemdef.Name
@@ -249,6 +250,7 @@ class DefineXMLReader:
                 )
             if itemdef.Origin:
                 data["define_variable_origin_type"] = self._get_origin_type(itemdef)
+            data["define_variable_has_no_data"] = itemref.HasNoData or "No"
 
         return data
 

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -137,6 +137,28 @@ def test_extract_variable_metadata():
                     assert variable[key] == expected_exroute_metadata[key]
 
 
+def test_extract_variable_metadata_with_has_no_data():
+    """
+    Unit test for DefineXMLReader.extract_domain_metadata function.
+    """
+    with open(test_define_file_path, "rb") as file:
+        contents: bytes = file.read()
+        reader = DefineXMLReader.from_file_contents(contents)
+        variable_metadata: List[dict] = reader.extract_variables_metadata(
+            domain_name="AE"
+        )
+        target_variable = next(
+            iter(
+                [
+                    variable
+                    for variable in variable_metadata
+                    if variable["define_variable_name"] == "AEHLT"
+                ]
+            )
+        )
+        assert target_variable["define_variable_has_no_data"] == "Yes"
+
+
 @pytest.mark.parametrize(
     "define_file_path, domain_name, define_variable_name, expected",
     [

--- a/tests/unit/test_operations/test_variable_is_null.py
+++ b/tests/unit/test_operations/test_variable_is_null.py
@@ -50,3 +50,23 @@ def test_variable_is_null(
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:
         assert val == expected
+
+
+def test_define_crosscheck_variable_is_null(mock_data_service, operation_params):
+    define_metadata = pd.DataFrame.from_dict(
+        {
+            "define_variable_name": ["AEHLT", "AETERM"],
+            "define_variable_has_no_data": ["Yes", "No"],
+        }
+    )
+    dataset = pd.DataFrame.from_dict({"AEHLT": [None, None], "AETERM": [1, 2]})
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    operation_params.dataframe = define_metadata
+    operation_params.target = "define_variable_name"
+    mock_data_service.get_dataset.return_value = dataset
+    result = VariableIsNull(
+        operation_params, pd.DataFrame.copy(define_metadata), cache, mock_data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    assert result[operation_params.operation_id].to_list() == [True, False]

--- a/tests/unit/test_operations/test_variable_is_null.py
+++ b/tests/unit/test_operations/test_variable_is_null.py
@@ -4,9 +4,6 @@ from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
 import pytest
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
-from cdisc_rules_engine.services.data_services.data_service_factory import (
-    DataServiceFactory,
-)
 
 
 @pytest.mark.parametrize(
@@ -38,15 +35,17 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
         ),
     ],
 )
-def test_variable_is_null(data, expected, operation_params: OperationParams):
+def test_variable_is_null(
+    data, expected, mock_data_service, operation_params: OperationParams
+):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
-    data_service = DataServiceFactory(config, cache).get_data_service()
     operation_params.dataframe = data
     operation_params.target = "--VAR"
     operation_params.domain = "AE"
+    mock_data_service.get_dataset.return_value = data
     result = VariableIsNull(
-        operation_params, pd.DataFrame.copy(data), cache, data_service
+        operation_params, pd.DataFrame.copy(data), cache, mock_data_service
     ).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:


### PR DESCRIPTION
… to always get content
This PR adds the following:
* Add HasNoData attribute to variable metadata
* modify variable_is_null operation to always get the dataset contents. And iterate over rows in the case of a define crosscheck

Steps to test:
* Run the unit tests
* Write a rule with the following logic:
```
Rule Type: Define Item Metadata Check
Check:
 name: define_variable_has_no_data
 operator: equal_to
 value: Yes
 name: $variable_is_null
 operator: equal_to
 value: False

Operations:
  - id: $variable_is_null
    name: define_variable_name
    operator: variable_is_null # Return true if at least one record is non null
```
* Test rule with data and a define xml file that has a variable with HasNoData = "Yes", while the provided dataset has data