### PR TITLE
ISS 265: Added define_order_number functionality

### DIFF
--- a/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
@@ -20,6 +20,7 @@ class DefineVariablesDatasetBuilder(BaseDatasetBuilder):
         "define_variable_origin_type",
         "define_variable_is_collected",
         "define_variable_has_no_data",
+        "define_variable_order_number",
         """
         # get Define XML metadata for domain and use it as a rule comparator
         variable_metadata: List[dict] = self.get_define_xml_variables_metadata()

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
@@ -7,7 +7,7 @@ class VariablesMetadataDatasetBuilder(BaseDatasetBuilder):
          Returns the variable metadata from a given file as a dataframe.
          The resulting dataframe has the following columns:
         variable_name
-        variable_order
+        variable_order_number
         variable_label
         variable_size
         variable_data_type

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_dataset_builder.py
@@ -9,7 +9,7 @@ class VariablesMetadataWithDefineDatasetBuilder(BaseDatasetBuilder):
         Returns the variable metadata from a given file.
         Returns a dataframe with the following columns:
         variable_name
-        variable_order
+        variable_order_number
         variable_label
         variable_size
         variable_data_type
@@ -22,6 +22,9 @@ class VariablesMetadataWithDefineDatasetBuilder(BaseDatasetBuilder):
         define_variable_format,
         define_variable_allowed_terms,
         define_variable_origin_type,
+        define_variable_is_collected,
+        define_variable_has_no_data,
+        define_variable_order_number,
 
         """
         # get Define XML metadata for domain and use it as a rule comparator

--- a/cdisc_rules_engine/models/variable_metadata_container.py
+++ b/cdisc_rules_engine/models/variable_metadata_container.py
@@ -14,7 +14,7 @@ class VariableMetadataContainer(RepresentationInterface):
     def to_representation(self) -> dict:
         return {
             "variable_name": self.names,
-            "variable_order": self.order,
+            "variable_order_number": self.order,
             "variable_label": self.labels,
             "variable_size": self.sizes,
             "variable_data_type": self.data_types,

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -81,7 +81,7 @@ class DummyDataService(BaseDataService):
     def get_variables_metadata(self, dataset_name: str, **params) -> pd.DataFrame:
         metadata_to_return = {
             "variable_name": [],
-            "variable_order": [],
+            "variable_order_number": [],
             "variable_label": [],
             "variable_size": [],
             "variable_data_type": [],
@@ -92,8 +92,8 @@ class DummyDataService(BaseDataService):
             metadata_to_return["variable_name"] = metadata_to_return[
                 "variable_name"
             ] + [variable.name]
-            metadata_to_return["variable_order"] = metadata_to_return[
-                "variable_order"
+            metadata_to_return["variable_order_number"] = metadata_to_return[
+                "variable_order_number"
             ] + [i + 1]
             metadata_to_return["variable_label"] = metadata_to_return[
                 "variable_label"

--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -207,6 +207,7 @@ class BaseDefineXMLReader(ABC):
             "define_variable_allowed_terms": [],
             "define_variable_origin_type": "",
             "define_variable_has_no_data": "",
+            "define_variable_order_number": None,
         }
         if itemdef:
             data["define_variable_name"] = itemdef.Name
@@ -233,6 +234,7 @@ class BaseDefineXMLReader(ABC):
             if itemdef.Origin:
                 data["define_variable_origin_type"] = self._get_origin_type(itemdef)
             data["define_variable_has_no_data"] = getattr(itemref, "HasNoData", "")
+            data["define_variable_order_number"] = itemref.OrderNumber
 
         return data
 

--- a/resources/schema/CORE-base.json
+++ b/resources/schema/CORE-base.json
@@ -115,6 +115,38 @@
       },
       "type": "array"
     },
+    "MetaVariables": {
+      "enum": [
+        "dataset_label",
+        "dataset_name",
+        "dataset_size",
+        "define_dataset_class",
+        "define_dataset_is_non_standard",
+        "define_dataset_label",
+        "define_dataset_location",
+        "define_dataset_name",
+        "define_dataset_structure",
+        "define_variable_allowed_terms",
+        "define_variable_ccode",
+        "define_variable_data_type",
+        "define_variable_format",
+        "define_variable_is_collected",
+        "define_variable_label",
+        "define_variable_name",
+        "define_variable_order_number",
+        "define_variable_origin_type",
+        "define_variable_role",
+        "define_variable_size",
+        "filename",
+        "variable_data_type",
+        "variable_format",
+        "variable_label",
+        "variable_name",
+        "variable_order_number",
+        "variable_size"
+      ],
+      "type": "string"
+    },
     "OperationId": {
       "pattern": "^\\$.+$",
       "type": "string"
@@ -149,38 +181,10 @@
               "$ref": "#/$defs/OperationId"
             },
             {
-              "$ref": "#/$defs/VariableName"
+              "$ref": "#/$defs/MetaVariables"
             },
             {
-              "enum": [
-                "dataset_label",
-                "dataset_name",
-                "dataset_size",
-                "define_dataset_class",
-                "define_dataset_is_non_standard",
-                "define_dataset_label",
-                "define_dataset_location",
-                "define_dataset_name",
-                "define_dataset_structure",
-                "define_variable_allowed_terms",
-                "define_variable_ccode",
-                "define_variable_data_type",
-                "define_variable_format",
-                "define_variable_is_collected",
-                "define_variable_label",
-                "define_variable_name",
-                "define_variable_origin_type",
-                "define_variable_role",
-                "define_variable_size",
-                "filename",
-                "variable_data_type",
-                "variable_format",
-                "variable_label",
-                "variable_name",
-                "variable_order",
-                "variable_size"
-              ],
-              "type": "string"
+              "$ref": "#/$defs/VariableName"
             }
           ]
         },
