### PR TITLE
Add list-ct command

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,20 @@ Note: JSON dataset should match the format provided by the rule editor:
 }
 ```
 
+* list-ct - list ct packages available in the cache
+```
+Usage: python core.py list-ct [OPTIONS]
+
+  Command to list the ct packages available in the cache.
+
+Options:
+  -c, --cache_path TEXT  Relative path to cache files containing pre loaded
+                         metadata and rules
+  -s, --subsets TEXT     CT package subset type. Ex: sdtmct. Multiple values
+                         allowed
+  --help                 Show this message and exit.
+```
+
 #### PyPI Quickstart: Validate data within python
 
 An alternative to running the validation from the command line is to instead import the rules engine library in python and run rules against data directly (without needing your data to be in `.xpt` format).

--- a/core.py
+++ b/core.py
@@ -439,6 +439,29 @@ def version():
     print(__version__)
 
 
+@click.command()
+@click.option(
+    "-c",
+    "--cache_path",
+    default=DefaultFilePaths.CACHE.value,
+    help="Relative path to cache files containing pre loaded metadata and rules",
+)
+@click.option(
+    "-s",
+    "--subsets",
+    required=False,
+    multiple=True,
+)
+def list_ct(cache_path: str, subsets: Tuple[str]):
+    if subsets:
+        subsets = set([subset.lower() for subset in subsets])
+
+    for file in os.listdir(cache_path):
+        file_prefix = file.split("-")[0]
+        if file_prefix.endswith("ct") and (not subsets or file_prefix in subsets):
+            print(os.path.splitext(file)[0])
+
+
 cli.add_command(validate)
 cli.add_command(update_cache)
 cli.add_command(list_rules)
@@ -446,6 +469,7 @@ cli.add_command(list_rule_sets)
 cli.add_command(list_dataset_metadata)
 cli.add_command(test)
 cli.add_command(version)
+cli.add_command(list_ct)
 
 if __name__ == "__main__":
     freeze_support()

--- a/core.py
+++ b/core.py
@@ -449,10 +449,14 @@ def version():
 @click.option(
     "-s",
     "--subsets",
+    help="CT package subset type. Ex: sdtmct. Multiple values allowed",
     required=False,
     multiple=True,
 )
 def list_ct(cache_path: str, subsets: Tuple[str]):
+    """
+    Command to list the ct packages available in the cache.
+    """
     if subsets:
         subsets = set([subset.lower() for subset in subsets])
 


### PR DESCRIPTION
Steps to test:

1. Run the command: `python core.py list-ct` and verify all available ct packages are listed
2. Run the command again and specify one or more ct subsets using the `-s` flag. Ex: `-s adamct -s glossaryct`
3. Verify that the only ct subsets shown correspond with the provided -s flag(s)
4. Review the document displayed by running `python core.py list-ct --help`