### PR TITLE
Support CG0312

### DIFF
--- a/cdisc_rules_engine/enums/rule_types.py
+++ b/cdisc_rules_engine/enums/rule_types.py
@@ -2,32 +2,18 @@ from cdisc_rules_engine.enums.base_enum import BaseEnum
 
 
 class RuleTypes(BaseEnum):
-    RELATIONSHIP_INTEGRITY = "Relationship Integrity Check"
-    VARIABLE_PRESENCE = "Variable Presence"
-    VALUE_PRESENCE = "Value Presence"
-    RANGE_CHECK = "Range & Limit"
-    DATASET_METADATA_CHECK = "Dataset Metadata Check"
-    DATASET_METADATA_CHECK_AGAINST_DEFINE = "Dataset Metadata Check against Define XML"
-    VARIABLE_METADATA_CHECK_AGAINST_DEFINE = (
-        "Variable Metadata Check against Define XML"
-    )
-    VALUE_LEVEL_METADATA_CHECK_AGAINST_DEFINE = (
-        "Value Level Metadata Check against Define XML"
-    )
     DATASET_CONTENTS_CHECK_AGAINST_DEFINE_AND_LIBRARY = (
         "Dataset Contents Check against Define XML and Library Metadata"
     )
-    VARIABLE_METADATA_CHECK = "Variable Metadata Check"
-    DOMAIN_PRESENCE_CHECK = "Domain Presence Check"
-    DATA_PATTERN_AND_FORMAT = "Data Pattern and Format"
-    EXTERNAL_DICTIONARIES = "External Dictionaries"
-    FUNCTIONAL_DEPENDENCY = "Functional Dependency"
-    DATE_ARITHMETIC = "Date Arithmetic"
-    DATA_DOMAIN_AGGREGATION = "Data Domain Aggregation"
-    DEFINE_ITEM_METADATA_CHECK = "Define Item Metadata Check"
+    DATASET_METADATA_CHECK = "Dataset Metadata Check"
+    DATASET_METADATA_CHECK_AGAINST_DEFINE = "Dataset Metadata Check against Define XML"
     DEFINE_ITEM_GROUP_METADATA_CHECK = "Define Item Group Metadata Check"
-    POPULATED_VALUES = "Populated Values"
-    UNIQUENESS = "Uniqueness"
-    VARIABLE_LENGTH = "Variable Length"
-    VARIABLE_ORDER = "Variable Order"
-    CONSISTENCY = "Consistency"
+    DEFINE_ITEM_METADATA_CHECK = "Define Item Metadata Check"
+    DOMAIN_PRESENCE_CHECK = "Domain Presence Check"
+    VALUE_LEVEL_METADATA_CHECK_AGAINST_DEFINE = (
+        "Value Level Metadata Check against Define XML"
+    )
+    VARIABLE_METADATA_CHECK = "Variable Metadata Check"
+    VARIABLE_METADATA_CHECK_AGAINST_DEFINE = (
+        "Variable Metadata Check against Define XML"
+    )

--- a/cdisc_rules_engine/operations/domain_is_custom.py
+++ b/cdisc_rules_engine/operations/domain_is_custom.py
@@ -19,10 +19,8 @@ class DomainIsCustom(BaseOperation):
         standard_data: dict = self.cache.get(cache_key)
         if standard_data is None:
             cdisc_library_service = CDISCLibraryService(config, self.cache)
-            standard_data = set(
-                cdisc_library_service.get_standard(
-                    self.params.standard.lower(), self.params.standard_version
-                )
+            standard_data = cdisc_library_service.get_standard_details(
+                self.params.standard.lower(), self.params.standard_version
             )
-            self.cache.set(cache_key, standard_data)
+            self.cache.add(cache_key, standard_data)
         return self.params.domain not in standard_data.get("domains", {})

--- a/cdisc_rules_engine/operations/domain_is_custom.py
+++ b/cdisc_rules_engine/operations/domain_is_custom.py
@@ -1,0 +1,28 @@
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+)
+from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
+from cdisc_rules_engine import config
+
+
+class DomainIsCustom(BaseOperation):
+    def _execute_operation(self):
+        """
+        Gets standard details from cache and checks if
+        given domain is in standard domains.
+        If no -> the domain is custom.
+        """
+        cache_key = get_standard_details_cache_key(
+            self.params.standard, self.params.standard_version
+        )
+        standard_data: dict = self.cache.get(cache_key)
+        if standard_data is None:
+            cdisc_library_service = CDISCLibraryService(config, self.cache)
+            standard_data = set(
+                cdisc_library_service.get_standard(
+                    self.params.standard.lower(), self.params.standard_version
+                )
+            )
+            self.cache.set(cache_key, standard_data)
+        return self.params.domain not in standard_data.get("domains", {})