@@ -1024,11 +1028,13 @@
               "get_column_order_from_library",
               "get_model_column_order",
               "get_parent_model_column_order",
+              "label_referenced_variable_metadata",
               "max",
               "max_date",
               "mean",
               "min",
               "min_date",
+              "name_referenced_variable_metadata",
               "permissible_variables",
               "record_count",
               "required_variables",
@@ -1063,14 +1069,7 @@
         },
         "Output Variables": {
           "items": {
-            "oneOf": [
-              {
-                "$ref": "#/$defs/OperationId"
-              },
-              {
-                "$ref": "#/$defs/VariableName"
-              }
-            ]
+            "$ref": "#/$defs/Operator/properties/name"
           },
           "type": "array"
         }

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -131,6 +131,7 @@ def test_extract_variable_metadata():
             "define_variable_allowed_terms": ["Subcutaneous Route of Administration"],
             "define_variable_origin_type": "Predecessor",
             "define_variable_is_collected": False,
+            "define_variable_order_number": 11,
         }
         for variable in variable_metadata:
             assert variable["define_variable_name"] in expected_variables

--- a/tests/unit/test_dummy_data_service.py
+++ b/tests/unit/test_dummy_data_service.py
@@ -136,4 +136,4 @@ def test_get_variables_metadata():
     assert metadata["variable_label"].iloc[0] == "AE Sequence"
     assert metadata["variable_data_type"].iloc[0] == "integer"
     assert metadata["variable_size"].iloc[0] == 5
-    assert metadata["variable_order"].iloc[0] == 1
+    assert metadata["variable_order_number"].iloc[0] == 1

--- a/tests/unit/test_local_data_service.py
+++ b/tests/unit/test_local_data_service.py
@@ -60,7 +60,7 @@ def test_get_variables_metdata():
     expected_keys = [
         "variable_name",
         "variable_format",
-        "variable_order",
+        "variable_order_number",
         "variable_data_type",
         "variable_label",
     ]


### PR DESCRIPTION
To verify:
1. Refer to the updated unit tests
2. Run the rule editor locally against the local rule engine and rule engine branch using these local.settings.json properties:
   - `"RULE_SCHEMA_URL": "https://raw.githubusercontent.com/cdisc-org/cdisc-rules-engine/ISS-265-as-validator-i-want-to-cross-check-study-data-against-that-the-study-definexml-for-mismatching-variable-ordering-so-that-i-can-fix-the-issue/resources/schema/CORE-base.json"`
   - `"EXECUTE_RULE_URL": "http://localhost:`<Rule Engine Port #>`/api/TestRule"`
