### PR TITLE
Add name and label referenced variable metadata operations

### DIFF
--- a/cdisc_rules_engine/operations/domain_label.py
+++ b/cdisc_rules_engine/operations/domain_label.py
@@ -1,10 +1,7 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
     search_in_list_of_dicts,
 )
-from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
-from cdisc_rules_engine import config
 
 
 class DomainLabel(BaseOperation):
@@ -12,16 +9,7 @@ class DomainLabel(BaseOperation):
         """
         Return the domain label for the currently executing domain
         """
-        cache_key = get_standard_details_cache_key(
-            self.params.standard, self.params.standard_version
-        )
-        standard_data: dict = self.cache.get(cache_key)
-        if standard_data is None:
-            cdisc_library_service = CDISCLibraryService(config, self.cache)
-            standard_data = cdisc_library_service.get_standard_details(
-                self.params.standard.lower(), self.params.standard_version
-            )
-            self.cache.add(cache_key, standard_data)
+        standard_data = self._retrieve_standards_metadata()
         domain_details = None
         for c in standard_data.get("classes", []):
             domain_details = search_in_list_of_dicts(

--- a/cdisc_rules_engine/operations/label_referenced_variable_metadata.py
+++ b/cdisc_rules_engine/operations/label_referenced_variable_metadata.py
@@ -1,0 +1,23 @@
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+import pandas as pd
+
+
+class LabelReferencedVariableMetadata(BaseOperation):
+    def _execute_operation(self):
+        """
+        Generates a dataframe where each record in the dataframe
+        is the variable metadata corresponding with the variable label
+        found in the column provided in self.params.target.
+        """
+        variables_metadata = self._get_variables_metadata_from_standard()
+        df = pd.DataFrame(variables_metadata).add_prefix(f"{self.params.operation_id}_")
+        return (
+            df.merge(
+                self.evaluation_dataset,
+                left_on=f"{self.params.operation_id}_label",
+                right_on=self.params.target,
+                how="right",
+            )
+            .filter(like=self.params.operation_id, axis=1)
+            .fillna("")
+        )

--- a/cdisc_rules_engine/operations/name_referenced_variable_metadata.py
+++ b/cdisc_rules_engine/operations/name_referenced_variable_metadata.py
@@ -1,0 +1,23 @@
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+import pandas as pd
+
+
+class NameReferencedVariableMetadata(BaseOperation):
+    def _execute_operation(self):
+        """
+        Generates a dataframe where each record in the dataframe
+        is the variable metadata corresponding with the variable name
+        found in the column provided in self.params.target.
+        """
+        variables_metadata = self._get_variables_metadata_from_standard()
+        df = pd.DataFrame(variables_metadata).add_prefix(f"{self.params.operation_id}_")
+        return (
+            df.merge(
+                self.evaluation_dataset,
+                left_on=f"{self.params.operation_id}_name",
+                right_on=self.params.target,
+                how="right",
+            )
+            .filter(like=self.params.operation_id, axis=1)
+            .fillna("")
+        )

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -47,6 +47,12 @@ from cdisc_rules_engine.operations.expected_variables import ExpectedVariables
 from cdisc_rules_engine.operations.permissible_variables import PermissibleVariables
 from cdisc_rules_engine.operations.study_domains import StudyDomains
 from cdisc_rules_engine.operations.valid_codelist_dates import ValidCodelistDates
+from cdisc_rules_engine.operations.label_referenced_variable_metadata import (
+    LabelReferencedVariableMetadata,
+)
+from cdisc_rules_engine.operations.name_referenced_variable_metadata import (
+    NameReferencedVariableMetadata,
+)
 
 
 class OperationsFactory(FactoryInterface):
@@ -82,6 +88,8 @@ class OperationsFactory(FactoryInterface):
         "permissible_variables": PermissibleVariables,
         "study_domains": StudyDomains,
         "valid_codelist_dates": ValidCodelistDates,
+        "label_referenced_variable_metadata": LabelReferencedVariableMetadata,
+        "name_referenced_variable_metadata": NameReferencedVariableMetadata,
     }
 
     @classmethod