--- a/cdisc_rules_engine/operations/domain_label.py
+++ b/cdisc_rules_engine/operations/domain_label.py
@@ -18,12 +18,10 @@ class DomainLabel(BaseOperation):
         standard_data: dict = self.cache.get(cache_key)
         if standard_data is None:
             cdisc_library_service = CDISCLibraryService(config, self.cache)
-            standard_data = set(
-                cdisc_library_service.get_standard(
-                    self.params.standard.lower(), self.params.standard_version
-                )
+            standard_data = cdisc_library_service.get_standard_details(
+                self.params.standard.lower(), self.params.standard_version
             )
-            self.cache.set(cache_key, standard_data)
+            self.cache.add(cache_key, standard_data)
         domain_details = None
         for c in standard_data.get("classes", []):
             domain_details = search_in_list_of_dicts(

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -16,6 +16,7 @@ from cdisc_rules_engine.operations.parent_library_model_column_order import (
 from cdisc_rules_engine.operations.max_date import MaxDate
 from cdisc_rules_engine.operations.maximum import Maximum
 from cdisc_rules_engine.operations.mean import Mean
+from cdisc_rules_engine.operations.domain_is_custom import DomainIsCustom
 from cdisc_rules_engine.operations.domain_label import DomainLabel
 from cdisc_rules_engine.operations.meddra_code_references_validator import (
     MedDRACodeReferencesValidator,
@@ -74,6 +75,7 @@ class OperationsFactory(FactoryInterface):
         "variable_value_count": VariableValueCount,
         "variable_count": VariableCount,
         "variable_is_null": VariableIsNull,
+        "domain_is_custom": DomainIsCustom,
         "domain_label": DomainLabel,
         "required_variables": RequiredVariables,
         "expected_variables": ExpectedVariables,

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -38,7 +38,6 @@ from cdisc_rules_engine.utilities.utils import (
     get_directory_path,
     get_library_variables_metadata_cache_key,
     get_standard_codelist_cache_key,
-    get_standard_details_cache_key,
     is_split_dataset,
     serialize_rule,
 )
@@ -339,23 +338,6 @@ class RulesEngine:
             define_xml_contents, cache_service_obj=self.cache
         )
         return define_xml_reader.extract_domain_metadata(domain_name=domain_name)
-
-    def is_custom_domain(self, domain: str) -> bool:
-        """
-        Gets standard details from cache and checks if
-        given domain is in standard domains.
-        If no -> the domain is custom.
-        """
-        # request standard details from cache
-        standard_details: dict = (
-            self.cache.get(
-                get_standard_details_cache_key(self.standard, self.standard_version)
-            )
-            or {}
-        )
-
-        # check if domain is in standard details
-        return domain not in standard_details.get("domains", {})
 
     def get_define_xml_value_level_metadata(
         self, dataset_path: str, domain_name: str

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -127,7 +127,7 @@ class DummyDataService(BaseDataService):
             with open(dataset_name, "rb") as f:
                 return f.read()
 
-        return bytes(self.define_xml)
+        return self.define_xml.encode()
 
     def has_all_files(self, prefix: str, file_names: List[str]) -> bool:
         return True

--- a/cdisc_rules_engine/services/define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml_reader.py
@@ -218,6 +218,7 @@ class DefineXMLReader:
             "define_variable_name": "",
             "define_variable_label": "",
             "define_variable_data_type": "",
+            "define_variable_is_collected": "",
             "define_variable_role": "",
             "define_variable_size": "",
             "define_variable_ccode": "",
@@ -323,7 +324,7 @@ class DefineXMLReader:
             "define_dataset_location": getattr(metadata.leaf, "href", None),
             "define_dataset_class": str(metadata.Class.Name),
             "define_dataset_structure": str(metadata.Structure),
-            "define_dataset_is_non_standard": str(metadata.IsNonStandard),
+            "define_dataset_is_non_standard": str(metadata.IsNonStandard or ""),
         }
 
     def validate_schema(self) -> bool:

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -70,7 +70,7 @@ def test_extract_domain_metadata():
             "define_dataset_location": "ts.xml",
             "define_dataset_class": "TRIAL DESIGN",
             "define_dataset_structure": "One record per trial summary parameter value",
-            "define_dataset_is_non_standard": "None",
+            "define_dataset_is_non_standard": "",
             "define_dataset_variables": [
                 "STUDYID",
                 "DOMAIN",

--- a/tests/unit/test_operations/test_domain_is_custom.py
+++ b/tests/unit/test_operations/test_domain_is_custom.py
@@ -1,0 +1,89 @@
+import pytest
+import pandas as pd
+
+from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.operations.domain_is_custom import DomainIsCustom
+from cdisc_rules_engine.services.cache import InMemoryCacheService
+from cdisc_rules_engine.services.data_services import LocalDataService
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+)
+
+
+@pytest.mark.parametrize(
+    "dataframe, domain, standard, standard_version, expected",
+    [
+        (
+            pd.DataFrame.from_dict(
+                {
+                    "STUDYID": [
+                        "TEST_STUDY",
+                        "TEST_STUDY",
+                        "TEST_STUDY",
+                    ],
+                    "AETERM": [
+                        "test",
+                        "test",
+                        "test",
+                    ],
+                }
+            ),
+            "AE",
+            "sdtmig",
+            "3-4",
+            False,
+        ),
+        (
+            pd.DataFrame.from_dict(
+                {
+                    "STUDYID": [
+                        "TEST_STUDY",
+                        "TEST_STUDY",
+                        "TEST_STUDY",
+                    ],
+                    "BCTERM": [
+                        "test",
+                        "test",
+                        "test",
+                    ],
+                }
+            ),
+            "BC",
+            "sdtmig",
+            "3-4",
+            True,
+        ),
+    ],
+)
+def test_domain_is_custom(
+    operation_params: OperationParams,
+    dataframe: pd.DataFrame,
+    domain: str,
+    standard: str,
+    standard_version: str,
+    expected: bool,
+):
+    standard_metadata = {
+        "domains": {"AE"},
+    }
+    operation_params.dataframe = dataframe
+    operation_params.domain = domain
+    operation_params.standard = standard
+    operation_params.standard_version = standard_version
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    cache.add(
+        get_standard_details_cache_key(
+            operation_params.standard, operation_params.standard_version
+        ),
+        standard_metadata,
+    )
+    # execute operation
+    data_service = LocalDataService.get_instance(cache_service=cache)
+    operation = DomainIsCustom(
+        operation_params, operation_params.dataframe, cache, data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    assert result[operation_params.operation_id].equals(
+        pd.Series([expected, expected, expected])
+    )

--- a/tests/unit/test_rule_tester/test_rule_tester.py
+++ b/tests/unit/test_rule_tester/test_rule_tester.py
@@ -206,7 +206,7 @@ def test_rule_with_define_xml(define_xml_variable_validation_rule: dict):
         }
     ]
 
-    with open(test_define_file_path, "rb") as file:
+    with open(test_define_file_path, "r") as file:
         contents: bytes = file.read()
         tester = RuleTester(datasets, contents)
         data = tester.validate(define_xml_variable_validation_rule)

--- a/tests/unit/test_rule_tester/test_rule_tester.py
+++ b/tests/unit/test_rule_tester/test_rule_tester.py
@@ -207,7 +207,7 @@ def test_rule_with_define_xml(define_xml_variable_validation_rule: dict):
     ]
 
     with open(test_define_file_path, "r") as file:
-        contents: bytes = file.read()
+        contents: str = file.read()
         tester = RuleTester(datasets, contents)
         data = tester.validate(define_xml_variable_validation_rule)
         assert "AE" in data

--- a/tests/unit/test_rules_engine.py
+++ b/tests/unit/test_rules_engine.py
@@ -2028,31 +2028,6 @@ def test_dataset_references_invalid_whodrug_terms(
     ]
 
 
-def test_is_custom_domain():
-    """
-    Unit test for RulesEngine.is_custom_domain() function.
-    """
-    cache = InMemoryCacheService()
-    standard = "sdtmig"
-    standard_version = "3-1-2"
-    cache_key = get_standard_details_cache_key(standard, standard_version)
-    cache.add(
-        cache_key,
-        {
-            "domains": {
-                "AE",
-                "EC",
-                "DM",
-            }
-        },
-    )
-    engine = RulesEngine(
-        cache=cache, standard=standard, standard_version=standard_version
-    )
-    assert engine.is_custom_domain("AP")
-    assert not engine.is_custom_domain("AE")
-
-
 @patch("cdisc_rules_engine.services.data_services.LocalDataService.get_dataset")
 def test_validate_variables_order_against_library_metadata(
     mock_get_dataset: MagicMock,


### PR DESCRIPTION
Related to editor PR: https://github.com/cdisc-org/conformance-rules-editor/pull/183

You can test by running the modified unit tests. Additionally, you can test the combined functionality with the rule editor. The following test package should yield 3 positive and 1 negative result.

Test data file: [CG0312.xlsx](https://github.com/cdisc-org/cdisc-rules-engine/files/11401405/CG0312.xlsx)
Define xml file: [defineV21-SDTM.xml.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11401406/defineV21-SDTM.xml.txt)
Rule YAML:
```yaml
# Variable: DOMAIN
# Condition: Custom domain present in study
# Rule: DOMAIN not in reserved or modeled standard
Check:
  all:
    - name: define_dataset_is_non_standard
      operator: equal_to
      value: Yes
    - name: $domain_is_custom
      operator: equal_to
      value: false
Operations:
  - id: $domain_is_custom
    operator: domain_is_custom
Core:
  Id: CDISC.SDTMIG.CG0312
  Version: "1"
  Status: Draft
Description:
  Raise an error when custom domains use the reserved or modelled standard
  names
Outcome:
  Message: Custom domains use the reserved or modelled standard names.
Rule Type: Define Item Group Metadata Check
Sensitivity: Dataset
Authorities:
  - Organization: CDISC
    Standards:
      - Name: SDTMIG
        Version: "3.4"
        References:
          - Origin: SDTM and SDTMIG Conformance Rules
            Rule Identifier:
              Id: CG0312
              Version: "1"
            Version: "2.0"
            Citations:
              - Cited Guidance:
                  "'A custom domain may only be created if the data\
                  \ are different in nature and do not fit into an existing published\
                  \ domain.'"
                Document: IG v3.4
                Item: NA
                Section: "2.6"
      - Name: SDTMIG
        Version: "3.2"
        References:
          - Origin: SDTM and SDTMIG Conformance Rules
            Rule Identifier:
              Id: CG0312
              Version: "1"
            Version: "2.0"
            Citations:
              - Cited Guidance:
                  The following standard domains, listed in alphabetical
                  order by Domain Code, with their respective domain codes have been
                  defined or referenced by the CDISC SDS Team in this document. Note
                  that other domain models may be posted separately for comment after
                  this publication. See list in 2.5
                Document: IG v3.2
                Section: "2.5"
      - Name: SDTMIG
        Version: "3.3"
        References:
          - Origin: SDTM and SDTMIG Conformance Rules
            Rule Identifier:
              Id: CG0312
              Version: "1"
            Version: "2.0"
            Citations:
              - Cited Guidance:
                  A custom domain may only be created if the data are
                  different in nature and do not fit into an existing published domain.
                Document: IG v3.3
                Section: "2.6"
Scope:
  Classes:
    Include:
      - ALL
  Domains:
    Include:
      - ALL
Executability: Fully Executable
```