3. Add the following rule:
```yaml
Check:
  all:
    - name: variable_order_number
      operator: not_equal_to
Core:
  Id: TEST var order vs define
  Version: "1"
  Status: Draft
Rule Type: Variable Metadata Check against Define XML
Description:  Var Order Wrong
Outcome:
  Message: Var Order Wrong
  Output Variables:
    - define_variable_name
    - define_variable_order_number
    - variable_name
    - variable_order_number
Sensitivity: Record
Authorities:
  - Organization: CDISC
    Standards:
      - Name: SDTMIG
        Version: "3.4"
        References:
          - Origin: SDTM and SDTMIG Conformance Rules
            Rule Identifier:
              Id: CG0000
              Version: "1"
            Version: "2.0"
Scope:
  Classes:
    Include:
      - ALL
  Domains:
    Include:
      - ALL
Executability: Fully Executable
```
4. Confirm the rule validates against the schema
5. Confirm the rule produces the expected negative results (7) with the following test data:
   - [CG0312.xlsx](https://github.com/cdisc-org/cdisc-rules-engine/files/11455342/CG0312.xlsx)
   - [defineV21-SDTM.xml.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11455345/defineV21-SDTM.xml.txt)

Results
```json
{
  "TS": [
    {
      "executionStatus": "success",
      "domain": "TS",
      "variables": [
        "define_variable_name",
        "define_variable_order_number",
        "variable_name",
        "variable_order_number"
      ],
      "message": "Var Order Wrong",
      "errors": [
        {
          "value": {
            "define_variable_name": "TSVAL",
            "variable_name": "TSVAL",
            "define_variable_order_number": 6,
            "variable_order_number": 4
          },
          "row": 4
        }
      ]
    }
  ],
  "DI": [
    {
      "executionStatus": "success",
      "domain": "DI",
      "variables": [
        "define_variable_name",
        "define_variable_order_number",
        "variable_name",
        "variable_order_number"
      ],
      "message": "Var Order Wrong",
      "errors": [
        {
          "value": {
            "define_variable_name": "DISEQ",
            "variable_name": "DISEQ",
            "define_variable_order_number": 4,
            "variable_order_number": 3
          },
          "row": 3
        },
        {
          "value": {
            "define_variable_name": "DIVAL",
            "variable_name": "DIVAL",
            "define_variable_order_number": 7,
            "variable_order_number": 4
          },
          "row": 4
        }
      ]
    }
  ],
  "XS": [
    {
      "executionStatus": "success",
      "domain": "XS",
      "variables": [
        "define_variable_name",
        "define_variable_order_number",
        "variable_name",
        "variable_order_number"
      ],
      "message": "Var Order Wrong",
      "errors": [
        {
          "value": {
            "define_variable_name": "XSSEQ",
            "variable_name": "XSSEQ",
            "define_variable_order_number": 5,
            "variable_order_number": 3
          },
          "row": 3
        },
        {
          "value": {
            "define_variable_name": "XSORRES",
            "variable_name": "XSORRES",
            "define_variable_order_number": 9,
            "variable_order_number": 4
          },
          "row": 4
        }
      ]
    }
  ],
  "XX": [
    {
      "executionStatus": "success",
      "domain": "XX",
      "variables": [
        "define_variable_name",
        "define_variable_order_number",
        "variable_name",
        "variable_order_number"
      ],
      "message": "Var Order Wrong",
      "errors": [
        {
          "value": {
            "define_variable_name": "XXSEQ",
            "variable_name": "XXSEQ",
            "define_variable_order_number": 4,
            "variable_order_number": 3
          },
          "row": 3
        },
        {
          "value": {
            "define_variable_name": "XXORRES",
            "variable_name": "XXORRES",
            "define_variable_order_number": 8,
            "variable_order_number": 4
          },
          "row": 4
        }
      ]
    }
  ]
}
```