--- a/tests/unit/test_operations/test_label_referenced_variable_metadata.py
+++ b/tests/unit/test_operations/test_label_referenced_variable_metadata.py
@@ -1,0 +1,131 @@
+import pandas as pd
+from cdisc_rules_engine.constants.classes import GENERAL_OBSERVATIONS_CLASS
+from cdisc_rules_engine.enums.variable_roles import VariableRoles
+from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.operations.label_referenced_variable_metadata import (
+    LabelReferencedVariableMetadata,
+)
+from cdisc_rules_engine.services.cache import InMemoryCacheService
+from cdisc_rules_engine.services.data_services import LocalDataService
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+    get_model_details_cache_key,
+)
+
+
+def test_get_label_referenced_variable_metadata(operation_params: OperationParams):
+    model_metadata = {
+        "datasets": [
+            {
+                "name": "AE",
+                "datasetVariables": [
+                    {
+                        "name": "AETERM",
+                        "ordinal": 4,
+                    },
+                    {
+                        "name": "AESEQ",
+                        "ordinal": 3,
+                    },
+                ],
+            }
+        ],
+        "classes": [
+            {
+                "name": "Events",
+                "classVariables": [
+                    {"name": "--TERM", "ordinal": 1},
+                    {"name": "--SEQ", "ordinal": 2},
+                ],
+            },
+            {
+                "name": GENERAL_OBSERVATIONS_CLASS,
+                "classVariables": [
+                    {
+                        "name": "DOMAIN",
+                        "role": VariableRoles.IDENTIFIER.value,
+                        "ordinal": 2,
+                    },
+                    {
+                        "name": "STUDYID",
+                        "role": VariableRoles.IDENTIFIER.value,
+                        "ordinal": 1,
+                    },
+                    {
+                        "name": "TIMING_VAR",
+                        "role": VariableRoles.TIMING.value,
+                        "ordinal": 33,
+                    },
+                ],
+            },
+        ],
+    }
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1, "label": "TEST AE"},
+                            {"name": "AENEW", "ordinal": 2, "label": "NEW AE"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    operation_params.dataframe = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+            "AELABEL": ["TEST AE", "NEW AE", "TEST A"],
+        }
+    )
+    operation_params.domain = "AE"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+    operation_params.target = "AELABEL"
+    operation_params.operation_id = "$label_referenced_variable"
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    cache.add(
+        get_standard_details_cache_key(
+            operation_params.standard, operation_params.standard_version
+        ),
+        standard_metadata,
+    )
+    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
+    # execute operation
+    data_service = LocalDataService.get_instance(cache_service=cache)
+    operation = LabelReferencedVariableMetadata(
+        operation_params, operation_params.dataframe, cache, data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    expected_columns = [
+        "STUDYID",
+        "AETERM",
+        "AELABEL",
+        "$label_referenced_variable_name",
+        "$label_referenced_variable_role",
+        "$label_referenced_variable_ordinal",
+        "$label_referenced_variable_label",
+    ]
+
+    assert result.columns.to_list() == expected_columns
+    assert result["$label_referenced_variable_name"][0] == "AETEST"
+    assert result["$label_referenced_variable_name"][1] == "AENEW"
+
+    # Check unmatched label in the AELABEL column
+    assert result["$label_referenced_variable_name"][2] == ""

--- a/tests/unit/test_operations/test_name_referenced_variable_metadata.py
+++ b/tests/unit/test_operations/test_name_referenced_variable_metadata.py
@@ -1,0 +1,133 @@
+import pandas as pd
+from cdisc_rules_engine.constants.classes import GENERAL_OBSERVATIONS_CLASS
+from cdisc_rules_engine.enums.variable_roles import VariableRoles
+from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.operations.name_referenced_variable_metadata import (
+    NameReferencedVariableMetadata,
+)
+from cdisc_rules_engine.services.cache import InMemoryCacheService
+from cdisc_rules_engine.services.data_services import LocalDataService
+from cdisc_rules_engine.utilities.utils import (
+    get_standard_details_cache_key,
+    get_model_details_cache_key,
+)
+
+
+def test_get_label_referenced_variable_metadata(operation_params: OperationParams):
+    model_metadata = {
+        "datasets": [
+            {
+                "name": "AE",
+                "datasetVariables": [
+                    {
+                        "name": "AETERM",
+                        "ordinal": 4,
+                    },
+                    {
+                        "name": "AESEQ",
+                        "ordinal": 3,
+                    },
+                ],
+            }
+        ],
+        "classes": [
+            {
+                "name": "Events",
+                "classVariables": [
+                    {"name": "--TERM", "ordinal": 1},
+                    {"name": "--SEQ", "ordinal": 2},
+                ],
+            },
+            {
+                "name": GENERAL_OBSERVATIONS_CLASS,
+                "classVariables": [
+                    {
+                        "name": "DOMAIN",
+                        "role": VariableRoles.IDENTIFIER.value,
+                        "ordinal": 2,
+                    },
+                    {
+                        "name": "STUDYID",
+                        "role": VariableRoles.IDENTIFIER.value,
+                        "ordinal": 1,
+                    },
+                    {
+                        "name": "TIMING_VAR",
+                        "role": VariableRoles.TIMING.value,
+                        "ordinal": 33,
+                    },
+                ],
+            },
+        ],
+    }
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1, "label": "TEST AE"},
+                            {"name": "AENEW", "ordinal": 2, "label": "NEW AE"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    operation_params.dataframe = pd.DataFrame.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+            "AEREF": ["AETEST", "AENEW", "AEUNMATCHED"],
+            "AELABEL": ["TEST AE", "NEW AE", "TEST A"],
+        }
+    )
+    operation_params.domain = "AE"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+    operation_params.target = "AEREF"
+    operation_params.operation_id = "$name_referenced_variable"
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    cache.add(
+        get_standard_details_cache_key(
+            operation_params.standard, operation_params.standard_version
+        ),
+        standard_metadata,
+    )
+    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
+    # execute operation
+    data_service = LocalDataService.get_instance(cache_service=cache)
+    operation = NameReferencedVariableMetadata(
+        operation_params, operation_params.dataframe, cache, data_service
+    )
+    result: pd.DataFrame = operation.execute()
+    expected_columns = [
+        "STUDYID",
+        "AETERM",
+        "AEREF",
+        "AELABEL",
+        "$name_referenced_variable_name",
+        "$name_referenced_variable_role",
+        "$name_referenced_variable_ordinal",
+        "$name_referenced_variable_label",
+    ]
+
+    assert result.columns.to_list() == expected_columns
+    assert result["$name_referenced_variable_label"][0] == "TEST AE"
+    assert result["$name_referenced_variable_label"][1] == "NEW AE"
+
+    # Check unmatched label in the AELABEL column
+    assert result["$name_referenced_variable_label"][2] == ""


### PR DESCRIPTION
This PR adds operations for getting referenced variable metadata from the library based on name or label

Steps to test:

1. Run the unit tests