### PR TITLE
Convert remaining file name manipulation to os file path manipulation

### DIFF
--- a/cdisc_rules_engine/operations/variable_count.py
+++ b/cdisc_rules_engine/operations/variable_count.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import os
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 import asyncio
 from collections import Counter
@@ -34,7 +35,7 @@ class VariableCount(BaseOperation):
     async def _get_dataset_variable_count(self, dataset: dict) -> Counter:
         domain = dataset.get("domain", "")
         data: pd.DataFrame = self.data_service.get_dataset(
-            f"{self.params.directory_path}/{dataset.get('filename')}"
+            os.path.join(self.params.directory_path, dataset.get("filename"))
         )
         target_variable = self.params.target.replace("--", domain, 1)
         return 1 if target_variable in data else 0

--- a/cdisc_rules_engine/operations/variable_value_count.py
+++ b/cdisc_rules_engine/operations/variable_value_count.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 import asyncio
+import os
 from collections import Counter
 from typing import List
 from cdisc_rules_engine.utilities.utils import (
@@ -34,7 +35,7 @@ class VariableValueCount(BaseOperation):
         domain = dataset.get("domain")
         if is_split_dataset(self.params.datasets, domain):
             files = [
-                f"{self.params.directory_path}/{dataset.get('filename')}"
+                os.path.join(self.params.directory_path, dataset.get("filename"))
                 for dataset in get_corresponding_datasets(self.params.datasets, domain)
             ]
             data: pd.DataFrame = self.data_service.join_split_datasets(
@@ -42,7 +43,7 @@ class VariableValueCount(BaseOperation):
             )
         else:
             data: pd.DataFrame = self.data_service.get_dataset(
-                f"{self.params.directory_path}/{dataset.get('filename')}"
+                os.path.join(self.params.directory_path, dataset.get("filename"))
             )
         target_variable = self.params.target.replace("--", domain, 1)
         if target_variable in data:

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -4,7 +4,7 @@ from typing import List, Union
 import pandas as pd
 from business_rules import export_rule_data
 from business_rules.engine import run
-
+import os
 from cdisc_rules_engine.config import config as default_config
 from cdisc_rules_engine.constants.define_xml_constants import DEFINE_XML_FILE_NAME
 from cdisc_rules_engine.dummy_models.dummy_dataset import DummyDataset
@@ -300,7 +300,7 @@ class RulesEngine:
         relationship_data = {}
         if self.rule_processor.is_relationship_dataset(domain):
             relationship_data = self.data_processor.preprocess_relationship_dataset(
-                dataset_path.rsplit("/", 1)[0], dataset, datasets
+                os.path.dirname(dataset_path), dataset, datasets
             )
         dataset_variable = DatasetVariable(
             dataset,

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -331,7 +331,7 @@ class RulesEngine:
         Gets Define XML metadata and returns it as dict.
         """
         directory_path = get_directory_path(dataset_path)
-        define_xml_path: str = f"{directory_path}/{DEFINE_XML_FILE_NAME}"
+        define_xml_path: str = os.path.join(directory_path, DEFINE_XML_FILE_NAME)
         define_xml_contents: bytes = self.data_service.get_define_xml_contents(
             dataset_name=define_xml_path
         )
@@ -364,7 +364,7 @@ class RulesEngine:
         Gets Define XML variable metadata and returns it as dataframe.
         """
         directory_path = get_directory_path(dataset_path)
-        define_xml_path: str = f"{directory_path}/{DEFINE_XML_FILE_NAME}"
+        define_xml_path: str = os.path.join(directory_path, DEFINE_XML_FILE_NAME)
         define_xml_contents: bytes = self.data_service.get_define_xml_contents(
             dataset_name=define_xml_path
         )

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -3,7 +3,7 @@ from abc import ABC
 from functools import wraps, partial
 from typing import Callable, List, Optional, Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
-
+import os
 import numpy as np
 import pandas as pd
 
@@ -176,7 +176,7 @@ class BaseDataService(DataServiceInterface, ABC):
             )
             if domain_details:
                 file_name = domain_details["filename"]
-                new_file_path = f"{directory_path}/{file_name}"
+                new_file_path = os.path.join(directory_path, file_name)
                 new_domain_dataset = self.get_dataset(dataset_name=new_file_path)
             else:
                 raise ValueError("Filename for domain doesn't exist")

--- a/cdisc_rules_engine/utilities/data_processor.py
+++ b/cdisc_rules_engine/utilities/data_processor.py
@@ -15,6 +15,7 @@ from cdisc_rules_engine.services.data_services import (
     DummyDataService,
 )
 from cdisc_rules_engine.utilities.utils import search_in_list_of_dicts
+import os
 
 
 class DataProcessor:
@@ -85,7 +86,7 @@ class DataProcessor:
             datasets, lambda item: item.get("domain") == domain
         )
         if domain_details:
-            data_filename = f"{dataset_path}/{domain_details['filename']}"
+            data_filename = os.path.join(dataset_path, domain_details["filename"])
             new_data = self.data_service.get_dataset(dataset_name=data_filename)
             reference_data[domain] = self.get_columns(new_data, columns)
         return reference_data

--- a/cdisc_rules_engine/utilities/dataset_preprocessor.py
+++ b/cdisc_rules_engine/utilities/dataset_preprocessor.py
@@ -13,6 +13,7 @@ from cdisc_rules_engine.utilities.utils import (
     replace_pattern_in_list_of_strings,
     search_in_list_of_dicts,
 )
+import os
 
 
 class DatasetPreprocessor:
@@ -92,7 +93,7 @@ class DatasetPreprocessor:
 
     def _download_dataset(self, filename: str) -> pd.DataFrame:
         return self._data_service.get_dataset(
-            dataset_name=f'{self._dataset_path.rsplit("/", 1)[0]}/{filename}'
+            dataset_name=os.path.join(os.path.dirname(self._dataset_path), filename)
         )
 
     def _merge_datasets(

--- a/cdisc_rules_engine/utilities/reporting_utilities.py
+++ b/cdisc_rules_engine/utilities/reporting_utilities.py
@@ -15,6 +15,6 @@ def get_define_version(dataset_paths: List[str]) -> Optional[str]:
     path_to_data = os.path.dirname(dataset_paths[0])
     if not path_to_data or DEFINE_XML_FILE_NAME not in os.listdir(path_to_data):
         return None
-    path_to_define = "/".join([path_to_data, DEFINE_XML_FILE_NAME])
+    path_to_define = os.path.join(path_to_data, DEFINE_XML_FILE_NAME)
     define_xml_reader = DefineXMLReader.from_filename(path_to_define)
     return define_xml_reader.get_define_version()

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -98,7 +98,6 @@ def run_validation(args: Validation_args):
     shared_cache = get_cache_service(manager)
     engine_logger.info(f"Populating cache, cache path: {args.cache}")
     shared_cache = fill_cache_with_provided_data(shared_cache, args)
-
     # install dictionaries if needed
     fill_cache_with_dictionaries(shared_cache, args)
     rules = get_rules(shared_cache, args)

--- a/scripts/test_rule.py
+++ b/scripts/test_rule.py
@@ -68,7 +68,10 @@ def validate_single_rule(cache, path, args, datasets, rule: dict = None):
             validated_domains.add(dataset.domain)
             results.append(
                 engine.test_validation(
-                    rule, f"{directory}/{dataset.filename}", datasets, dataset.domain
+                    rule,
+                    os.path.join(directory, dataset.filename),
+                    datasets,
+                    dataset.domain,
                 )
             )
     results = list(itertools.chain(*results))

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch, MagicMock
 
 import pandas as pd
 import pytest
-
+import os
 from cdisc_rules_engine.models.dataset_metadata import DatasetMetadata
 from cdisc_rules_engine.models.dataset_types import DatasetTypes
 from cdisc_rules_engine.services.data_services import cached_dataset, LocalDataService
@@ -125,8 +125,8 @@ def test_get_dataset_class_associated_domains():
     ce_dataset = pd.DataFrame.from_dict({"DOMAIN": ["CE"], "CETERM": ["test"]})
     data_bundle_path = "cdisc/databundle"
     path_to_dataset_map: dict = {
-        f"{data_bundle_path}/ap.xpt": ap_dataset,
-        f"{data_bundle_path}/ce.xpt": ce_dataset,
+        os.path.join(data_bundle_path, "ap.xpt"): ap_dataset,
+        os.path.join(data_bundle_path, "ce.xpt"): ce_dataset,
     }
     with patch(
         "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",

--- a/tests/unit/test_dataset_preprocessor.py
+++ b/tests/unit/test_dataset_preprocessor.py
@@ -1,6 +1,6 @@
 from typing import List
 from unittest.mock import MagicMock, patch
-
+import os
 import pandas as pd
 
 from cdisc_rules_engine.services.cache.in_memory_cache_service import (
@@ -128,8 +128,8 @@ def test_preprocess(mock_get_dataset: MagicMock, dataset_rule_equal_to: dict):
 
     # mock blob storage call
     path_to_dataset_map: dict = {
-        "path/ae.xpt": ae_dataset,
-        "path/ts.xpt": ts_dataset,
+        os.path.join("path", "ae.xpt"): ae_dataset,
+        os.path.join("path", "ts.xpt"): ts_dataset,
     }
     mock_get_dataset.side_effect = lambda dataset_name: path_to_dataset_map[
         dataset_name
@@ -146,7 +146,11 @@ def test_preprocess(mock_get_dataset: MagicMock, dataset_rule_equal_to: dict):
 
     data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     preprocessor = DatasetPreprocessor(
-        ec_dataset, "EC", "path/ec.xpt", data_service, InMemoryCacheService()
+        ec_dataset,
+        "EC",
+        os.path.join("path", "ec.xpt"),
+        data_service,
+        InMemoryCacheService(),
     )
     preprocessed_dataset: pd.DataFrame = preprocessor.preprocess(
         dataset_rule_equal_to, datasets
@@ -259,8 +263,8 @@ def test_preprocess_relationship_dataset(
 
     # mock blob storage call
     path_to_dataset_map: dict = {
-        "path/ec.xpt": ec_dataset,
-        "path/suppec.xpt": suppec_dataset,
+        os.path.join("path", "ec.xpt"): ec_dataset,
+        os.path.join("path", "suppec.xpt"): suppec_dataset,
     }
     mock_get_dataset.side_effect = lambda dataset_name: path_to_dataset_map[
         dataset_name
@@ -280,7 +284,11 @@ def test_preprocess_relationship_dataset(
 
     data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     preprocessor = DatasetPreprocessor(
-        ec_dataset, "EC", "path/ec.xpt", data_service, InMemoryCacheService()
+        ec_dataset,
+        "EC",
+        os.path.join("path", "ec.xpt"),
+        data_service,
+        InMemoryCacheService(),
     )
     preprocessed_dataset: pd.DataFrame = preprocessor.preprocess(
         dataset_rule_record_in_parent_domain_equal_to, datasets
@@ -366,8 +374,8 @@ def test_preprocess_with_merge_comparison(
     )
 
     path_to_dataset_map: dict = {
-        "study_id/data_bundle_id/ae.xpt": match_dataset,
-        "study_id/data_bundle_id/ec.xpt": target_dataset,
+        os.path.join("study_id", "data_bundle_id", "ae.xpt"): match_dataset,
+        os.path.join("study_id", "data_bundle_id", "ec.xpt"): target_dataset,
     }
     mock_get_dataset.side_effect = lambda dataset_name: path_to_dataset_map[
         dataset_name
@@ -377,7 +385,7 @@ def test_preprocess_with_merge_comparison(
     preprocessor = DatasetPreprocessor(
         target_dataset,
         "EC",
-        "study_id/data_bundle_id/ec.xpt",
+        os.path.join("study_id", "data_bundle_id", "ec.xpt"),
         data_service,
         InMemoryCacheService(),
     )

--- a/tests/unit/test_operations/test_variable_count.py
+++ b/tests/unit/test_operations/test_variable_count.py
@@ -4,6 +4,7 @@ from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 import pytest
+import os
 
 
 @pytest.mark.parametrize(
@@ -15,7 +16,7 @@ def test_variable_count(
 ):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
-    dataset_path = "study/bundle/blah"
+    dataset_path = os.path.join("study", "bundle", "blah")
     datasets_map = {
         "AE": pd.DataFrame.from_dict(
             {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
@@ -40,7 +41,7 @@ def test_variable_count(
         {"domain": "AE", "filename": "AE2"},
     ]
     mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
-        name.split("/")[-1]
+        os.path.split(name)[-1]
     )
     mock_data_service.join_split_datasets.side_effect = lambda func, files: pd.concat(
         [func(f) for f in files]

--- a/tests/unit/test_operations/test_variable_value_count.py
+++ b/tests/unit/test_operations/test_variable_value_count.py
@@ -3,6 +3,7 @@ from cdisc_rules_engine.operations.variable_value_count import VariableValueCoun
 from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
 import pytest
+import os
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 
 
@@ -21,7 +22,7 @@ def test_variable_value_count(
 ):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
-    dataset_path = "study/bundle/blah"
+    dataset_path = os.path.join("study", "bundle", "blah")
     datasets_map = {
         "AE": pd.DataFrame.from_dict(
             {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
@@ -40,7 +41,7 @@ def test_variable_value_count(
         {"domain": "AE", "filename": "AE2"},
     ]
     mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
-        name.split("/")[-1]
+        os.path.split(name)[-1]
     )
     mock_data_service.join_split_datasets.side_effect = lambda func, files: pd.concat(
         [func(f) for f in files]

--- a/tests/unit/test_rules_engine.py
+++ b/tests/unit/test_rules_engine.py
@@ -196,8 +196,8 @@ def test_validate_rule_cross_dataset_check(dataset_rule_equal_to: dict):
     )
     # mock blob storage call
     path_to_dataset_map: dict = {
-        "path/ae.xpt": ae_dataset,
-        "path/ec.xpt": ec_dataset,
+        os.path.join("path", "ae.xpt"): ae_dataset,
+        os.path.join("path", "ec.xpt"): ec_dataset,
     }
     with patch(
         "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",
@@ -208,7 +208,7 @@ def test_validate_rule_cross_dataset_check(dataset_rule_equal_to: dict):
             {"domain": "AE", "filename": "ae.xpt"},
         ]
         validation_result: List[str] = RulesEngine().validate_single_rule(
-            dataset_rule_equal_to, "path/ec.xpt", datasets, "EC"
+            dataset_rule_equal_to, os.path.join("path", "ec.xpt"), datasets, "EC"
         )
         assert validation_result == [
             {
@@ -284,15 +284,18 @@ def test_validate_one_to_one_rel_across_datasets(dataset_rule_one_to_one_related
         }
     )
     path_to_dataset_map: dict = {
-        "path/ae.xpt": ae_dataset,
-        "path/ec.xpt": ec_dataset,
+        os.path.join("path", "ae.xpt"): ae_dataset,
+        os.path.join("path", "ec.xpt"): ec_dataset,
     }
     with patch(
         "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",
         side_effect=lambda dataset_name: path_to_dataset_map[dataset_name],
     ):
         validation_result: List[dict] = RulesEngine().validate_single_rule(
-            dataset_rule_one_to_one_related, "path/ec.xpt", datasets, "EC"
+            dataset_rule_one_to_one_related,
+            os.path.join("path", "ec.xpt"),
+            datasets,
+            "EC",
         )
         assert validation_result == [
             {
@@ -1585,8 +1588,8 @@ def test_validate_record_in_parent_domain(
         }
     )
     path_to_dataset_map: dict = {
-        "path/ec.xpt": ec_dataset,
-        "path/suppec.xpt": suppec_dataset,
+        os.path.join("path", "ec.xpt"): ec_dataset,
+        os.path.join("path", "suppec.xpt"): suppec_dataset,
     }
     with patch(
         "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",
@@ -1603,7 +1606,10 @@ def test_validate_record_in_parent_domain(
             },
         ]
         validation_result: List[str] = RulesEngine().validate_single_rule(
-            dataset_rule_record_in_parent_domain_equal_to, "path/ec.xpt", datasets, "EC"
+            dataset_rule_record_in_parent_domain_equal_to,
+            os.path.join("path", "ec.xpt"),
+            datasets,
+            "EC",
         )
         assert validation_result == [
             {

--- a/tests/unit/test_utilities/test_data_processor.py
+++ b/tests/unit/test_utilities/test_data_processor.py
@@ -1,6 +1,6 @@
 from typing import List
 from unittest.mock import patch
-
+import os
 import pandas as pd
 import pytest
 from cdisc_rules_engine.services.cache.in_memory_cache_service import (
@@ -59,10 +59,10 @@ def test_preprocess_relationship_dataset(data):
     )
     dm = pd.DataFrame.from_dict({"USUBJID": [1, 2, 3, 4, 5, 6000]})
     path_to_dataset_map: dict = {
-        "path/ae.xpt": ae,
-        "path/ec.xpt": ec,
-        "path/dm.xpt": dm,
-        "path/data.xpt": data,
+        os.path.join("path", "ae.xpt"): ae,
+        os.path.join("path", "ec.xpt"): ec,
+        os.path.join("path", "dm.xpt"): dm,
+        os.path.join("path", "data.xpt"): data,
     }
     with patch(
         "cdisc_rules_engine.services.data_services.LocalDataService.get_dataset",


### PR DESCRIPTION
Steps to test:

1. Run the unit test
2. Run a validation in both windows and linux using the -d flag and verify the results are the same
3. Run a validation in both windows and linux using the -dp flag and verify the results are the same