### PR TITLE
Add operation to get variable's codelist from define

### DIFF
--- a/cdisc_rules_engine/operations/define_variable_codelist.py
+++ b/cdisc_rules_engine/operations/define_variable_codelist.py
@@ -1,0 +1,31 @@
+from cdisc_rules_engine.constants.define_xml_constants import DEFINE_XML_FILE_NAME
+from cdisc_rules_engine.services.define_xml.define_xml_reader_factory import (
+    DefineXMLReaderFactory,
+)
+from .base_operation import BaseOperation
+import os
+
+
+class DefineVariableCodelist(BaseOperation):
+    def _execute_operation(self):
+        """
+        Returns the codelist specified in the define for the specified target variable
+        """
+        define_contents = self.data_service.get_define_xml_contents(
+            dataset_name=os.path.join(self.params.directory_path, DEFINE_XML_FILE_NAME)
+        )
+        define_reader = DefineXMLReaderFactory.from_file_contents(define_contents)
+        variables_metadata = define_reader.extract_variables_metadata(
+            self.params.domain
+        )
+        variable_metadata = next(
+            iter(
+                [
+                    metadata
+                    for metadata in variables_metadata
+                    if metadata["define_variable_name"] == self.params.target
+                ]
+            ),
+            {},
+        )
+        return variable_metadata.get("define_variable_ccode", "")

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -53,6 +53,9 @@ from cdisc_rules_engine.operations.label_referenced_variable_metadata import (
 from cdisc_rules_engine.operations.name_referenced_variable_metadata import (
     NameReferencedVariableMetadata,
 )
+from cdisc_rules_engine.operations.define_variable_codelist import (
+    DefineVariableCodelist,
+)
 
 
 class OperationsFactory(FactoryInterface):
@@ -90,6 +93,7 @@ class OperationsFactory(FactoryInterface):
         "valid_codelist_dates": ValidCodelistDates,
         "label_referenced_variable_metadata": LabelReferencedVariableMetadata,
         "name_referenced_variable_metadata": NameReferencedVariableMetadata,
+        "define_variable_codelist": DefineVariableCodelist,
     }
 
     @classmethod

--- a/resources/schema/CORE-base.json
+++ b/resources/schema/CORE-base.json
@@ -1018,6 +1018,7 @@
           },
           "operator": {
             "enum": [
+              "define_variable_codelist",
               "distinct",
               "domain_is_custom",
               "domain_label",

--- a/tests/resources/define.xml
+++ b/tests/resources/define.xml
@@ -1,0 +1,11789 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="define2-1.xsl"?>
+<!-- ********************************************************************************* -->
+<!-- File: defineV21-MSGv2.xml                                                          -->
+<!-- Author: CDISC MSG v2 Team                                                         -->
+<!-- Description: This is a draft define.xml V2.1.0 document based on the define.xml   -->
+<!--    Metadata provided by the MSG v2 Team                                           -->
+<!--    plus adjustments to comply with the Define-XML Specification Version 2.1.0     -->
+<!-- Release Note(s):                                                                  -->
+<!--  1. The resulting HTML presentation and the availability and usability of         -->
+<!--      functions will vary depending upon which browser application used.           -->
+<!-- ********************************************************************************* -->
+
+
+<ODM 
+  xmlns="http://www.cdisc.org/ns/odm/v1.3" 
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:def="http://www.cdisc.org/ns/def/v2.1"
+
+  ODMVersion="1.3.2"
+  FileOID="www.cdisc.org/StudyMSGv2/1/Define-XML_2.1.0"
+  FileType="Snapshot"
+  CreationDateTime="2021-01-24T17:47:32" AsOfDateTime="2021-01-24T16:59:33"
+  Originator="CDISC MSG Team"
+  SourceSystem="M.Hungria-System"
+  SourceSystemVersion="2.1-A1"
+  def:Context="Other"
+  >
+
+
+  <!-- ******************************************  -->
+  <!-- OID conventions used in this example:       -->
+  <!--    Study                   = STDY.          -->
+  <!--    MetaDataVersion         = MDV.           -->
+  <!--    def:Standard            = STD.           -->
+  <!--    def:ValueListDef        = VL.            -->
+  <!--    def:WhereClauseDef      = WC.            -->
+  <!--    ItemGroupDef            = IG.            -->
+  <!--    ItemDef                 = IT.            -->
+  <!--    CodeList                = CL.            -->
+  <!--    MethodDef               = MT.            -->
+  <!--    def:CommentDef          = COM.           -->
+  <!--    def:leaf, leafID        = LF.            -->
+  <!-- ******************************************  -->
+  
+<Study OID="cdisc.com/CDISCPILOT01">
+  <GlobalVariables>
+    <StudyName>CDISCPILOT01</StudyName>
+    <StudyDescription>Study Data Tabulation Model Metadata Submission Guidelines Sample Study</StudyDescription>
+    <ProtocolName>CDISCPILOT01</ProtocolName>
+  </GlobalVariables>
+  <MetaDataVersion OID="MDV.MSGv2.0.SDTMIG.3.3.SDTM.1.7"
+    Name="Data Definitions for MSGv2.0 SDTM datasets."
+    Description="This metadata version contains only a subset of SDTM domains available in the SDTMIG 3.3. The data contained do not represent the data which would appear together in an actual regulatory submission."
+    def:DefineVersion="2.1.0"
+    def:CommentOID="COM.MDV">
+
+      <!-- ************************************************************************** -->
+      <!-- Standard Definitions                                                       -->
+      <!-- ************************************************************************** -->
+
+  <def:Standards>
+      <def:Standard OID="STD.1" Name="STDTMIG" Type="IG" Version="3.3" Status="Final" def:CommentOID="COM.ST1"/>
+      <def:Standard OID="STD.2_1" Name="SDTMIG-MD" Type="IG" Version="1.1" Status="Final" def:CommentOID="COM.ST2"/>
+      <def:Standard OID="STD.4" Name="CDISC/NCI" Type="CT" PublishingSet="DEFINE-XML" Version="2020-12-18" Status="Final" def:CommentOID="COM.ST4"/>
+      <def:Standard OID="STD.3" Name="CDISC/NCI" Type="CT" PublishingSet="SDTM" Version="2020-12-18" Status="Final" def:CommentOID="COM.ST3"/>
+  </def:Standards>
+
+      <!-- ************************************************************************** -->
+      <!-- Supporting Documents                                                       -->
+      <!-- ************************************************************************** -->
+
+      <def:SupplementalDoc>
+        <def:DocumentRef leafID="LF.csdrg"/>
+      </def:SupplementalDoc>
+
+      <!-- ************************************************************************************************************************ -->
+      <!-- Value List Definitions Section (Required for Supplemental Qualifiers, Optional for other Normalized (Vertical) Datasets) -->
+      <!--       (Note that any definitions not provided at a Value Level will be inherited from the parent item definition)        -->
+      <!-- ************************************************************************************************************************ -->
+
+      <def:ValueListDef OID="VL.AETERM">
+        <ItemRef ItemOID="IT.AE.AETERM.1" OrderNumber="1" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.AETERM1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.AE.AETERM.2" OrderNumber="2" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.AETERM2"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.DSDECOD">
+        <ItemRef ItemOID="IT.DS.DSDECOD.3" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.DSDECOD1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.DS.DSDECOD.4" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.DSDECOD2"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.DSTERM">
+        <ItemRef ItemOID="IT.DS.DSTERM.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.DSTERM1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.DS.DSTERM.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.DSTERM2"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.FAORRES">
+        <ItemRef ItemOID="IT.FA.FAORRES.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.FASEV"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.FA.FAORRES.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.FAOCCUR"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.FASTRESC">
+        <ItemRef ItemOID="IT.FA.FASTRESC.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.FASEV"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.FA.FASTRESC.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.FAOCCUR"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.FTORRES">
+        <ItemRef ItemOID="IT.FT.FTORRES.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.AVL0201-15"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.FT.FTORRES.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.AVL0216-17"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.FT.FTORRES.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.AVL0218-32"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.FT.FTORRES.4" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.AVL0233-34"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.LBORRES">
+        <ItemRef ItemOID="IT.LB.LBORRES.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_SET1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_SET2"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_SET3"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.4" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_SPGRAV"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.5" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_SET4"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.6" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_SET5"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.7" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_SET6"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.8" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_COLOR"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRES.9" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRES_GLUC"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.LBORRESU">
+        <ItemRef ItemOID="IT.LB.LBORRESU.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_ALT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_ALB"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_ALP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.4" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_AST"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.5" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_BASO"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.6" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_BILI"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.7" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_CA"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.8" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_CL"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.9" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_CHOL"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.10" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_CK"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.11" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_CREAT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.12" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_EOS"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.13" OrderNumber="13" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_MCH"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.14" OrderNumber="14" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_MCHC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.15" OrderNumber="15" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_MCV"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.16" OrderNumber="16" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_RBC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.17" OrderNumber="17" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_GGT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.18" OrderNumber="18" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_GLUC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.19" OrderNumber="19" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_HCT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.20" OrderNumber="20" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_HGB"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.21" OrderNumber="21" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_WBC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.22" OrderNumber="22" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_LYM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.23" OrderNumber="23" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_MONO"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.24" OrderNumber="24" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_PHOS"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.25" OrderNumber="25" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_PLAT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.26" OrderNumber="26" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_K"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.27" OrderNumber="27" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_PROT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.28" OrderNumber="28" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_SODIUM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.29" OrderNumber="29" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_TSH"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.30" OrderNumber="30" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_URATE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.31" OrderNumber="31" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_UREAN"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBORRESU.32" OrderNumber="32" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_ORRESU_UNITS_VITB12"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.LBSTRESC">
+        <ItemRef ItemOID="IT.LB.LBSTRESC.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_K"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_RBC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_SET1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.4" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_BILI"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.5" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_SET2"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.6" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_CREAT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.7" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_URATE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.8" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_MCHC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.9" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_SET3"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.10" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_VITB12"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.11" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_HGB"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.12" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_SET4"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.13" OrderNumber="13" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_SET5"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.14" OrderNumber="14" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_SET6"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.15" OrderNumber="15" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_CK"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.16" OrderNumber="16" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_COLOR"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESC.17" OrderNumber="17" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESC_GLUC"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.LBSTRESU">
+        <ItemRef ItemOID="IT.LB.LBSTRESU.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_ALT_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_ALB_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_ALP_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.4" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_AST_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.5" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_BASO_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.6" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_BILI_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.7" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_CA_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.8" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_CL_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.9" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_CHOL_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.10" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_CK_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.11" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_CREAT_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.12" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_EOS_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.13" OrderNumber="13" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_MCH_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.14" OrderNumber="14" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_MCHC_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.15" OrderNumber="15" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_MCV_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.16" OrderNumber="16" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_RBC_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.17" OrderNumber="17" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_GGT_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.18" OrderNumber="18" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_GLUC_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.19" OrderNumber="19" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_HGB_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.20" OrderNumber="20" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_WBC_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.21" OrderNumber="21" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_LYM_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.22" OrderNumber="22" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_MONO_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.23" OrderNumber="23" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_PHOS_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.24" OrderNumber="24" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_PLAT_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.25" OrderNumber="25" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_K_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.26" OrderNumber="26" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_PROT_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.27" OrderNumber="27" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_SODIUM_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.28" OrderNumber="28" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_TSH_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.29" OrderNumber="29" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_URATE_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.30" OrderNumber="30" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_UREAN_STD"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.LB.LBSTRESU.31" OrderNumber="31" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.LB_STRESU_UNITS_VITB12_STD"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.OEORRES">
+        <ItemRef ItemOID="IT.OE.OEORRES.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.OEORRES1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.OE.OEORRES.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.OEORRES2"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.QSORRES_PHQ">
+        <ItemRef ItemOID="IT.QSPH.QSORRES.1" OrderNumber="1" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PHQ0101-09"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QSPH.QSORRES.2" OrderNumber="2" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PHQ0110"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QSPH.QSORRES.3" OrderNumber="3" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PHQ0111"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.QSSTRESC_PHQ">
+        <ItemRef ItemOID="IT.QSPH.QSSTRESC.1" OrderNumber="1" Mandatory="Yes" MethodOID="MT.QSSTRESC_PH">
+          <def:WhereClauseRef WhereClauseOID="WC.PHQ0101-09S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QSPH.QSSTRESC.2" OrderNumber="2" Mandatory="Yes" MethodOID="MT.QSSTRESC_PH_10_11">
+          <def:WhereClauseRef WhereClauseOID="WC.PHQ0110S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.QSPH.QSSTRESC.3" OrderNumber="3" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.PHQ0111S"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.RACE">
+        <ItemRef ItemOID="IT.DM.RACE.1" OrderNumber="1" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.RACE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.DM.RACE.2" OrderNumber="2" Mandatory="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.RACEMULT"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.RSORRES">
+        <ItemRef ItemOID="IT.RS.RSORRES.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD101"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD102"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD103"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.4" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD104"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.5" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD105"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.6" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD106"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.7" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD107"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.8" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD108"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.9" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD109"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.10" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD110"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.11" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD111"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.12" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD112"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.13" OrderNumber="13" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD113"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.14" OrderNumber="14" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD114"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.15" OrderNumber="15" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD115"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.16" OrderNumber="16" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD116A"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.17" OrderNumber="17" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD116B"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.18" OrderNumber="18" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD117"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSORRES.19" OrderNumber="19" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD118"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.RSSTRESC">
+        <ItemRef ItemOID="IT.RS.RSSTRESC.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD101S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD102S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD103S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.4" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD104S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.5" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD105S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.6" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD106S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.7" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD107S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.8" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD108S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.9" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD109S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.10" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD110S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.11" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD111S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.12" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD112S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.13" OrderNumber="13" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD113S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.14" OrderNumber="14" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD114S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.15" OrderNumber="15" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD115S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.16" OrderNumber="16" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD116AS"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.17" OrderNumber="17" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD116BS"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.18" OrderNumber="18" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD117S"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.RS.RSSTRESC.19" OrderNumber="19" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HAMD118S"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPDM">
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.1" OrderNumber="1" Mandatory="Yes"
+         Role="Result Qualifier">
+          <def:WhereClauseRef WhereClauseOID="WC.RACE1"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.2" OrderNumber="2" Mandatory="Yes"
+         Role="Result Qualifier">
+          <def:WhereClauseRef WhereClauseOID="WC.RACE2"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.3" OrderNumber="3" Mandatory="Yes"
+         Role="Result Qualifier">
+          <def:WhereClauseRef WhereClauseOID="WC.RACE3"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.4" OrderNumber="4" Mandatory="Yes"
+         Role="Result Qualifier" def:HasNoData="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.RACE4"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL.5" OrderNumber="5" Mandatory="Yes"
+         Role="Result Qualifier" def:HasNoData="Yes">
+          <def:WhereClauseRef WhereClauseOID="WC.RACE5"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPEC">
+        <ItemRef ItemOID="IT.SUPPEC.QVAL.1" OrderNumber="1" Mandatory="Yes"
+         Role="Variable Qualifier">
+          <def:WhereClauseRef WhereClauseOID="WC.ECREASOC"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPNV">
+        <ItemRef ItemOID="IT.SUPPNV.QVAL.1" OrderNumber="1" Mandatory="Yes"
+         Role="Result Qualifier">
+          <def:WhereClauseRef WhereClauseOID="WC.NVCLSIG"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.SUPPOE">
+        <ItemRef ItemOID="IT.SUPPOE.QVAL.1" OrderNumber="1" Mandatory="No"
+         Role="Result Qualifier">
+          <def:WhereClauseRef WhereClauseOID="WC.OECLSIG"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.TSVAL">
+        <ItemRef ItemOID="IT.TS.TSVAL.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_YN"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_INTEGER"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_DATE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.4" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_FRM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.5" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_FREQ"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.6" OrderNumber="6" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_UNIT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.7" OrderNumber="7" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_COUNTRY"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.8" OrderNumber="8" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_INDIC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.9" OrderNumber="9" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_MODEL"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.10" OrderNumber="10" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_INTTYPE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.11" OrderNumber="11" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_DURATION"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.12" OrderNumber="12" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_OBJPRIM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.13" OrderNumber="13" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_OBJSEC"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.14" OrderNumber="14" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_OUTMSPRI"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.15" OrderNumber="15" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_PCLAS"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.16" OrderNumber="16" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_FLOAT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.17" OrderNumber="17" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_REGID"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.18" OrderNumber="18" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_ROUTE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.19" OrderNumber="19" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_SDTM"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.20" OrderNumber="20" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_SEX"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.21" OrderNumber="21" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_SPONSOR"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.22" OrderNumber="22" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_STOPRULE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.23" OrderNumber="23" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_STYPE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.24" OrderNumber="24" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_BLIND"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.25" OrderNumber="25" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_CONTROL"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.26" OrderNumber="26" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_TDIGRP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.27" OrderNumber="27" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_TINDTP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.28" OrderNumber="28" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_TITLE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.29" OrderNumber="29" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_PHASE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.30" OrderNumber="30" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_TRT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.TS.TSVAL.31" OrderNumber="31" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TS_TTYPE"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.VSORRES">
+        <ItemRef ItemOID="IT.VS.VSORRES.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.BP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HEIGHT"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.PULSE"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.5" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TEMP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRES.6" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.WEIGHT"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.VSORRESU">
+        <ItemRef ItemOID="IT.VS.VSORRESU.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.BP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRESU.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HEIGHTU"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRESU.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.PULSEU"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRESU.5" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TEMPU"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSORRESU.6" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.WEIGHTU"/>
+        </ItemRef>
+      </def:ValueListDef>
+      <def:ValueListDef OID="VL.VSSTRESU">
+        <ItemRef ItemOID="IT.VS.VSSTRESU.1" OrderNumber="1" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.BP"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSSTRESU.2" OrderNumber="2" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.HEIGHTU"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSSTRESU.3" OrderNumber="3" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.PULSEU"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSSTRESU.5" OrderNumber="4" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.TEMPU"/>
+        </ItemRef>
+        <ItemRef ItemOID="IT.VS.VSSTRESU.6" OrderNumber="5" Mandatory="No">
+          <def:WhereClauseRef WhereClauseOID="WC.WEIGHTU"/>
+        </ItemRef>
+      </def:ValueListDef>
+
+
+      <!-- ************************************************************************** -->
+      <!-- WhereClause Definitions Section (Used/Referenced in Value List Definitions) -->
+      <!-- ************************************************************************** -->
+
+      <def:WhereClauseDef OID="WC.AETERM1">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.AE.AETERM">
+          <CheckValue>INJECTION SITE REACTION</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.AETERM2">
+        <RangeCheck Comparator="NE" SoftHard="Soft" def:ItemOID="IT.AE.AETERM">
+          <CheckValue>INJECTION SITE REACTION</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.AVL0201-15">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.FT.FTTESTCD">
+          <CheckValue>AVL0201</CheckValue>
+          <CheckValue>AVL0202</CheckValue>
+          <CheckValue>AVL0203</CheckValue>
+          <CheckValue>AVL0204</CheckValue>
+          <CheckValue>AVL0205</CheckValue>
+          <CheckValue>AVL0206</CheckValue>
+          <CheckValue>AVL0207</CheckValue>
+          <CheckValue>AVL0208</CheckValue>
+          <CheckValue>AVL0209</CheckValue>
+          <CheckValue>AVL0210</CheckValue>
+          <CheckValue>AVL0211</CheckValue>
+          <CheckValue>AVL0212</CheckValue>
+          <CheckValue>AVL0213</CheckValue>
+          <CheckValue>AVL0214</CheckValue>
+          <CheckValue>AVL0215</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.AVL0216-17">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.FT.FTTESTCD">
+          <CheckValue>AVL0216</CheckValue>
+          <CheckValue>AVL0217</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.AVL0218-32">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.FT.FTTESTCD">
+          <CheckValue>AVL0218</CheckValue>
+          <CheckValue>AVL0219</CheckValue>
+          <CheckValue>AVL0220</CheckValue>
+          <CheckValue>AVL0221</CheckValue>
+          <CheckValue>AVL0222</CheckValue>
+          <CheckValue>AVL0223</CheckValue>
+          <CheckValue>AVL0224</CheckValue>
+          <CheckValue>AVL0225</CheckValue>
+          <CheckValue>AVL0226</CheckValue>
+          <CheckValue>AVL0227</CheckValue>
+          <CheckValue>AVL0228</CheckValue>
+          <CheckValue>AVL0229</CheckValue>
+          <CheckValue>AVL0230</CheckValue>
+          <CheckValue>AVL0231</CheckValue>
+          <CheckValue>AVL0232</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.AVL0233-34">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.FT.FTTESTCD">
+          <CheckValue>AVL0233</CheckValue>
+          <CheckValue>AVL0234</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.BP">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>DIABP</CheckValue>
+          <CheckValue>SYSBP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.DSDECOD1">
+        <RangeCheck Comparator="NE" SoftHard="Soft" def:ItemOID="IT.DS.DSSCAT">
+          <CheckValue></CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.DSDECOD2">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.DS.DSSCAT">
+          <CheckValue></CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.DSTERM1">
+        <RangeCheck Comparator="NE" SoftHard="Soft" def:ItemOID="IT.DS.DSSCAT">
+          <CheckValue></CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.DSTERM2">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.DS.DSSCAT">
+          <CheckValue></CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.ECREASOC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.SUPPEC.QNAM">
+          <CheckValue>ECREASOC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.FAOCCUR">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.FA.FATESTCD">
+          <CheckValue>OCCUR</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.FASEV">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.FA.FATESTCD">
+          <CheckValue>SEV</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD101">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD101</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD101S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD101</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD102">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD102</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD102S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD102</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD103">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD103</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD103S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD103</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD104">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD104</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD104S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD104</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD105">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD105</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD105S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD105</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD106">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD106</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD106S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD106</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD107">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD107</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD107S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD107</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD108">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD108</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD108S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD108</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD109">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD109</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD109S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD109</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD110">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD110</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD110S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD110</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD111">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD111</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD111S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD111</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD112">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD112</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD112S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD112</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD113">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD113</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD113S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD113</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD114">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD114</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD114S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD114</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD115">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD115</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD115S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD115</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD116A">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD116A</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD116AS">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD116A</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD116B">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD116B</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD116BS">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD116B</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD117">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD117</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD117S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD117</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD118">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD118</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HAMD118S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.RS.RSTESTCD">
+          <CheckValue>HAMD118</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HEIGHT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>HEIGHT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.HEIGHTU">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>HEIGHT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_ALB">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_ALP">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_ALT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_AST">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>AST</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_BASO">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>BASO</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_BILI">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>BILI</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_CA">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CA</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_CHOL">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CHOL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_CK">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CK</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_CL">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_CREAT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CREAT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_EOS">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>EOS</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_GGT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>GGT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_GLUC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>GLUC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_HCT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>HCT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_HGB">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>HGB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_K">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>K</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_LYM">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>LYM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_MCH">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MCH</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_MCHC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MCHC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_MCV">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MCV</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_MONO">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MONO</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_PHOS">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>PHOS</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_PLAT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>PLAT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_PROT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>PROT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_RBC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>RBC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_SODIUM">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>SODIUM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_TSH">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>TSH</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_URATE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>URATE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_UREAN">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>UREAN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_VITB12">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>VITB12</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRESU_UNITS_WBC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>WBC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_COLOR">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>COLOR</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_GLUC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>GLUC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_SET1">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALB</CheckValue>
+          <CheckValue>BILI</CheckValue>
+          <CheckValue>CA</CheckValue>
+          <CheckValue>CREAT</CheckValue>
+          <CheckValue>K</CheckValue>
+          <CheckValue>PHOS</CheckValue>
+          <CheckValue>PROT</CheckValue>
+          <CheckValue>URATE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_SET2">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>HCT</CheckValue>
+          <CheckValue>HGB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_SET3">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>BASO</CheckValue>
+          <CheckValue>EOS</CheckValue>
+          <CheckValue>LYM</CheckValue>
+          <CheckValue>MONO</CheckValue>
+          <CheckValue>RBC</CheckValue>
+          <CheckValue>TSH</CheckValue>
+          <CheckValue>WBC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_SET4">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ANISO</CheckValue>
+          <CheckValue>KETONES</CheckValue>
+          <CheckValue>MACROCY</CheckValue>
+          <CheckValue>PH</CheckValue>
+          <CheckValue>POIKILO</CheckValue>
+          <CheckValue>UROBIL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_SET5">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALT</CheckValue>
+          <CheckValue>AST</CheckValue>
+          <CheckValue>GGT</CheckValue>
+          <CheckValue>MCH</CheckValue>
+          <CheckValue>MCHC</CheckValue>
+          <CheckValue>MCV</CheckValue>
+          <CheckValue>UREAN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_SET6">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALP</CheckValue>
+          <CheckValue>CHOL</CheckValue>
+          <CheckValue>CK</CheckValue>
+          <CheckValue>CL</CheckValue>
+          <CheckValue>PLAT</CheckValue>
+          <CheckValue>SODIUM</CheckValue>
+          <CheckValue>VITB12</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_ORRES_SPGRAV">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>SPGRAV</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_BILI">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>BILI</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_CK">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CK</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_COLOR">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>COLOR</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_CREAT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CREAT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_GLUC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>GLUC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_HGB">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>HGB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_K">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>K</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_MCHC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MCHC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_RBC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>RBC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_SET1">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>BASO</CheckValue>
+          <CheckValue>EOS</CheckValue>
+          <CheckValue>LYM</CheckValue>
+          <CheckValue>MONO</CheckValue>
+          <CheckValue>RBC</CheckValue>
+          <CheckValue>TSH</CheckValue>
+          <CheckValue>WBC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_SET2">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>SPGRAV</CheckValue>
+          <CheckValue>UREAN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_SET3">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CA</CheckValue>
+          <CheckValue>CHOL</CheckValue>
+          <CheckValue>MCH</CheckValue>
+          <CheckValue>PHOS</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_SET4">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ANISO</CheckValue>
+          <CheckValue>KETONES</CheckValue>
+          <CheckValue>MACROCY</CheckValue>
+          <CheckValue>PH</CheckValue>
+          <CheckValue>POIKILO</CheckValue>
+          <CheckValue>UROBIL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_SET5">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALB</CheckValue>
+          <CheckValue>ALT</CheckValue>
+          <CheckValue>AST</CheckValue>
+          <CheckValue>GGT</CheckValue>
+          <CheckValue>PROT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_SET6">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALP</CheckValue>
+          <CheckValue>CL</CheckValue>
+          <CheckValue>MCV</CheckValue>
+          <CheckValue>PLAT</CheckValue>
+          <CheckValue>SODIUM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_URATE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>URATE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESC_VITB12">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>VITB12</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_ALB_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_ALP_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_ALT_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>ALT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_AST_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>AST</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_BASO_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>BASO</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_BILI_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>BILI</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_CA_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CA</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_CHOL_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CHOL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_CK_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CK</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_CL_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_CREAT_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>CREAT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_EOS_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>EOS</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_GGT_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>GGT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_GLUC_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>GLUC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_HGB_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>HGB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_K_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>K</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_LYM_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>LYM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_MCHC_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MCHC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_MCH_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MCH</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_MCV_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MCV</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_MONO_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>MONO</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_PHOS_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>PHOS</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_PLAT_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>PLAT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_PROT_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>PROT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_RBC_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>RBC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_SODIUM_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>SODIUM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_TSH_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>TSH</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_URATE_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>URATE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_UREAN_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>UREAN</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_VITB12_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>VITB12</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.LB_STRESU_UNITS_WBC_STD">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.LB.LBTESTCD">
+          <CheckValue>WBC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.NVCLSIG">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.SUPPNV.QNAM">
+          <CheckValue>NVCLSIG</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.OECLSIG">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.SUPPOE.QNAM">
+          <CheckValue>OECLSIG</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.OEORRES1">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.OE.OETESTCD">
+          <CheckValue>INTP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.OEORRES2">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.OE.OETESTCD">
+          <CheckValue>ABDETAIL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PHQ0101-09">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.QSPH.QSTESTCD">
+          <CheckValue>PHQ0101</CheckValue>
+          <CheckValue>PHQ0102</CheckValue>
+          <CheckValue>PHQ0103</CheckValue>
+          <CheckValue>PHQ0104</CheckValue>
+          <CheckValue>PHQ0105</CheckValue>
+          <CheckValue>PHQ0106</CheckValue>
+          <CheckValue>PHQ0107</CheckValue>
+          <CheckValue>PHQ0108</CheckValue>
+          <CheckValue>PHQ0109</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PHQ0101-09S">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.QSPH.QSTESTCD">
+          <CheckValue>PHQ0101</CheckValue>
+          <CheckValue>PHQ0102</CheckValue>
+          <CheckValue>PHQ0103</CheckValue>
+          <CheckValue>PHQ0104</CheckValue>
+          <CheckValue>PHQ0105</CheckValue>
+          <CheckValue>PHQ0106</CheckValue>
+          <CheckValue>PHQ0107</CheckValue>
+          <CheckValue>PHQ0108</CheckValue>
+          <CheckValue>PHQ0109</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PHQ0110">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.QSPH.QSTESTCD">
+          <CheckValue>PHQ0110</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PHQ0110S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.QSPH.QSTESTCD">
+          <CheckValue>PHQ0110</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PHQ0111">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.QSPH.QSTESTCD">
+          <CheckValue>PHQ0111</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PHQ0111S">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.QSPH.QSTESTCD">
+          <CheckValue>PHQ0111</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PULSE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>PULSE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.PULSEU">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>PULSE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.RACE">
+        <RangeCheck Comparator="NE" SoftHard="Soft" def:ItemOID="IT.DM.RACE">
+          <CheckValue>MULTIPLE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.RACE1">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM">
+          <CheckValue>RACE1</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.RACE2">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM">
+          <CheckValue>RACE2</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.RACE3">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM">
+          <CheckValue>RACE3</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.RACE4">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM">
+          <CheckValue>RACE4</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.RACE5">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.SUPPDM.QNAM">
+          <CheckValue>RACE5</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.RACEMULT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.DM.RACE">
+          <CheckValue>MULTIPLE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TEMP">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>TEMP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TEMPU">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>TEMP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_BLIND">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TBLIND</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_CONTROL">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TCNTRL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_COUNTRY">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>FCNTRY</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_DATE">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>DCUTDTC</CheckValue>
+          <CheckValue>SENDTC</CheckValue>
+          <CheckValue>SSTDTC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_DURATION">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TS_DURATION</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_FLOAT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TS_FLOAT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_FREQ">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>DOSFRQ</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_FRM">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>DOSFRM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_INDIC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>INDIC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_INTEGER">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>ACTSUB</CheckValue>
+          <CheckValue>AGEMAX</CheckValue>
+          <CheckValue>AGEMIN</CheckValue>
+          <CheckValue>DOSE</CheckValue>
+          <CheckValue>NARMS</CheckValue>
+          <CheckValue>PLANSUB</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_INTTYPE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>INTTYPE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_MODEL">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>INTMODEL</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_OBJPRIM">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>OBJPRIM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_OBJSEC">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>OBJSEC</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_OUTMSPRI">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>OUTMSPRI</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_PCLAS">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>PCLAS</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_PHASE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TPHASE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_REGID">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>REGID</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_ROUTE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>ROUTE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_SDTM">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>SDTIGVER</CheckValue>
+          <CheckValue>SDTMVER</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_SEX">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>SEXPOP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_SPONSOR">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>SPONSOR</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_STOPRULE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>STOPRULE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_STYPE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>STYPE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_TDIGRP">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TDIGRP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_TINDTP">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TINDTP</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_TITLE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TITLE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_TRT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TRT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_TTYPE">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>TTYPE</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_UNIT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>DOSU</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.TS_YN">
+        <RangeCheck Comparator="IN" SoftHard="Soft" def:ItemOID="IT.TS.TSPARMCD">
+          <CheckValue>ADAPT</CheckValue>
+          <CheckValue>ADDON</CheckValue>
+          <CheckValue>HLTSUBJI</CheckValue>
+          <CheckValue>RANDOM</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.WEIGHT">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>WEIGHT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+      <def:WhereClauseDef OID="WC.WEIGHTU">
+        <RangeCheck Comparator="EQ" SoftHard="Soft" def:ItemOID="IT.VS.VSTESTCD">
+          <CheckValue>WEIGHT</CheckValue>
+        </RangeCheck>
+      </def:WhereClauseDef>
+
+
+      <!-- ************************************************************************************ -->
+      <!-- ItemGroupDef Definitions Section (Datasets and and first set of variable properties) -->
+      <!-- ************************************************************************************ -->
+
+      <!-- Dataset Definition (TA) -->
+      <ItemGroupDef OID="IG.TA" Name="TA" Domain="TA"
+        Repeating="No" IsReferenceData="Yes" SASDatasetName="TA"
+        def:Structure="One record per planned Element per Arm"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.TA">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Arms</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.TA.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TA.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TA.ARMCD" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Topic"/>
+        <ItemRef ItemOID="IT.TA.ARM" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.TA.TAETORD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Timing"/>
+        <ItemRef ItemOID="IT.TA.ETCD" Mandatory="Yes" OrderNumber="6" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.TA.ELEMENT" Mandatory="No" OrderNumber="7" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.TA.TABRANCH" Mandatory="No" OrderNumber="8" Role="Rule"/>
+        <ItemRef ItemOID="IT.TA.TATRANS" Mandatory="No" OrderNumber="9" Role="Rule"/>
+        <ItemRef ItemOID="IT.TA.EPOCH" Mandatory="Yes" OrderNumber="10" MethodOID="MT.EPOCH" Role="Timing"/>
+        <def:Class Name="TRIAL DESIGN"/>
+        <def:leaf ID="LF.TA" xlink:href="ta.xml">
+          <def:title>ta.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (TE) -->
+      <ItemGroupDef OID="IG.TE" Name="TE" Domain="TE"
+        Repeating="No" IsReferenceData="Yes" SASDatasetName="TE"
+        def:Structure="One record per planned Element"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.TE">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Elements</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.TE.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TE.ETCD" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Topic"/>
+        <ItemRef ItemOID="IT.TE.ELEMENT" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.TE.TESTRL" Mandatory="Yes" OrderNumber="5" Role="Rule"/>
+        <ItemRef ItemOID="IT.TE.TEENRL" Mandatory="No" OrderNumber="6" Role="Rule"/>
+        <def:Class Name="TRIAL DESIGN"/>
+        <def:leaf ID="LF.TE" xlink:href="te.xml">
+          <def:title>te.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (TI) -->
+      <ItemGroupDef OID="IG.TI" Name="TI" Domain="TI"
+        Repeating="No" IsReferenceData="Yes" SASDatasetName="TI"
+        def:Structure="One record per I/E criterion"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.TI">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Inclusion/Exclusion Criteria</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.TI.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TI.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TI.IETESTCD" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Topic"/>
+        <ItemRef ItemOID="IT.TI.IETEST" Mandatory="Yes" OrderNumber="4" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.TI.IECAT" Mandatory="Yes" OrderNumber="5" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.TI.TIVERS" Mandatory="No" OrderNumber="6" KeySequence="3" Role="Record Qualifier"/>
+        <def:Class Name="TRIAL DESIGN"/>
+        <def:leaf ID="LF.TI" xlink:href="ti.xml">
+          <def:title>ti.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (TS) -->
+      <ItemGroupDef OID="IG.TS" Name="TS" Domain="TS"
+        Repeating="No" IsReferenceData="Yes" SASDatasetName="TS"
+        def:Structure="One record per trial summary parameter value"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.TS">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Summary</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.TS.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TS.TSSEQ" Mandatory="Yes" OrderNumber="3" KeySequence="4" MethodOID="MT.TSSEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TS.TSGRPID" Mandatory="No" OrderNumber="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TS.TSPARMCD" Mandatory="Yes" OrderNumber="5" KeySequence="2" Role="Topic"/>
+        <ItemRef ItemOID="IT.TS.TSPARM" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.TS.TSVAL" Mandatory="No" OrderNumber="7" KeySequence="3" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.TS.TSVALNF" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.TS.TSVALCD" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.TS.TSVCDREF" Mandatory="No" OrderNumber="10" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.TS.TSVCDVER" Mandatory="No" OrderNumber="11" Role="Result Qualifier"/>
+        <def:Class Name="TRIAL DESIGN"/>
+        <def:leaf ID="LF.TS" xlink:href="ts.xml">
+          <def:title>ts.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (TV) -->
+      <ItemGroupDef OID="IG.TV" Name="TV" Domain="TV"
+        Repeating="No" IsReferenceData="Yes" SASDatasetName="TV"
+        def:Structure="One record per planned Visit per Arm"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.TV">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Visits</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.TV.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TV.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.TV.VISITNUM" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Topic"/>
+        <ItemRef ItemOID="IT.TV.VISIT" Mandatory="No" OrderNumber="4" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.TV.ARMCD" Mandatory="No" OrderNumber="5" KeySequence="3" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.TV.TVSTRL" Mandatory="Yes" OrderNumber="6" Role="Rule"/>
+        <ItemRef ItemOID="IT.TV.TVENRL" Mandatory="No" OrderNumber="7" Role="Rule"/>
+        <def:Class Name="TRIAL DESIGN"/>
+        <def:leaf ID="LF.TV" xlink:href="tv.xml">
+          <def:title>tv.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (DM) -->
+      <ItemGroupDef OID="IG.DM" Name="DM" Domain="DM"
+        Repeating="No" IsReferenceData="No" SASDatasetName="DM"
+        def:Structure="One record per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.DM">
+        <Description>
+          <TranslatedText xml:lang="en">Demographics</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.DM.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DM.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DM.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DM.SUBJID" Mandatory="Yes" OrderNumber="4" Role="Topic"/>
+        <ItemRef ItemOID="IT.DM.RFSTDTC" Mandatory="No" OrderNumber="5" MethodOID="MT.RFSTDTC" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.RFENDTC" Mandatory="No" OrderNumber="6" MethodOID="MT.RFENDTC" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.RFXSTDTC" Mandatory="No" OrderNumber="7" MethodOID="MT.RFXSTDTC" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.RFXENDTC" Mandatory="No" OrderNumber="8" MethodOID="MT.RFXENDTC" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.RFICDTC" Mandatory="No" OrderNumber="9" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.RFPENDTC" Mandatory="No" OrderNumber="10" MethodOID="MT.RFPENDTC" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.DTHDTC" Mandatory="No" OrderNumber="11" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.DTHFL" Mandatory="No" OrderNumber="12" MethodOID="MT.DTHFL" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.SITEID" Mandatory="Yes" OrderNumber="13" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.BRTHDTC" Mandatory="No" OrderNumber="14" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.AGE" Mandatory="No" OrderNumber="15" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.AGEU" Mandatory="No" OrderNumber="16" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.DM.SEX" Mandatory="Yes" OrderNumber="17" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.RACE" Mandatory="No" OrderNumber="18" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.ETHNIC" Mandatory="No" OrderNumber="19" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.ARMCD" Mandatory="No" OrderNumber="20" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.ARM" Mandatory="No" OrderNumber="21" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.DM.ACTARMCD" Mandatory="No" OrderNumber="22" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.ACTARM" Mandatory="No" OrderNumber="23" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.DM.ARMNRS" Mandatory="No" OrderNumber="24" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.ACTARMUD" Mandatory="No" OrderNumber="25" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.DM.COUNTRY" Mandatory="Yes" OrderNumber="26" Role="Record Qualifier"/>
+        <def:Class Name="SPECIAL PURPOSE"/>
+        <def:leaf ID="LF.DM" xlink:href="dm.xml">
+          <def:title>dm.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SE) -->
+      <ItemGroupDef OID="IG.SE" Name="SE" Domain="SE"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="SE"
+        def:Structure="One record per actual Element per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.SE">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Elements</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.SE.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SE.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SE.SESEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SE.ETCD" Mandatory="Yes" OrderNumber="5" KeySequence="4" Role="Topic"/>
+        <ItemRef ItemOID="IT.SE.ELEMENT" Mandatory="No" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.SE.EPOCH" Mandatory="No" OrderNumber="7" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.SE.SESTDTC" Mandatory="Yes" OrderNumber="8" KeySequence="3" MethodOID="MT.SESTDTC" Role="Timing"/>
+        <ItemRef ItemOID="IT.SE.SEENDTC" Mandatory="No" OrderNumber="9" MethodOID="MT.SEENDTC" Role="Timing"/>
+        <ItemRef ItemOID="IT.SE.SESTDY" Mandatory="No" OrderNumber="10" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.SE.SEENDY" Mandatory="No" OrderNumber="11" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="SPECIAL PURPOSE"/>
+        <def:leaf ID="LF.SE" xlink:href="se.xml">
+          <def:title>se.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SV) -->
+      <ItemGroupDef OID="IG.SV" Name="SV" Domain="SV"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="SV"
+        def:Structure="One record per actual visit per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.SV">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Visits</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.SV.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SV.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SV.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SV.VISITNUM" Mandatory="Yes" OrderNumber="4" KeySequence="4" Role="Topic"/>
+        <ItemRef ItemOID="IT.SV.VISIT" Mandatory="No" OrderNumber="5" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.SV.SVSTDTC" Mandatory="No" OrderNumber="6" KeySequence="3" MethodOID="MT.SVSTDTC" Role="Timing"/>
+        <ItemRef ItemOID="IT.SV.SVENDTC" Mandatory="No" OrderNumber="7" MethodOID="MT.SVENDTC" Role="Timing"/>
+        <ItemRef ItemOID="IT.SV.SVSTDY" Mandatory="No" OrderNumber="8" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.SV.SVENDY" Mandatory="No" OrderNumber="9" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.SV.SVUPDES" Mandatory="No" OrderNumber="10" Role="Synonym Qualifier"/>
+        <def:Class Name="SPECIAL PURPOSE"/>
+        <def:leaf ID="LF.SV" xlink:href="sv.xml">
+          <def:title>sv.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (CM) -->
+      <ItemGroupDef OID="IG.CM" Name="CM" Domain="CM"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="CM"
+        def:Structure="One record per recorded medication occurrence or constant-dosing interval per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.CM">
+        <Description>
+          <TranslatedText xml:lang="en">Concomitant Medications</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.CM.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.CM.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.CM.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.CM.CMSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.CM.CMTRT" Mandatory="Yes" OrderNumber="5" KeySequence="4" Role="Topic"/>
+        <ItemRef ItemOID="IT.CM.CMINDC" Mandatory="No" OrderNumber="6" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.CM.CMDOSE" Mandatory="No" OrderNumber="7" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.CM.CMDOSU" Mandatory="No" OrderNumber="8" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.CM.CMDOSFRQ" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.CM.CMROUTE" Mandatory="No" OrderNumber="10" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.CM.EPOCH" Mandatory="No" OrderNumber="11" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.CM.CMSTDTC" Mandatory="No" OrderNumber="12" KeySequence="3" Role="Timing"/>
+        <ItemRef ItemOID="IT.CM.CMENDTC" Mandatory="No" OrderNumber="13" Role="Timing"/>
+        <ItemRef ItemOID="IT.CM.CMSTDY" Mandatory="No" OrderNumber="14" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.CM.CMENDY" Mandatory="No" OrderNumber="15" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.CM.CMENRTPT" Mandatory="No" OrderNumber="16" Role="Timing"/>
+        <ItemRef ItemOID="IT.CM.CMENTPT" Mandatory="No" OrderNumber="17" MethodOID="MT.CMENTPT" Role="Timing"/>
+        <def:Class Name="INTERVENTIONS"/>
+        <def:leaf ID="LF.CM" xlink:href="cm.xml">
+          <def:title>cm.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (EC) -->
+      <ItemGroupDef OID="IG.EC" Name="EC" Domain="EC"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="EC"
+        def:Structure="One record per constant-dosing interval per mood per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.EC">
+        <Description>
+          <TranslatedText xml:lang="en">Exposure as Collected</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.EC.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EC.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EC.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EC.SPDEVID" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EC.ECSEQ" Mandatory="Yes" OrderNumber="5" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EC.ECTRT" Mandatory="Yes" OrderNumber="6" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.EC.ECPRESP" Mandatory="Yes" OrderNumber="7" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECOCCUR" Mandatory="Yes" OrderNumber="8" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECDOSE" Mandatory="No" OrderNumber="9" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECDOSU" Mandatory="No" OrderNumber="10" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECDOSFRM" Mandatory="No" OrderNumber="11" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECDOSFRQ" Mandatory="No" OrderNumber="12" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECROUTE" Mandatory="No" OrderNumber="13" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECLOT" Mandatory="No" OrderNumber="14" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECPSTRG" Mandatory="Yes" OrderNumber="15" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.EC.ECPSTRGU" Mandatory="Yes" OrderNumber="16" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EC.EPOCH" Mandatory="No" OrderNumber="17" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.EC.ECSTDTC" Mandatory="No" OrderNumber="18" KeySequence="4" Role="Timing"/>
+        <ItemRef ItemOID="IT.EC.ECENDTC" Mandatory="No" OrderNumber="19" Role="Timing"/>
+        <ItemRef ItemOID="IT.EC.ECSTDY" Mandatory="No" OrderNumber="20" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.EC.ECENDY" Mandatory="No" OrderNumber="21" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="INTERVENTIONS"/>
+        <def:leaf ID="LF.EC" xlink:href="ec.xml">
+          <def:title>ec.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (EX) -->
+      <ItemGroupDef OID="IG.EX" Name="EX" Domain="EX"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="EX"
+        def:Structure="One record per constant dosing interval per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.EX">
+        <Description>
+          <TranslatedText xml:lang="en">Exposure</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.EX.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EX.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EX.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EX.SPDEVID" Mandatory="Yes" OrderNumber="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EX.EXSEQ" Mandatory="Yes" OrderNumber="5" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.EX.EXTRT" Mandatory="Yes" OrderNumber="6" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.EX.EXDOSE" Mandatory="No" OrderNumber="7" MethodOID="MT.EXDOSE" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.EX.EXDOSU" Mandatory="No" OrderNumber="8" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EX.EXDOSFRM" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EX.EXDOSFRQ" Mandatory="No" OrderNumber="10" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EX.EXROUTE" Mandatory="No" OrderNumber="11" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.EX.EXLOT" Mandatory="No" OrderNumber="12" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.EX.EPOCH" Mandatory="No" OrderNumber="13" Role="Timing"/>
+        <ItemRef ItemOID="IT.EX.EXSTDTC" Mandatory="No" OrderNumber="14" KeySequence="4" Role="Timing"/>
+        <ItemRef ItemOID="IT.EX.EXENDTC" Mandatory="No" OrderNumber="15" Role="Timing"/>
+        <ItemRef ItemOID="IT.EX.EXSTDY" Mandatory="No" OrderNumber="16" Role="Timing"/>
+        <ItemRef ItemOID="IT.EX.EXENDY" Mandatory="No" OrderNumber="17" Role="Timing"/>
+        <def:Class Name="INTERVENTIONS"/>
+        <def:leaf ID="LF.EX" xlink:href="ex.xml">
+          <def:title>ex.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (AE) -->
+      <ItemGroupDef OID="IG.AE" Name="AE" Domain="AE"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="AE"
+        def:Structure="One record per adverse event per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.AE">
+        <Description>
+          <TranslatedText xml:lang="en">Adverse Events</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.AE.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.AE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.AE.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.AE.AESEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.AE.AELNKID" Mandatory="No" OrderNumber="5" KeySequence="5" Role="Identifier"/>
+        <ItemRef ItemOID="IT.AE.AETERM" Mandatory="Yes" OrderNumber="6" Role="Topic"/>
+        <ItemRef ItemOID="IT.AE.AELLT" Mandatory="No" OrderNumber="7" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AELLTCD" Mandatory="No" OrderNumber="8" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEDECOD" Mandatory="Yes" OrderNumber="9" KeySequence="3" Role="Synonym Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEPTCD" Mandatory="No" OrderNumber="10" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEHLT" Mandatory="No" OrderNumber="11" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEHLTCD" Mandatory="No" OrderNumber="12" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEHLGT" Mandatory="No" OrderNumber="13" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEHLGTCD" Mandatory="No" OrderNumber="14" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEBODSYS" Mandatory="No" OrderNumber="15" Role="Record Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AEBDSYCD" Mandatory="No" OrderNumber="16" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AESOC" Mandatory="No" OrderNumber="17" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AESOCCD" Mandatory="No" OrderNumber="18" Role="Variable Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.AE.AESEV" Mandatory="No" OrderNumber="19" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AESER" Mandatory="No" OrderNumber="20" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AEACN" Mandatory="No" OrderNumber="21" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AEREL" Mandatory="No" OrderNumber="22" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AEOUT" Mandatory="No" OrderNumber="23" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AESCAN" Mandatory="No" OrderNumber="24" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AESCONG" Mandatory="No" OrderNumber="25" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AESDISAB" Mandatory="No" OrderNumber="26" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AESDTH" Mandatory="No" OrderNumber="27" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AESHOSP" Mandatory="No" OrderNumber="28" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AESLIFE" Mandatory="No" OrderNumber="29" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.AESOD" Mandatory="No" OrderNumber="30" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.AE.EPOCH" Mandatory="No" OrderNumber="31" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.AE.AESTDTC" Mandatory="No" OrderNumber="32" KeySequence="4" Role="Timing"/>
+        <ItemRef ItemOID="IT.AE.AEENDTC" Mandatory="No" OrderNumber="33" Role="Timing"/>
+        <ItemRef ItemOID="IT.AE.AESTDY" Mandatory="No" OrderNumber="34" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.AE.AEENDY" Mandatory="No" OrderNumber="35" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.AE.AEENRTPT" Mandatory="No" OrderNumber="36" Role="Timing"/>
+        <ItemRef ItemOID="IT.AE.AEENTPT" Mandatory="No" OrderNumber="37" MethodOID="MT.AEENTPT" Role="Timing"/>
+        <def:Class Name="EVENTS"/>
+        <def:leaf ID="LF.AE" xlink:href="ae.xml">
+          <def:title>ae.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (DS) -->
+      <ItemGroupDef OID="IG.DS" Name="DS" Domain="DS"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="DS"
+        def:Structure="One record per disposition status or protocol milestone per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.DS">
+        <Description>
+          <TranslatedText xml:lang="en">Disposition</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.DS.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DS.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DS.DSSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DS.DSLNKID" Mandatory="No" OrderNumber="5" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DS.DSTERM" Mandatory="Yes" OrderNumber="6" Role="Topic"/>
+        <ItemRef ItemOID="IT.DS.DSDECOD" Mandatory="Yes" OrderNumber="7" KeySequence="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.DS.DSCAT" Mandatory="No" OrderNumber="8" KeySequence="4" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.DS.DSSCAT" Mandatory="No" OrderNumber="9" KeySequence="5" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.DS.EPOCH" Mandatory="No" OrderNumber="10" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.DS.DSSTDTC" Mandatory="No" OrderNumber="11" KeySequence="3" Role="Timing"/>
+        <ItemRef ItemOID="IT.DS.DSSTDY" Mandatory="No" OrderNumber="12" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="EVENTS"/>
+        <def:leaf ID="LF.DS" xlink:href="ds.xml">
+          <def:title>ds.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (MH) -->
+      <ItemGroupDef OID="IG.MH" Name="MH" Domain="MH"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="MH"
+        def:Structure="One record per medical history event per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.MH">
+        <Description>
+          <TranslatedText xml:lang="en">Medical History</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.MH.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.MH.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.MH.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.MH.MHSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.MH.MHTERM" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.MH.MHEVDTYP" Mandatory="No" OrderNumber="6" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.MH.MHSTDTC" Mandatory="No" OrderNumber="7" KeySequence="4" Role="Timing"/>
+        <ItemRef ItemOID="IT.MH.MHSTDY" Mandatory="No" OrderNumber="8" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="EVENTS"/>
+        <def:leaf ID="LF.MH" xlink:href="mh.xml">
+          <def:title>mh.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (DD) -->
+      <ItemGroupDef OID="IG.DD" Name="DD" Domain="DD"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="DD"
+        def:Structure="One record per death detail per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.DD">
+        <Description>
+          <TranslatedText xml:lang="en">Death Details</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.DD.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DD.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DD.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DD.DDSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DD.DDLNKID" Mandatory="No" OrderNumber="5" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DD.DDTESTCD" Mandatory="Yes" OrderNumber="6" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.DD.DDTEST" Mandatory="Yes" OrderNumber="7" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.DD.DDORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.DD.DDSTRESC" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.DD.EPOCH" Mandatory="No" OrderNumber="10" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.DD.DDDTC" Mandatory="No" OrderNumber="11" Role="Timing"/>
+        <ItemRef ItemOID="IT.DD.DDDY" Mandatory="No" OrderNumber="12" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.DD" xlink:href="dd.xml">
+          <def:title>dd.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (FT) -->
+      <ItemGroupDef OID="IG.FT" Name="FT" Domain="FT"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="FT"
+        def:Structure="One record per functional test finding per timepoint per visit per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.FT">
+        <Description>
+          <TranslatedText xml:lang="en">Functional Tests</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.FT.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FT.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FT.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FT.FTSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FT.FTTESTCD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.FT.FTTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.FT.FTCAT" Mandatory="Yes" OrderNumber="7" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.FT.FTSCAT" Mandatory="Yes" OrderNumber="8" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.FT.FTORRES" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.FT.FTSTRESC" Mandatory="No" OrderNumber="10" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.FT.FTSTRESN" Mandatory="No" OrderNumber="11" MethodOID="MT.FTSTRESN" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.FT.FTLOBXFL" Mandatory="No" OrderNumber="12" MethodOID="MT.LOBXFL" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.FT.FTREPNUM" Mandatory="No" OrderNumber="13" KeySequence="4" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.FT.VISITNUM" Mandatory="No" OrderNumber="14" KeySequence="5" Role="Timing"/>
+        <ItemRef ItemOID="IT.FT.VISIT" Mandatory="No" OrderNumber="15" Role="Timing"/>
+        <ItemRef ItemOID="IT.FT.EPOCH" Mandatory="No" OrderNumber="16" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.FT.FTDTC" Mandatory="No" OrderNumber="17" Role="Timing"/>
+        <ItemRef ItemOID="IT.FT.FTDY" Mandatory="No" OrderNumber="18" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.FT.FTTPT" Mandatory="No" OrderNumber="19" Role="Timing"/>
+        <ItemRef ItemOID="IT.FT.FTTPTNUM" Mandatory="No" OrderNumber="20" Role="Timing"/>
+        <ItemRef ItemOID="IT.FT.FTELTM" Mandatory="No" OrderNumber="21" Role="Timing"/>
+        <ItemRef ItemOID="IT.FT.FTTPTREF" Mandatory="No" OrderNumber="22" Role="Timing"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.FT" xlink:href="ft.xml">
+          <def:title>ft.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (IE) -->
+      <ItemGroupDef OID="IG.IE" Name="IE" Domain="IE"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="IE"
+        def:Structure="One record per inclusion/exclusion criterion not met per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.IE">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Criteria Not Met</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.IE.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.IE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.IE.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.IE.IESEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.IE.IETESTCD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.IE.IETEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.IE.IECAT" Mandatory="Yes" OrderNumber="7" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.IE.IEORRES" Mandatory="Yes" OrderNumber="8" MethodOID="MT.IEORRES" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.IE.IESTRESC" Mandatory="Yes" OrderNumber="9" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.IE.EPOCH" Mandatory="No" OrderNumber="10" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.IE.IEDTC" Mandatory="No" OrderNumber="11" Role="Timing"/>
+        <ItemRef ItemOID="IT.IE.IEDY" Mandatory="No" OrderNumber="12" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.IE" xlink:href="ie.xml">
+          <def:title>ie.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (LB) -->
+      <ItemGroupDef OID="IG.LB" Name="LB" Domain="LB"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="LB"
+        def:Structure="One record per analyte per visit per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.LB">
+        <Description>
+          <TranslatedText xml:lang="en">Laboratory Test Results</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.LB.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.LB.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.LB.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.LB.LBSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.LB.LBTESTCD" Mandatory="Yes" OrderNumber="5" KeySequence="4" Role="Topic"/>
+        <ItemRef ItemOID="IT.LB.LBTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBCAT" Mandatory="No" OrderNumber="7" KeySequence="3" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBORRESU" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBORNRLO" Mandatory="No" OrderNumber="10" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBORNRHI" Mandatory="No" OrderNumber="11" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBSTRESC" Mandatory="No" OrderNumber="12" MethodOID="MT.LBSTRESC" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBSTRESN" Mandatory="No" OrderNumber="13" MethodOID="MT.STRESN" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBSTRESU" Mandatory="No" OrderNumber="14" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBSTNRLO" Mandatory="No" OrderNumber="15" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBSTNRHI" Mandatory="No" OrderNumber="16" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBNRIND" Mandatory="No" OrderNumber="17" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.LB.LBLOBXFL" Mandatory="No" OrderNumber="18" MethodOID="MT.LOBXFL" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.LB.VISITNUM" Mandatory="No" OrderNumber="19" KeySequence="6" Role="Timing"/>
+        <ItemRef ItemOID="IT.LB.VISIT" Mandatory="No" OrderNumber="20" Role="Timing"/>
+        <ItemRef ItemOID="IT.LB.EPOCH" Mandatory="No" OrderNumber="21" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.LB.LBDTC" Mandatory="No" OrderNumber="22" KeySequence="5" Role="Timing"/>
+        <ItemRef ItemOID="IT.LB.LBDY" Mandatory="No" OrderNumber="23" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.LB" xlink:href="lb.xml">
+          <def:title>lb.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (NV) -->
+      <ItemGroupDef OID="IG.NV" Name="NV" Domain="NV"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="NV"
+        def:Structure="One record per finding per visit per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+        def:HasNoData="Yes" def:CommentOID="COM.NV1">
+        <Description>
+          <TranslatedText xml:lang="en">Nervous System Findings</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.NV.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.NV.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.NV.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.NV.NVSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.NV.NVTESTCD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.NV.NVTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.NV.NVORRES" Mandatory="No" OrderNumber="7" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.NV.NVSTRESC" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.NV.VISITNUM" Mandatory="No" OrderNumber="9" KeySequence="4" Role="Timing"/>
+        <ItemRef ItemOID="IT.NV.EPOCH" Mandatory="No" OrderNumber="10" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.NV.NVDTC" Mandatory="No" OrderNumber="11" Role="Timing"/>
+        <ItemRef ItemOID="IT.NV.NVDY" Mandatory="No" OrderNumber="12" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="FINDINGS"/>
+      </ItemGroupDef>
+      <!-- Dataset Definition (OE) -->
+      <ItemGroupDef OID="IG.OE" Name="OE" Domain="OE"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="OE"
+        def:Structure="One record per ophthalmic finding per visit per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.OE">
+        <Description>
+          <TranslatedText xml:lang="en">Ophthalmic Examinations</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.OE.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.OE.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.OE.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.OE.FOCID" Mandatory="No" OrderNumber="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.OE.OESEQ" Mandatory="Yes" OrderNumber="5" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.OE.OETESTCD" Mandatory="Yes" OrderNumber="6" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.OE.OETEST" Mandatory="Yes" OrderNumber="7" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.OE.OEORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.OE.OESTRESC" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.OE.OELOC" Mandatory="No" OrderNumber="10" KeySequence="4" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.OE.OELAT" Mandatory="No" OrderNumber="11" KeySequence="5" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.OE.OEMETHOD" Mandatory="No" OrderNumber="12" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.OE.OELOBXFL" Mandatory="No" OrderNumber="13" MethodOID="MT.LOBXFL" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.OE.VISITNUM" Mandatory="No" OrderNumber="14" KeySequence="6" Role="Timing"/>
+        <ItemRef ItemOID="IT.OE.VISIT" Mandatory="No" OrderNumber="15" Role="Timing"/>
+        <ItemRef ItemOID="IT.OE.EPOCH" Mandatory="No" OrderNumber="16" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.OE.OEDTC" Mandatory="No" OrderNumber="17" Role="Timing"/>
+        <ItemRef ItemOID="IT.OE.OEDY" Mandatory="No" OrderNumber="18" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.OE" xlink:href="oe.xml">
+          <def:title>oe.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (QSPH) -->
+      <ItemGroupDef OID="IG.QSPH" Name="QSPH" Domain="QS"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="QSPH"
+        def:Structure="One record per questionnaire finding per visit per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:CommentOID="COM.QS1" def:ArchiveLocationID="LF.QSPH">
+        <Description>
+          <TranslatedText xml:lang="en">Questionnaires (PHQ-9)</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.QSPH.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.QSPH.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.QSPH.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.QSPH.QSSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.QSPH.QSTESTCD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.QSPH.QSTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.QSPH.QSCAT" Mandatory="Yes" OrderNumber="7" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.QSPH.QSORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.QSPH.QSSTRESC" Mandatory="No" OrderNumber="9" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.QSPH.QSSTRESN" Mandatory="No" OrderNumber="10" MethodOID="MT.QSSTRESN" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.QSPH.QSLOBXFL" Mandatory="No" OrderNumber="11" MethodOID="MT.LOBXFL" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.QSPH.VISITNUM" Mandatory="No" OrderNumber="12" KeySequence="4" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSPH.VISIT" Mandatory="No" OrderNumber="13" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSPH.EPOCH" Mandatory="No" OrderNumber="14" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSPH.QSDTC" Mandatory="No" OrderNumber="15" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSPH.QSDY" Mandatory="No" OrderNumber="16" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSPH.QSEVLINT" Mandatory="No" OrderNumber="17" Role="Timing"/>
+        <Alias Context="DomainDescription" Name="Questionnaires"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.QSPH" xlink:href="qsph.xml">
+          <def:title>qsph.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (QSSL) -->
+      <ItemGroupDef OID="IG.QSSL" Name="QSSL" Domain="QS"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="QSSL"
+        def:Structure="One record per questionnaire finding per visit per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:CommentOID="COM.QS2" def:ArchiveLocationID="LF.QSSL">
+        <Description>
+          <TranslatedText xml:lang="en">Questionnaires (SQLS)</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.QSSL.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.QSSL.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.QSSL.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.QSSL.QSSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.QSSL.QSTESTCD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.QSSL.QSTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.QSSL.QSCAT" Mandatory="Yes" OrderNumber="7" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.QSSL.QSORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.QSSL.QSSTRESC" Mandatory="No" OrderNumber="9" MethodOID="MT.QSSTRESC_SL" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.QSSL.QSSTRESN" Mandatory="No" OrderNumber="10" MethodOID="MT.QSSTRESN" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.QSSL.QSLOBXFL" Mandatory="No" OrderNumber="11" MethodOID="MT.LOBXFL" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.QSSL.VISITNUM" Mandatory="No" OrderNumber="12" KeySequence="4" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSSL.VISIT" Mandatory="No" OrderNumber="13" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSSL.EPOCH" Mandatory="No" OrderNumber="14" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSSL.QSDTC" Mandatory="No" OrderNumber="15" Role="Timing"/>
+        <ItemRef ItemOID="IT.QSSL.QSDY" Mandatory="No" OrderNumber="16" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <Alias Context="DomainDescription" Name="Questionnaires"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.QSSL" xlink:href="qssl.xml">
+          <def:title>qssl.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (RS) -->
+      <ItemGroupDef OID="IG.RS" Name="RS" Domain="RS"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="RS"
+        def:Structure="One record per response assessment or clinical classification assessment per time point per visit per subject per assessor per medical evaluator"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.RS">
+        <Description>
+          <TranslatedText xml:lang="en">Disease Response and Clin Classification</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.RS.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RS.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RS.RSSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RS.RSTESTCD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.RS.RSTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.RS.RSCAT" Mandatory="Yes" OrderNumber="7" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.RS.RSORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.RS.RSSTRESC" Mandatory="No" OrderNumber="9" MethodOID="MT.RSSTRESC" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.RS.RSSTRESN" Mandatory="No" OrderNumber="10" MethodOID="MT.STRESN" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.RS.RSLOBXFL" Mandatory="No" OrderNumber="11" MethodOID="MT.LOBXFL" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.RS.VISITNUM" Mandatory="No" OrderNumber="12" KeySequence="4" Role="Timing"/>
+        <ItemRef ItemOID="IT.RS.VISIT" Mandatory="No" OrderNumber="13" Role="Timing"/>
+        <ItemRef ItemOID="IT.RS.EPOCH" Mandatory="No" OrderNumber="14" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.RS.RSDTC" Mandatory="No" OrderNumber="15" Role="Timing"/>
+        <ItemRef ItemOID="IT.RS.RSDY" Mandatory="No" OrderNumber="16" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <ItemRef ItemOID="IT.RS.RSEVLINT" Mandatory="No" OrderNumber="17" Role="Timing"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.RS" xlink:href="rs.xml">
+          <def:title>rs.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (VS) -->
+      <ItemGroupDef OID="IG.VS" Name="VS" Domain="VS"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="VS"
+        def:Structure="One record per vital sign measurement per visit per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.VS">
+        <Description>
+          <TranslatedText xml:lang="en">Vital Signs</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.VS.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.VS.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.VS.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.VS.VSSEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.VS.VSTESTCD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.VS.VSTEST" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSPOS" Mandatory="No" OrderNumber="7" KeySequence="4" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSORRES" Mandatory="No" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSORRESU" Mandatory="No" OrderNumber="9" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSSTRESC" Mandatory="No" OrderNumber="10" MethodOID="MT.VSSTRESC" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSSTRESN" Mandatory="No" OrderNumber="11" MethodOID="MT.STRESN" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSSTRESU" Mandatory="No" OrderNumber="12" Role="Variable Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSSTAT" Mandatory="No" OrderNumber="13" Role="Record Qualifier" def:HasNoData="Yes"/>
+        <ItemRef ItemOID="IT.VS.VSLOC" Mandatory="No" OrderNumber="14" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSLOBXFL" Mandatory="No" OrderNumber="15" MethodOID="MT.LOBXFL" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VSREPNUM" Mandatory="No" OrderNumber="16" KeySequence="6" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.VS.VISITNUM" Mandatory="No" OrderNumber="17" KeySequence="5" Role="Timing"/>
+        <ItemRef ItemOID="IT.VS.VISIT" Mandatory="No" OrderNumber="18" Role="Timing"/>
+        <ItemRef ItemOID="IT.VS.EPOCH" Mandatory="No" OrderNumber="19" MethodOID="MT.EPOCH" Role="Timing"/>
+        <ItemRef ItemOID="IT.VS.VSDTC" Mandatory="No" OrderNumber="20" Role="Timing"/>
+        <ItemRef ItemOID="IT.VS.VSDY" Mandatory="No" OrderNumber="21" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="FINDINGS"/>
+        <def:leaf ID="LF.VS" xlink:href="vs.xml">
+          <def:title>vs.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (FA) -->
+      <ItemGroupDef OID="IG.FA" Name="FA" Domain="FA"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="FA"
+        def:Structure="One record per finding per object per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:CommentOID="COM.FA2" def:ArchiveLocationID="LF.FA">
+        <Description>
+          <TranslatedText xml:lang="en">Findings About Events or Interventions</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.FA.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FA.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FA.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FA.FASEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.SEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FA.FALNKGRP" Mandatory="No" OrderNumber="5" KeySequence="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.FA.FATESTCD" Mandatory="Yes" OrderNumber="6" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.FA.FATEST" Mandatory="Yes" OrderNumber="7" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.FA.FAOBJ" Mandatory="Yes" OrderNumber="8" KeySequence="5" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.FA.FACAT" Mandatory="No" OrderNumber="9" Role="Grouping Qualifier"/>
+        <ItemRef ItemOID="IT.FA.FAORRES" Mandatory="No" OrderNumber="10" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.FA.FASTRESC" Mandatory="No" OrderNumber="11" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.FA.FALOC" Mandatory="No" OrderNumber="12" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.FA.VISITNUM" Mandatory="No" OrderNumber="13" Role="Timing"/>
+        <ItemRef ItemOID="IT.FA.EPOCH" Mandatory="No" OrderNumber="14" Role="Timing"/>
+        <ItemRef ItemOID="IT.FA.FADTC" Mandatory="No" OrderNumber="15" KeySequence="6" Role="Timing"/>
+        <ItemRef ItemOID="IT.FA.FADY" Mandatory="No" OrderNumber="16" MethodOID="MT.DAYCALC" Role="Timing"/>
+        <def:Class Name="FINDINGS ABOUT"/>
+        <def:leaf ID="LF.FA" xlink:href="fa.xml">
+          <def:title>fa.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (RELREC) -->
+      <ItemGroupDef OID="IG.RELREC" Name="RELREC" Domain="RELREC"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="RELREC"
+        def:Structure="One record per related record, group of records or dataset"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.RELREC">
+        <Description>
+          <TranslatedText xml:lang="en">Related Records</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.RELREC.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RELREC.RDOMAIN" Mandatory="Yes" OrderNumber="2" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RELREC.USUBJID" Mandatory="No" OrderNumber="3" KeySequence="3" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RELREC.IDVAR" Mandatory="Yes" OrderNumber="4" KeySequence="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RELREC.IDVARVAL" Mandatory="No" OrderNumber="5" KeySequence="5" Role="Identifier"/>
+        <ItemRef ItemOID="IT.RELREC.RELTYPE" Mandatory="No" OrderNumber="6" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.RELREC.RELID" Mandatory="Yes" OrderNumber="7" KeySequence="6" Role="Record Qualifier"/>
+        <def:Class Name="RELATIONSHIP"/>
+        <def:leaf ID="LF.RELREC" xlink:href="relrec.xml">
+          <def:title>relrec.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPDM) -->
+      <ItemGroupDef OID="IG.SUPPDM" Name="SUPPDM" Domain="DM"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="SUPPDM"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.SUPPDM">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for DM</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.SUPPDM.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPDM.RDOMAIN" Mandatory="Yes" OrderNumber="2" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPDM.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="3" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPDM.IDVAR" Mandatory="No" OrderNumber="4" KeySequence="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPDM.IDVARVAL" Mandatory="No" OrderNumber="5" KeySequence="5" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPDM.QNAM" Mandatory="Yes" OrderNumber="6" KeySequence="6" Role="Topic"/>
+        <ItemRef ItemOID="IT.SUPPDM.QLABEL" Mandatory="Yes" OrderNumber="7" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPDM.QVAL" Mandatory="Yes" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPDM.QORIG" Mandatory="Yes" OrderNumber="9" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPDM.QEVAL" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+        <Alias Context="DomainDescription" Name="Demographics"/>
+        <def:Class Name="RELATIONSHIP"/>
+        <def:leaf ID="LF.SUPPDM" xlink:href="suppdm.xml">
+          <def:title>suppdm.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPEC) -->
+      <ItemGroupDef OID="IG.SUPPEC" Name="SUPPEC" Domain="EC"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="SUPPEC"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.SUPPEC">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for EC</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.SUPPEC.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPEC.RDOMAIN" Mandatory="Yes" OrderNumber="2" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPEC.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="3" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPEC.IDVAR" Mandatory="No" OrderNumber="4" KeySequence="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPEC.IDVARVAL" Mandatory="No" OrderNumber="5" KeySequence="5" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPEC.QNAM" Mandatory="Yes" OrderNumber="6" KeySequence="6" Role="Topic"/>
+        <ItemRef ItemOID="IT.SUPPEC.QLABEL" Mandatory="Yes" OrderNumber="7" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPEC.QVAL" Mandatory="Yes" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPEC.QORIG" Mandatory="Yes" OrderNumber="9" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPEC.QEVAL" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+        <Alias Context="DomainDescription" Name="Exposure as Collected"/>
+        <def:Class Name="RELATIONSHIP"/>
+        <def:leaf ID="LF.SUPPEC" xlink:href="suppec.xml">
+          <def:title>suppec.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPNV) -->
+      <ItemGroupDef OID="IG.SUPPNV" Name="SUPPNV" Domain="NV"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="SUPPNV"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+        def:HasNoData="Yes" def:CommentOID="COM.NV2">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for NV</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.SUPPNV.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPNV.RDOMAIN" Mandatory="Yes" OrderNumber="2" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPNV.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="3" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPNV.IDVAR" Mandatory="No" OrderNumber="4" KeySequence="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPNV.IDVARVAL" Mandatory="No" OrderNumber="5" KeySequence="5" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPNV.QNAM" Mandatory="Yes" OrderNumber="6" KeySequence="6" Role="Topic"/>
+        <ItemRef ItemOID="IT.SUPPNV.QLABEL" Mandatory="Yes" OrderNumber="7" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPNV.QVAL" Mandatory="Yes" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPNV.QORIG" Mandatory="Yes" OrderNumber="9" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPNV.QEVAL" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+        <Alias Context="DomainDescription" Name="Nervous System Findings"/>
+        <def:Class Name="RELATIONSHIP"/>
+      </ItemGroupDef>
+      <!-- Dataset Definition (SUPPOE) -->
+      <ItemGroupDef OID="IG.SUPPOE" Name="SUPPOE" Domain="OE"
+        Repeating="Yes" IsReferenceData="No" SASDatasetName="SUPPOE"
+        def:Structure="One record per IDVAR, IDVARVAL, and QNAM value per subject"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+        def:HasNoData="Yes" def:CommentOID="COM.OE1">
+        <Description>
+          <TranslatedText xml:lang="en">Supplemental Qualifiers for OE</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.SUPPOE.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPOE.RDOMAIN" Mandatory="Yes" OrderNumber="2" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPOE.USUBJID" Mandatory="Yes" OrderNumber="3" KeySequence="3" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPOE.IDVAR" Mandatory="No" OrderNumber="4" KeySequence="4" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPOE.IDVARVAL" Mandatory="No" OrderNumber="5" KeySequence="5" Role="Identifier"/>
+        <ItemRef ItemOID="IT.SUPPOE.QNAM" Mandatory="Yes" OrderNumber="6" KeySequence="6" Role="Topic"/>
+        <ItemRef ItemOID="IT.SUPPOE.QLABEL" Mandatory="Yes" OrderNumber="7" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPOE.QVAL" Mandatory="Yes" OrderNumber="8" Role="Result Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPOE.QORIG" Mandatory="Yes" OrderNumber="9" Role="Record Qualifier"/>
+        <ItemRef ItemOID="IT.SUPPOE.QEVAL" Mandatory="No" OrderNumber="10" Role="Record Qualifier"/>
+        <Alias Context="DomainDescription" Name="Ophthalmic Examinations"/>
+        <def:Class Name="RELATIONSHIP"/>
+      </ItemGroupDef>
+      <!-- Dataset Definition (DI) -->
+      <ItemGroupDef OID="IG.DI" Name="DI" Domain="DI"
+        Repeating="No" IsReferenceData="Yes" SASDatasetName="DI"
+        def:Structure="One record per device identifier per device"
+        Purpose="Tabulation" def:StandardOID="STD.1"
+ def:ArchiveLocationID="LF.DI">
+        <Description>
+          <TranslatedText xml:lang="en">Device Identifiers</TranslatedText>
+        </Description>
+        <ItemRef ItemOID="IT.DI.STUDYID" Mandatory="Yes" OrderNumber="1" KeySequence="1" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DI.DOMAIN" Mandatory="Yes" OrderNumber="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DI.SPDEVID" Mandatory="Yes" OrderNumber="3" KeySequence="2" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DI.DISEQ" Mandatory="Yes" OrderNumber="4" MethodOID="MT.DISEQ" Role="Identifier"/>
+        <ItemRef ItemOID="IT.DI.DIPARMCD" Mandatory="Yes" OrderNumber="5" KeySequence="3" Role="Topic"/>
+        <ItemRef ItemOID="IT.DI.DIPARM" Mandatory="Yes" OrderNumber="6" Role="Synonym Qualifier"/>
+        <ItemRef ItemOID="IT.DI.DIVAL" Mandatory="Yes" OrderNumber="7" Role="Result Qualifier"/>
+        <def:Class Name="STUDY REFERENCE"/>
+        <def:leaf ID="LF.DI" xlink:href="di.xml">
+          <def:title>di.xml</def:title>
+        </def:leaf>
+      </ItemGroupDef>
+
+
+      <!-- **************************************************************************** -->
+      <!-- ItemDef Definitions Section (Variables and Value List, remaining properties) -->
+      <!-- **************************************************************************** -->
+
+      <ItemDef OID="IT.AE.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_AE"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESEQ" Name="AESEQ" DataType="integer" Length="3" SASFieldName="AESEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AELNKID" Name="AELNKID" DataType="text" Length="50" SASFieldName="AELNKID">
+        <Description>
+          <TranslatedText xml:lang="en">Link ID</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AETERM" Name="AETERM" DataType="text" Length="200" SASFieldName="AETERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Adverse Event</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.AETERM"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AELLT" Name="AELLT" DataType="text" Length="1" SASFieldName="AELLT"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">Lowest Level Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AELLTCD" Name="AELLTCD" DataType="text" Length="1" SASFieldName="AELLTCD"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">Lowest Level Term Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEDECOD" Name="AEDECOD" DataType="text" Length="1" SASFieldName="AEDECOD"
+        def:CommentOID="COM.AEDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">Dictionary-Derived Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEPTCD" Name="AEPTCD" DataType="text" Length="1" SASFieldName="AEPTCD"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">Preferred Term Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEHLT" Name="AEHLT" DataType="text" Length="1" SASFieldName="AEHLT"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">High Level Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEHLTCD" Name="AEHLTCD" DataType="text" Length="1" SASFieldName="AEHLTCD"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">High Level Term Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEHLGT" Name="AEHLGT" DataType="text" Length="1" SASFieldName="AEHLGT"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">High Level Group Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEHLGTCD" Name="AEHLGTCD" DataType="text" Length="1" SASFieldName="AEHLGTCD"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">High Level Group Term Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEBODSYS" Name="AEBODSYS" DataType="text" Length="1" SASFieldName="AEBODSYS"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">Body System or Organ Class</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEBDSYCD" Name="AEBDSYCD" DataType="text" Length="1" SASFieldName="AEBDSYCD"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">Body System or Organ Class Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESOC" Name="AESOC" DataType="text" Length="1" SASFieldName="AESOC"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">Primary System Organ Class</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESOCCD" Name="AESOCCD" DataType="text" Length="1" SASFieldName="AESOCCD"
+        def:CommentOID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">Primary System Organ Class Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MEDDRA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESEV" Name="AESEV" DataType="text" Length="8" SASFieldName="AESEV">
+        <Description>
+          <TranslatedText xml:lang="en">Severity/Intensity</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AESEV"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESER" Name="AESER" DataType="text" Length="1" SASFieldName="AESER"
+        def:CommentOID="COM.AESER">
+        <Description>
+          <TranslatedText xml:lang="en">Serious Event</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEACN" Name="AEACN" DataType="text" Length="16" SASFieldName="AEACN">
+        <Description>
+          <TranslatedText xml:lang="en">Action Taken with Study Treatment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ACN"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEREL" Name="AEREL" DataType="text" Length="16" SASFieldName="AEREL">
+        <Description>
+          <TranslatedText xml:lang="en">Causality</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AEREL"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEOUT" Name="AEOUT" DataType="text" Length="32" SASFieldName="AEOUT">
+        <Description>
+          <TranslatedText xml:lang="en">Outcome of Adverse Event</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.OUT"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESCAN" Name="AESCAN" DataType="text" Length="1" SASFieldName="AESCAN">
+        <Description>
+          <TranslatedText xml:lang="en">Involves Cancer</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESCONG" Name="AESCONG" DataType="text" Length="1" SASFieldName="AESCONG">
+        <Description>
+          <TranslatedText xml:lang="en">Congenital Anomaly or Birth Defect</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESDISAB" Name="AESDISAB" DataType="text" Length="1" SASFieldName="AESDISAB">
+        <Description>
+          <TranslatedText xml:lang="en">Persist or Signif Disability/Incapacity</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESDTH" Name="AESDTH" DataType="text" Length="1" SASFieldName="AESDTH">
+        <Description>
+          <TranslatedText xml:lang="en">Results in Death</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESHOSP" Name="AESHOSP" DataType="text" Length="1" SASFieldName="AESHOSP">
+        <Description>
+          <TranslatedText xml:lang="en">Requires or Prolongs Hospitalization</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESLIFE" Name="AESLIFE" DataType="text" Length="1" SASFieldName="AESLIFE">
+        <Description>
+          <TranslatedText xml:lang="en">Is Life Threatening</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESOD" Name="AESOD" DataType="text" Length="1" SASFieldName="AESOD">
+        <Description>
+          <TranslatedText xml:lang="en">Occurred with Overdose</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESTDTC" Name="AESTDTC" DataType="date" SASFieldName="AESTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEENDTC" Name="AEENDTC" DataType="date" SASFieldName="AEENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AESTDY" Name="AESTDY" DataType="integer" Length="8" SASFieldName="AESTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEENDY" Name="AEENDY" DataType="integer" Length="8" SASFieldName="AEENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEENRTPT" Name="AEENRTPT" DataType="text" Length="7" SASFieldName="AEENRTPT">
+        <Description>
+          <TranslatedText xml:lang="en">End Relative to Reference Time Point</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ENRTPT_CM_AE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22 23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AEENTPT" Name="AEENTPT" DataType="date" SASFieldName="AEENTPT">
+        <Description>
+          <TranslatedText xml:lang="en">End Reference Time Point</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_CM"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMSEQ" Name="CMSEQ" DataType="integer" Length="3" SASFieldName="CMSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMTRT" Name="CMTRT" DataType="text" Length="200" SASFieldName="CMTRT">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Name of Drug, Med, or Therapy</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMINDC" Name="CMINDC" DataType="text" Length="200" SASFieldName="CMINDC"
+        def:CommentOID="COM.CMINDC">
+        <Description>
+          <TranslatedText xml:lang="en">Indication</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMDOSE" Name="CMDOSE" DataType="float" Length="5" SignificantDigits="3" SASFieldName="CMDOSE">
+        <Description>
+          <TranslatedText xml:lang="en">Dose per Administration</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMDOSU" Name="CMDOSU" DataType="text" Length="6" SASFieldName="CMDOSU">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_CM"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMDOSFRQ" Name="CMDOSFRQ" DataType="text" Length="3" SASFieldName="CMDOSFRQ">
+        <Description>
+          <TranslatedText xml:lang="en">Dosing Frequency per Interval</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FREQ_CM"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMROUTE" Name="CMROUTE" DataType="text" Length="24" SASFieldName="CMROUTE">
+        <Description>
+          <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ROUTE_CM"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMSTDTC" Name="CMSTDTC" DataType="partialDate" SASFieldName="CMSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Medication</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMENDTC" Name="CMENDTC" DataType="partialDate" SASFieldName="CMENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Medication</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMSTDY" Name="CMSTDY" DataType="integer" Length="8" SASFieldName="CMSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Medication</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMENDY" Name="CMENDY" DataType="integer" Length="8" SASFieldName="CMENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Medication</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMENRTPT" Name="CMENRTPT" DataType="text" Length="7" SASFieldName="CMENRTPT">
+        <Description>
+          <TranslatedText xml:lang="en">End Relative to Reference Time Point</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ENRTPT_CM_AE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="25" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.CM.CMENTPT" Name="CMENTPT" DataType="date" SASFieldName="CMENTPT">
+        <Description>
+          <TranslatedText xml:lang="en">End Reference Time Point</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DI.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DI.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_DI"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DI.SPDEVID" Name="SPDEVID" DataType="text" Length="200" SASFieldName="SPDEVID">
+        <Description>
+          <TranslatedText xml:lang="en">Sponsor Device Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DI.DISEQ" Name="DISEQ" DataType="integer" Length="3" SASFieldName="DISEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DI.DIPARMCD" Name="DIPARMCD" DataType="text" Length="7" SASFieldName="DIPARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Device Identifier Element Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DIPARMCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DI.DIPARM" Name="DIPARM" DataType="text" Length="13" SASFieldName="DIPARM">
+        <Description>
+          <TranslatedText xml:lang="en">Device Identifier Element Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DIPARM"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DI.DIVAL" Name="DIVAL" DataType="text" Length="200" SASFieldName="DIVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Device Identifier Element Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_DM"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.SUBJID" Name="SUBJID" DataType="text" Length="4" SASFieldName="SUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Identifier for the Study</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RFSTDTC" Name="RFSTDTC" DataType="date" SASFieldName="RFSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Reference Start Date/Time</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RFENDTC" Name="RFENDTC" DataType="date" SASFieldName="RFENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Reference End Date/Time</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RFXSTDTC" Name="RFXSTDTC" DataType="date" SASFieldName="RFXSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of First Study Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RFXENDTC" Name="RFXENDTC" DataType="date" SASFieldName="RFXENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Last Study Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RFICDTC" Name="RFICDTC" DataType="date" SASFieldName="RFICDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Informed Consent</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RFPENDTC" Name="RFPENDTC" DataType="date" SASFieldName="RFPENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of End of Participation</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.DTHDTC" Name="DTHDTC" DataType="date" SASFieldName="DTHDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Death</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="26" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.DTHFL" Name="DTHFL" DataType="text" Length="1" SASFieldName="DTHFL">
+        <Description>
+          <TranslatedText xml:lang="en">Subject Death Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.SITEID" Name="SITEID" DataType="text" Length="3" SASFieldName="SITEID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Site Identifier</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SITEID"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.BRTHDTC" Name="BRTHDTC" DataType="date" SASFieldName="BRTHDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Birth</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.AGE" Name="AGE" DataType="integer" Length="8" SASFieldName="AGE">
+        <Description>
+          <TranslatedText xml:lang="en">Age</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.AGEU" Name="AGEU" DataType="text" Length="5" SASFieldName="AGEU">
+        <Description>
+          <TranslatedText xml:lang="en">Age Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AGEU_YEARS"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.SEX" Name="SEX" DataType="text" Length="1" SASFieldName="SEX">
+        <Description>
+          <TranslatedText xml:lang="en">Sex</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SEX"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RACE" Name="RACE" DataType="text" Length="41" SASFieldName="RACE">
+        <Description>
+          <TranslatedText xml:lang="en">Race</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.RACE"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ETHNIC" Name="ETHNIC" DataType="text" Length="22" SASFieldName="ETHNIC">
+        <Description>
+          <TranslatedText xml:lang="en">Ethnicity</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ETHNIC"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ARMCD" Name="ARMCD" DataType="text" Length="8" SASFieldName="ARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARMCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ARM" Name="ARM" DataType="text" Length="28" SASFieldName="ARM">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARM"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ACTARMCD" Name="ACTARMCD" DataType="text" Length="8" SASFieldName="ACTARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Actual Arm Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARMCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ACTARM" Name="ACTARM" DataType="text" Length="28" SASFieldName="ACTARM">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Actual Arm</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARM"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ARMNRS" Name="ARMNRS" DataType="text" Length="14" SASFieldName="ARMNRS">
+        <Description>
+          <TranslatedText xml:lang="en">Reason Arm and/or Actual Arm is Null</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARMNRS"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.ACTARMUD" Name="ACTARMUD" DataType="text" Length="200" SASFieldName="ACTARMUD">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Unplanned Actual Arm</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DM.COUNTRY" Name="COUNTRY" DataType="text" Length="3" SASFieldName="COUNTRY">
+        <Description>
+          <TranslatedText xml:lang="en">Country</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ISO3166"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.RDOMAIN" Name="RDOMAIN" DataType="text" Length="6" SASFieldName="RDOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Related Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_DM"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.IDVAR" Name="IDVAR" DataType="text" Length="200" SASFieldName="IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.IDVARVAL" Name="IDVARVAL" DataType="text" Length="200" SASFieldName="IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QNAM" Name="QNAM" DataType="text" Length="5" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QLABEL" Name="QLABEL" DataType="text" Length="40" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL" Name="QVAL" DataType="text" Length="41" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPDM"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QORIG" Name="QORIG" DataType="text" Length="13" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QEVAL" Name="QEVAL" DataType="text" Length="200" SASFieldName="QEVAL"
+        def:CommentOID="COM.DM2">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_DS"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSSEQ" Name="DSSEQ" DataType="integer" Length="3" SASFieldName="DSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSLNKID" Name="DSLNKID" DataType="text" Length="50" SASFieldName="DSLNKID">
+        <Description>
+          <TranslatedText xml:lang="en">Link ID</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="27 28" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSTERM" Name="DSTERM" DataType="text" Length="200" SASFieldName="DSTERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Disposition Event</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.DSTERM"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSDECOD" Name="DSDECOD" DataType="text" Length="29" SASFieldName="DSDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">Standardized Disposition Term</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.DSDECOD"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSCAT" Name="DSCAT" DataType="text" Length="18" SASFieldName="DSCAT"
+        def:CommentOID="COM.DS1">
+        <Description>
+          <TranslatedText xml:lang="en">Category for Disposition Event</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DSCAT"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5 27 28" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSSCAT" Name="DSSCAT" DataType="text" Length="19" SASFieldName="DSSCAT"
+        def:CommentOID="COM.DS1">
+        <Description>
+          <TranslatedText xml:lang="en">Subcategory for Disposition Event</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DSSCAT"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="27 28" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSSTDTC" Name="DSSTDTC" DataType="date" SASFieldName="DSSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Disposition Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5 27 28" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSSTDY" Name="DSSTDY" DataType="integer" Length="8" SASFieldName="DSSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Disposition Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_EC"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.SPDEVID" Name="SPDEVID" DataType="text" Length="200" SASFieldName="SPDEVID">
+        <Description>
+          <TranslatedText xml:lang="en">Sponsor Device Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECSEQ" Name="ECSEQ" DataType="integer" Length="3" SASFieldName="ECSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECTRT" Name="ECTRT" DataType="text" Length="10" SASFieldName="ECTRT">
+        <Description>
+          <TranslatedText xml:lang="en">Name of Treatment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EXTRT"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECPRESP" Name="ECPRESP" DataType="text" Length="1" SASFieldName="ECPRESP">
+        <Description>
+          <TranslatedText xml:lang="en">Pre-Specified</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECOCCUR" Name="ECOCCUR" DataType="text" Length="1" SASFieldName="ECOCCUR">
+        <Description>
+          <TranslatedText xml:lang="en">Occurrence</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECDOSE" Name="ECDOSE" DataType="integer" Length="8" SASFieldName="ECDOSE">
+        <Description>
+          <TranslatedText xml:lang="en">Dose</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECDOSU" Name="ECDOSU" DataType="text" Length="2" SASFieldName="ECDOSU">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_ECDOSU"/>
+        <def:Origin Type="Assigned" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECDOSFRM" Name="ECDOSFRM" DataType="text" Length="9" SASFieldName="ECDOSFRM">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Form</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FRM_ECEX"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECDOSFRQ" Name="ECDOSFRQ" DataType="text" Length="2" SASFieldName="ECDOSFRQ">
+        <Description>
+          <TranslatedText xml:lang="en">Dosing Frequency per Interval</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FREQ_ECEX"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECROUTE" Name="ECROUTE" DataType="text" Length="12" SASFieldName="ECROUTE">
+        <Description>
+          <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ROUTE_ECEX"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECLOT" Name="ECLOT" DataType="text" Length="200" SASFieldName="ECLOT">
+        <Description>
+          <TranslatedText xml:lang="en">Lot Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECPSTRG" Name="ECPSTRG" DataType="float" Length="4" SignificantDigits="1" SASFieldName="ECPSTRG">
+        <Description>
+          <TranslatedText xml:lang="en">Pharmaceutical Strength</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECPSTRGU" Name="ECPSTRGU" DataType="text" Length="3" SASFieldName="ECPSTRGU">
+        <Description>
+          <TranslatedText xml:lang="en">Pharmaceutical Strength Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_ECPSTRGU"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECSTDTC" Name="ECSTDTC" DataType="date" SASFieldName="ECSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECENDTC" Name="ECENDTC" DataType="date" SASFieldName="ECENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECSTDY" Name="ECSTDY" DataType="integer" Length="8" SASFieldName="ECSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EC.ECENDY" Name="ECENDY" DataType="integer" Length="8" SASFieldName="ECENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.RDOMAIN" Name="RDOMAIN" DataType="text" Length="6" SASFieldName="RDOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Related Domain Abbreviation</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.IDVAR" Name="IDVAR" DataType="text" Length="200" SASFieldName="IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.IDVARVAL" Name="IDVARVAL" DataType="text" Length="200" SASFieldName="IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.QNAM" Name="QNAM" DataType="text" Length="8" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.QLABEL" Name="QLABEL" DataType="text" Length="40" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.QVAL" Name="QVAL" DataType="text" Length="200" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPEC"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.QORIG" Name="QORIG" DataType="text" Length="13" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.QEVAL" Name="QEVAL" DataType="text" Length="200" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_EX"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.SPDEVID" Name="SPDEVID" DataType="text" Length="200" SASFieldName="SPDEVID">
+        <Description>
+          <TranslatedText xml:lang="en">Sponsor Device Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">EC.SPDEVID</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXSEQ" Name="EXSEQ" DataType="integer" Length="3" SASFieldName="EXSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXTRT" Name="EXTRT" DataType="text" Length="10" SASFieldName="EXTRT">
+        <Description>
+          <TranslatedText xml:lang="en">Name of Treatment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EXTRT"/>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECTRT</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXDOSE" Name="EXDOSE" DataType="integer" Length="8" SASFieldName="EXDOSE">
+        <Description>
+          <TranslatedText xml:lang="en">Dose</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXDOSU" Name="EXDOSU" DataType="text" Length="2" SASFieldName="EXDOSU">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_EX"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXDOSFRM" Name="EXDOSFRM" DataType="text" Length="9" SASFieldName="EXDOSFRM">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Form</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FRM_ECEX"/>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECDOSFRM</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXDOSFRQ" Name="EXDOSFRQ" DataType="text" Length="2" SASFieldName="EXDOSFRQ">
+        <Description>
+          <TranslatedText xml:lang="en">Dosing Frequency per Interval</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FREQ_ECEX"/>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECDOSFRQ</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXROUTE" Name="EXROUTE" DataType="text" Length="12" SASFieldName="EXROUTE">
+        <Description>
+          <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ROUTE_ECEX"/>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECROUTE</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXLOT" Name="EXLOT" DataType="text" Length="200" SASFieldName="EXLOT">
+        <Description>
+          <TranslatedText xml:lang="en">Lot Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECLOT</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">EC.EPOCH</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXSTDTC" Name="EXSTDTC" DataType="date" SASFieldName="EXSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECSTDTC</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXENDTC" Name="EXENDTC" DataType="date" SASFieldName="EXENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECENDTC</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXSTDY" Name="EXSTDY" DataType="integer" Length="8" SASFieldName="EXSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECSTDY</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.EX.EXENDY" Name="EXENDY" DataType="integer" Length="8" SASFieldName="EXENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">ECENDY</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FA.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_FA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FASEQ" Name="FASEQ" DataType="integer" Length="3" SASFieldName="FASEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FALNKGRP" Name="FALNKGRP" DataType="text" Length="200" SASFieldName="FALNKGRP">
+        <Description>
+          <TranslatedText xml:lang="en">Link Group ID</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FATESTCD" Name="FATESTCD" DataType="text" Length="5" SASFieldName="FATESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Findings About Test Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FATESTCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FATEST" Name="FATEST" DataType="text" Length="20" SASFieldName="FATEST">
+        <Description>
+          <TranslatedText xml:lang="en">Findings About Test Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FATEST"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FAOBJ" Name="FAOBJ" DataType="text" Length="10" SASFieldName="FAOBJ">
+        <Description>
+          <TranslatedText xml:lang="en">Object of the Observation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FAOBJ"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="24" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FACAT" Name="FACAT" DataType="text" Length="23" SASFieldName="FACAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category for Findings About</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FACAT"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="24" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FAORRES" Name="FAORRES" DataType="text" Length="8" SASFieldName="FAORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="24" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.FAORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FASTRESC" Name="FASTRESC" DataType="text" Length="8" SASFieldName="FASTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">FAORRES</TranslatedText>
+          </Description>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.FASTRESC"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FALOC" Name="FALOC" DataType="text" Length="3" SASFieldName="FALOC">
+        <Description>
+          <TranslatedText xml:lang="en">Location of the Finding About</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LOC"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM"
+        def:CommentOID="COM.FA1">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FADTC" Name="FADTC" DataType="date" SASFieldName="FADTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FADY" Name="FADY" DataType="integer" Length="8" SASFieldName="FADY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_FT"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTSEQ" Name="FTSEQ" DataType="integer" Length="3" SASFieldName="FTSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTTESTCD" Name="FTTESTCD" DataType="text" Length="7" SASFieldName="FTTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Short Name of Test</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AVL02TC"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTTEST" Name="FTTEST" DataType="text" Length="23" SASFieldName="FTTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Name of Test</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AVL02TT"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTCAT" Name="FTCAT" DataType="text" Length="8" SASFieldName="FTCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FTCAT"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTSCAT" Name="FTSCAT" DataType="text" Length="200" SASFieldName="FTSCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Subcategory</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTORRES" Name="FTORRES" DataType="text" Length="12" SASFieldName="FTORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.FTORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTSTRESC" Name="FTSTRESC" DataType="text" Length="200" SASFieldName="FTSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Standard Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">FTORRES</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTSTRESN" Name="FTSTRESN" DataType="integer" Length="8" SASFieldName="FTSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTLOBXFL" Name="FTLOBXFL" DataType="text" Length="1" SASFieldName="FTLOBXFL">
+        <Description>
+          <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTREPNUM" Name="FTREPNUM" DataType="integer" Length="8" SASFieldName="FTREPNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Repetition Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="17 18" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTDTC" Name="FTDTC" DataType="partialDatetime" SASFieldName="FTDTC"
+        def:CommentOID="COM.DTC1">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Test</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="17 18" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTDY" Name="FTDY" DataType="integer" Length="8" SASFieldName="FTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Test</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTTPT" Name="FTTPT" DataType="text" Length="200" SASFieldName="FTTPT">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Time Point Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTTPTNUM" Name="FTTPTNUM" DataType="integer" Length="8" SASFieldName="FTTPTNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Time Point Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTELTM" Name="FTELTM" DataType="text" Length="200" SASFieldName="FTELTM">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Elapsed Time from Time Point Ref</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="18" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTTPTREF" Name="FTTPTREF" DataType="text" Length="200" SASFieldName="FTTPTREF">
+        <Description>
+          <TranslatedText xml:lang="en">Time Point Reference</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_IE"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IESEQ" Name="IESEQ" DataType="integer" Length="3" SASFieldName="IESEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IETESTCD" Name="IETESTCD" DataType="text" Length="7" SASFieldName="IETESTCD"
+        def:CommentOID="COM.IE2">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IETESTCD"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IETEST" Name="IETEST" DataType="text" Length="196" SASFieldName="IETEST"
+        def:CommentOID="COM.IE2">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IETEST"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IECAT" Name="IECAT" DataType="text" Length="9" SASFieldName="IECAT">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Category</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IECAT"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEORRES" Name="IEORRES" DataType="text" Length="1" SASFieldName="IEORRES">
+        <Description>
+          <TranslatedText xml:lang="en">I/E Criterion Original Result</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Derived" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IESTRESC" Name="IESTRESC" DataType="text" Length="1" SASFieldName="IESTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">I/E Criterion Result in Std Format</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">IEORRES</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEDTC" Name="IEDTC" DataType="date" SASFieldName="IEDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="6" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.IE.IEDY" Name="IEDY" DataType="integer" Length="8" SASFieldName="IEDY"
+        def:CommentOID="COM.IE1">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.DOMAIN" Name="DOMAIN" DataType="text" Length="4" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_QS"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSSEQ" Name="QSSEQ" DataType="integer" Length="3" SASFieldName="QSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSTESTCD" Name="QSTESTCD" DataType="text" Length="7" SASFieldName="QSTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Question Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PHQ01C"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSTEST" Name="QSTEST" DataType="text" Length="40" SASFieldName="QSTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Question Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PHQ01T"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSCAT" Name="QSCAT" DataType="text" Length="5" SASFieldName="QSCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category of Question</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.QSCAT_PH"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSORRES" Name="QSORRES" DataType="text" Length="23" SASFieldName="QSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.QSORRES_PHQ"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSSTRESC" Name="QSSTRESC" DataType="text" Length="20" SASFieldName="QSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.QSSTRESC_PHQ"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSSTRESN" Name="QSSTRESN" DataType="integer" Length="8" SASFieldName="QSSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSLOBXFL" Name="QSLOBXFL" DataType="text" Length="1" SASFieldName="QSLOBXFL">
+        <Description>
+          <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSDTC" Name="QSDTC" DataType="date" SASFieldName="QSDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Finding</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSDY" Name="QSDY" DataType="integer" Length="8" SASFieldName="QSDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Finding</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSEVLINT" Name="QSEVLINT" DataType="durationDatetime" SASFieldName="QSEVLINT">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluation Interval</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.DOMAIN" Name="DOMAIN" DataType="text" Length="4" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_QS"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSSEQ" Name="QSSEQ" DataType="integer" Length="3" SASFieldName="QSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSTESTCD" Name="QSTESTCD" DataType="text" Length="8" SASFieldName="QSTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Question Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SWLS01TC"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSTEST" Name="QSTEST" DataType="text" Length="39" SASFieldName="QSTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Question Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SWLS01TN"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSCAT" Name="QSCAT" DataType="text" Length="4" SASFieldName="QSCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category of Question</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.QSCAT_SL"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="16" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSORRES" Name="QSORRES" DataType="text" Length="26" SASFieldName="QSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Finding in Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SWLSR"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="16" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSSTRESC" Name="QSSTRESC" DataType="text" Length="1" SASFieldName="QSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SWLSR_S"/>
+        <def:Origin Type="Derived" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="16" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSSTRESN" Name="QSSTRESN" DataType="integer" Length="8" SASFieldName="QSSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="16" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSLOBXFL" Name="QSLOBXFL" DataType="text" Length="1" SASFieldName="QSLOBXFL">
+        <Description>
+          <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSDTC" Name="QSDTC" DataType="date" SASFieldName="QSDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Finding</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSSL.QSDY" Name="QSDY" DataType="integer" Length="8" SASFieldName="QSDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Finding</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.RDOMAIN" Name="RDOMAIN" DataType="text" Length="6" SASFieldName="RDOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Related Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RDOMAIN_RELREC"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.IDVAR" Name="IDVAR" DataType="text" Length="200" SASFieldName="IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.IDVARVAL" Name="IDVARVAL" DataType="text" Length="200" SASFieldName="IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.RELTYPE" Name="RELTYPE" DataType="text" Length="4" SASFieldName="RELTYPE">
+        <Description>
+          <TranslatedText xml:lang="en">Relationship Type</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RELTYPE"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RELREC.RELID" Name="RELID" DataType="text" Length="200" SASFieldName="RELID">
+        <Description>
+          <TranslatedText xml:lang="en">Relationship Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_RS"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSEQ" Name="RSSEQ" DataType="integer" Length="3" SASFieldName="RSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSTESTCD" Name="RSTESTCD" DataType="text" Length="8" SASFieldName="RSTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Assessment Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD17C"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSTEST" Name="RSTEST" DataType="text" Length="37" SASFieldName="RSTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Assessment Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD17T"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSCAT" Name="RSCAT" DataType="text" Length="7" SASFieldName="RSCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category for Assessment</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RSCAT"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES" Name="RSORRES" DataType="text" Length="198" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.RSORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC" Name="RSSTRESC" DataType="text" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+        <def:ValueListRef ValueListOID="VL.RSSTRESC"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESN" Name="RSSTRESN" DataType="integer" Length="8" SASFieldName="RSSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSLOBXFL" Name="RSLOBXFL" DataType="text" Length="1" SASFieldName="RSLOBXFL">
+        <Description>
+          <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSDTC" Name="RSDTC" DataType="date" SASFieldName="RSDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Assessment</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSDY" Name="RSDY" DataType="integer" Length="8" SASFieldName="RSDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Assessment</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSEVLINT" Name="RSEVLINT" DataType="durationDatetime" SASFieldName="RSEVLINT">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluation Interval</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SE.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_SE"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.SESEQ" Name="SESEQ" DataType="integer" Length="3" SASFieldName="SESEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.ETCD" Name="ETCD" DataType="text" Length="7" SASFieldName="ETCD">
+        <Description>
+          <TranslatedText xml:lang="en">Element Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ETCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.ELEMENT" Name="ELEMENT" DataType="text" Length="26" SASFieldName="ELEMENT">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ELEMENT"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.SESTDTC" Name="SESTDTC" DataType="date" SASFieldName="SESTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.SEENDTC" Name="SEENDTC" DataType="date" SASFieldName="SEENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.SESTDY" Name="SESTDY" DataType="integer" Length="8" SASFieldName="SESTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SE.SEENDY" Name="SEENDY" DataType="integer" Length="8" SASFieldName="SEENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_SV"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.SVSTDTC" Name="SVSTDTC" DataType="date" SASFieldName="SVSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.SVENDTC" Name="SVENDTC" DataType="date" SASFieldName="SVENDTC">
+        <Description>
+          <TranslatedText xml:lang="en">End Date/Time of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.SVSTDY" Name="SVSTDY" DataType="integer" Length="8" SASFieldName="SVSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.SVENDY" Name="SVENDY" DataType="integer" Length="8" SASFieldName="SVENDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of End of Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SV.SVUPDES" Name="SVUPDES" DataType="text" Length="200" SASFieldName="SVUPDES">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Unplanned Visit</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_TA"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.ARMCD" Name="ARMCD" DataType="text" Length="8" SASFieldName="ARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARMCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.ARM" Name="ARM" DataType="text" Length="28" SASFieldName="ARM">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Planned Arm</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARM"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.TAETORD" Name="TAETORD" DataType="integer" Length="8" SASFieldName="TAETORD">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Order of Element within Arm</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.ETCD" Name="ETCD" DataType="text" Length="7" SASFieldName="ETCD">
+        <Description>
+          <TranslatedText xml:lang="en">Element Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ETCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.ELEMENT" Name="ELEMENT" DataType="text" Length="26" SASFieldName="ELEMENT">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ELEMENT"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.TABRANCH" Name="TABRANCH" DataType="text" Length="200" SASFieldName="TABRANCH">
+        <Description>
+          <TranslatedText xml:lang="en">Branch</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.TATRANS" Name="TATRANS" DataType="text" Length="200" SASFieldName="TATRANS">
+        <Description>
+          <TranslatedText xml:lang="en">Transition Rule</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TA.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_TE"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.ETCD" Name="ETCD" DataType="text" Length="7" SASFieldName="ETCD">
+        <Description>
+          <TranslatedText xml:lang="en">Element Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ETCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.ELEMENT" Name="ELEMENT" DataType="text" Length="26" SASFieldName="ELEMENT">
+        <Description>
+          <TranslatedText xml:lang="en">Description of Element</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ELEMENT"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.TESTRL" Name="TESTRL" DataType="text" Length="200" SASFieldName="TESTRL">
+        <Description>
+          <TranslatedText xml:lang="en">Rule for Start of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TE.TEENRL" Name="TEENRL" DataType="text" Length="200" SASFieldName="TEENRL">
+        <Description>
+          <TranslatedText xml:lang="en">Rule for End of Element</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TI.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TI.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_TI"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TI.IETESTCD" Name="IETESTCD" DataType="text" Length="7" SASFieldName="IETESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Incl/Excl Criterion Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IETESTCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TI.IETEST" Name="IETEST" DataType="text" Length="196" SASFieldName="IETEST">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Criterion</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IETEST"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TI.IECAT" Name="IECAT" DataType="text" Length="9" SASFieldName="IECAT">
+        <Description>
+          <TranslatedText xml:lang="en">Inclusion/Exclusion Category</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.IECAT"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TI.TIVERS" Name="TIVERS" DataType="text" Length="200" SASFieldName="TIVERS">
+        <Description>
+          <TranslatedText xml:lang="en">Protocol Criteria Versions</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_TS"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSSEQ" Name="TSSEQ" DataType="integer" Length="3" SASFieldName="TSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSGRPID" Name="TSGRPID" DataType="text" Length="200" SASFieldName="TSGRPID">
+        <Description>
+          <TranslatedText xml:lang="en">Group ID</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSPARMCD" Name="TSPARMCD" DataType="text" Length="8" SASFieldName="TSPARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Summary Parameter Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TSPARMCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSPARM" Name="TSPARM" DataType="text" Length="40" SASFieldName="TSPARM">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Summary Parameter</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TSPARM"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Parameter Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.TSVAL"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVALNF" Name="TSVALNF" DataType="text" Length="4" SASFieldName="TSVALNF">
+        <Description>
+          <TranslatedText xml:lang="en">Parameter Null Flavor</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ISO21090"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVALCD" Name="TSVALCD" DataType="text" Length="200" SASFieldName="TSVALCD">
+        <Description>
+          <TranslatedText xml:lang="en">Parameter Value Code</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVCDREF" Name="TSVCDREF" DataType="text" Length="200" SASFieldName="TSVCDREF">
+        <Description>
+          <TranslatedText xml:lang="en">Name of the Reference Terminology</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVCDVER" Name="TSVCDVER" DataType="text" Length="200" SASFieldName="TSVCDVER">
+        <Description>
+          <TranslatedText xml:lang="en">Version of the Reference Terminology</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_TV"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.ARMCD" Name="ARMCD" DataType="text" Length="8" SASFieldName="ARMCD">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Arm Code</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ARMCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.TVSTRL" Name="TVSTRL" DataType="text" Length="200" SASFieldName="TVSTRL">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Start Rule</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TV.TVENRL" Name="TVENRL" DataType="text" Length="200" SASFieldName="TVENRL">
+        <Description>
+          <TranslatedText xml:lang="en">Visit End Rule</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_VS"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSEQ" Name="VSSEQ" DataType="integer" Length="3" SASFieldName="VSSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSTESTCD" Name="VSTESTCD" DataType="text" Length="6" SASFieldName="VSTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Vital Signs Test Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VSTESTCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSTEST" Name="VSTEST" DataType="text" Length="24" SASFieldName="VSTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Vital Signs Test Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VSTEST"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSPOS" Name="VSPOS" DataType="text" Length="8" SASFieldName="VSPOS">
+        <Description>
+          <TranslatedText xml:lang="en">Vital Signs Position of Subject</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.POSITION_VS"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES" Name="VSORRES" DataType="text" Length="8" SASFieldName="VSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.VSORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU" Name="VSORRESU" DataType="text" Length="9" SASFieldName="VSORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Original Units</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.VSORRESU"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESC" Name="VSSTRESC" DataType="text" Length="200" SASFieldName="VSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESN" Name="VSSTRESN" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VSSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESU" Name="VSSTRESU" DataType="text" Length="9" SASFieldName="VSSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+        <def:ValueListRef ValueListOID="VL.VSSTRESU"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTAT" Name="VSSTAT" DataType="text" Length="8" SASFieldName="VSSTAT"
+        def:CommentOID="COM.VS1">
+        <Description>
+          <TranslatedText xml:lang="en">Completion Status</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ND"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSLOC" Name="VSLOC" DataType="text" Length="11" SASFieldName="VSLOC">
+        <Description>
+          <TranslatedText xml:lang="en">Location of Vital Signs Measurement</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LOC_VS"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSLOBXFL" Name="VSLOBXFL" DataType="text" Length="1" SASFieldName="VSLOBXFL">
+        <Description>
+          <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSREPNUM" Name="VSREPNUM" DataType="integer" Length="8" SASFieldName="VSREPNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Repetition Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 10 12" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSDTC" Name="VSDTC" DataType="date" SASFieldName="VSDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Measurements</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSDY" Name="VSDY" DataType="integer" Length="8" SASFieldName="VSDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Vital Signs</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_NV"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.NVSEQ" Name="NVSEQ" DataType="integer" Length="3" SASFieldName="NVSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.NVTESTCD" Name="NVTESTCD" DataType="text" Length="4" SASFieldName="NVTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Short Name of Nervous System Test</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NVTESTCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.NVTEST" Name="NVTEST" DataType="text" Length="14" SASFieldName="NVTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Name of Nervous System Test</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NVTEST"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.NVORRES" Name="NVORRES" DataType="text" Length="8" SASFieldName="NVORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NORMABNM"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="20" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.NV.NVSTRESC" Name="NVSTRESC" DataType="text" Length="8" SASFieldName="NVSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NORMABNM"/>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">NVORRES</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.NV.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.NV.NVDTC" Name="NVDTC" DataType="date" SASFieldName="NVDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="20" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.NV.NVDY" Name="NVDY" DataType="integer" Length="8" SASFieldName="NVDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Visit/Collection/Exam</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.RDOMAIN" Name="RDOMAIN" DataType="text" Length="6" SASFieldName="RDOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Related Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_NV"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.IDVAR" Name="IDVAR" DataType="text" Length="200" SASFieldName="IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.IDVARVAL" Name="IDVARVAL" DataType="text" Length="200" SASFieldName="IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.QNAM" Name="QNAM" DataType="text" Length="7" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.QLABEL" Name="QLABEL" DataType="text" Length="40" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.QVAL" Name="QVAL" DataType="text" Length="1" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPNV"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.QORIG" Name="QORIG" DataType="text" Length="13" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.QEVAL" Name="QEVAL" DataType="text" Length="200" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_MH"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHSEQ" Name="MHSEQ" DataType="integer" Length="3" SASFieldName="MHSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHTERM" Name="MHTERM" DataType="text" Length="19" SASFieldName="MHTERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Medical History</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MHTERM"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHEVDTYP" Name="MHEVDTYP" DataType="text" Length="13" SASFieldName="MHEVDTYP">
+        <Description>
+          <TranslatedText xml:lang="en">Medical History Event Date Type</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.MHEVDTP"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="7" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHSTDTC" Name="MHSTDTC" DataType="date" SASFieldName="MHSTDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Start Date/Time of Medical History Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="7" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.MH.MHSTDY" Name="MHSTDY" DataType="integer" Length="8" SASFieldName="MHSTDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Start of Observation</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DD.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_DD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DD.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DDSEQ" Name="DDSEQ" DataType="integer" Length="3" SASFieldName="DDSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DDLNKID" Name="DDLNKID" DataType="text" Length="50" SASFieldName="DDLNKID">
+        <Description>
+          <TranslatedText xml:lang="en">Link ID</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="26" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DDTESTCD" Name="DDTESTCD" DataType="text" Length="6" SASFieldName="DDTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Death Detail Assessment Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DDTESTCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DDTEST" Name="DDTEST" DataType="text" Length="22" SASFieldName="DDTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Death Detail Assessment Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DDTEST"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DDORRES" Name="DDORRES" DataType="text" Length="200" SASFieldName="DDORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding as Collected</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="26" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DDSTRESC" Name="DDSTRESC" DataType="text" Length="200" SASFieldName="DDSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">DDORRES</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DD.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DDDTC" Name="DDDTC" DataType="date" SASFieldName="DDDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="26" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DD.DDDY" Name="DDDY" DataType="integer" Length="8" SASFieldName="DDDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_LB"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSEQ" Name="LBSEQ" DataType="integer" Length="3" SASFieldName="LBSEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBTESTCD" Name="LBTESTCD" DataType="text" Length="7" SASFieldName="LBTESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Test or Examination Short Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LBTESTCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBTEST" Name="LBTEST" DataType="text" Length="39" SASFieldName="LBTEST">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Test or Examination Name</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LBTEST"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBCAT" Name="LBCAT" DataType="text" Length="10" SASFieldName="LBCAT">
+        <Description>
+          <TranslatedText xml:lang="en">Category for Lab Test</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LBCAT"/>
+        <def:Origin Type="Collected" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES" Name="LBORRES" DataType="text" Length="6" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Vendor"/>
+        <def:ValueListRef ValueListOID="VL.LBORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU" Name="LBORRESU" DataType="text" Length="7" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Vendor"/>
+        <def:ValueListRef ValueListOID="VL.LBORRESU"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORNRLO" Name="LBORNRLO" DataType="text" Length="200" SASFieldName="LBORNRLO">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Lower Limit in Orig Unit</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORNRHI" Name="LBORNRHI" DataType="text" Length="200" SASFieldName="LBORNRHI">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Upper Limit in Orig Unit</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC" Name="LBSTRESC" DataType="text" Length="8" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Vendor"/>
+        <def:ValueListRef ValueListOID="VL.LBSTRESC"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESN" Name="LBSTRESN" DataType="float" Length="8" SignificantDigits="5" SASFieldName="LBSTRESN">
+        <Description>
+          <TranslatedText xml:lang="en">Numeric Result/Finding in Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU" Name="LBSTRESU" DataType="text" Length="7" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Standard Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Vendor"/>
+        <def:ValueListRef ValueListOID="VL.LBSTRESU"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTNRLO" Name="LBSTNRLO" DataType="float" Length="5" SignificantDigits="3" SASFieldName="LBSTNRLO">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Lower Limit-Std Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTNRHI" Name="LBSTNRHI" DataType="float" Length="5" SignificantDigits="2" SASFieldName="LBSTNRHI">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Upper Limit-Std Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBNRIND" Name="LBNRIND" DataType="text" Length="8" SASFieldName="LBNRIND">
+        <Description>
+          <TranslatedText xml:lang="en">Reference Range Indicator</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NRIND"/>
+        <def:Origin Type="Collected" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBLOBXFL" Name="LBLOBXFL" DataType="text" Length="1" SASFieldName="LBLOBXFL">
+        <Description>
+          <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Derived" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBDTC" Name="LBDTC" DataType="partialDatetime" SASFieldName="LBDTC"
+        def:CommentOID="COM.DTC1">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Specimen Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBDY" Name="LBDY" DataType="integer" Length="8" SASFieldName="LBDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Specimen Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Vendor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.DOMAIN" Name="DOMAIN" DataType="text" Length="2" SASFieldName="DOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_OE"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.FOCID" Name="FOCID" DataType="text" Length="2" SASFieldName="FOCID">
+        <Description>
+          <TranslatedText xml:lang="en">Focus of Study-Specific Interest</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.OEFOCUS"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OESEQ" Name="OESEQ" DataType="integer" Length="3" SASFieldName="OESEQ">
+        <Description>
+          <TranslatedText xml:lang="en">Sequence Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OETESTCD" Name="OETESTCD" DataType="text" Length="8" SASFieldName="OETESTCD">
+        <Description>
+          <TranslatedText xml:lang="en">Short Name of Ophthalmic Test or Exam</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.OETESTCD"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OETEST" Name="OETEST" DataType="text" Length="18" SASFieldName="OETEST">
+        <Description>
+          <TranslatedText xml:lang="en">Name of Ophthalmic Test or Exam</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.OETEST"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OEORRES" Name="OEORRES" DataType="text" Length="200" SASFieldName="OEORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+        <def:ValueListRef ValueListOID="VL.OEORRES"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OESTRESC" Name="OESTRESC" DataType="text" Length="200" SASFieldName="OESTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">OEORRES</TranslatedText>
+          </Description>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OELOC" Name="OELOC" DataType="text" Length="21" SASFieldName="OELOC">
+        <Description>
+          <TranslatedText xml:lang="en">Location Used for the Measurement</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LOC_OE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OELAT" Name="OELAT" DataType="text" Length="5" SASFieldName="OELAT">
+        <Description>
+          <TranslatedText xml:lang="en">Laterality</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.LAT_OE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OEMETHOD" Name="OEMETHOD" DataType="text" Length="9" SASFieldName="OEMETHOD">
+        <Description>
+          <TranslatedText xml:lang="en">Method of Test or Examination</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.OEMETHOD"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OELOBXFL" Name="OELOBXFL" DataType="text" Length="1" SASFieldName="OELOBXFL">
+        <Description>
+          <TranslatedText xml:lang="en">Last Observation Before Exposure Flag</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.VISITNUM" Name="VISITNUM" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VISITNUM">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Number</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.VISIT" Name="VISIT" DataType="text" Length="200" SASFieldName="VISIT">
+        <Description>
+          <TranslatedText xml:lang="en">Visit Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.OE.EPOCH" Name="EPOCH" DataType="text" Length="9" SASFieldName="EPOCH">
+        <Description>
+          <TranslatedText xml:lang="en">Epoch</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.EPOCH"/>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OEDTC" Name="OEDTC" DataType="text" Length="200" SASFieldName="OEDTC">
+        <Description>
+          <TranslatedText xml:lang="en">Date/Time of Collection</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OEDY" Name="OEDY" DataType="integer" Length="8" SASFieldName="OEDY">
+        <Description>
+          <TranslatedText xml:lang="en">Study Day of Visit/Collection/Exam</TranslatedText>
+        </Description>
+        <def:Origin Type="Derived" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.STUDYID" Name="STUDYID" DataType="text" Length="12" SASFieldName="STUDYID">
+        <Description>
+          <TranslatedText xml:lang="en">Study Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.RDOMAIN" Name="RDOMAIN" DataType="text" Length="6" SASFieldName="RDOMAIN">
+        <Description>
+          <TranslatedText xml:lang="en">Related Domain Abbreviation</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.DOMAIN_OE"/>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.USUBJID" Name="USUBJID" DataType="text" Length="8" SASFieldName="USUBJID">
+        <Description>
+          <TranslatedText xml:lang="en">Unique Subject Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.IDVAR" Name="IDVAR" DataType="text" Length="200" SASFieldName="IDVAR">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.IDVARVAL" Name="IDVARVAL" DataType="text" Length="200" SASFieldName="IDVARVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Identifying Variable Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.QNAM" Name="QNAM" DataType="text" Length="7" SASFieldName="QNAM">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Name</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.QLABEL" Name="QLABEL" DataType="text" Length="40" SASFieldName="QLABEL">
+        <Description>
+          <TranslatedText xml:lang="en">Qualifier Variable Label</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.QVAL" Name="QVAL" DataType="text" Length="1" SASFieldName="QVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Data Value</TranslatedText>
+        </Description>
+        <def:ValueListRef ValueListOID="VL.SUPPOE"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.QORIG" Name="QORIG" DataType="text" Length="13" SASFieldName="QORIG">
+        <Description>
+          <TranslatedText xml:lang="en">Origin</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.QEVAL" Name="QEVAL" DataType="text" Length="200" SASFieldName="QEVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Evaluator</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AETERM.1" Name="AETERM" DataType="text" Length="200" SASFieldName="AETERM"
+        def:CommentOID="COM.AE2">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="23" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.AE.AETERM.2" Name="AETERM" DataType="text" Length="200" SASFieldName="AETERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Adverse Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="22" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSDECOD.3" Name="DSDECOD" DataType="text" Length="29" SASFieldName="DSDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">Standardized Disposition Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NCOMPLT"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="27 28" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSDECOD.4" Name="DSDECOD" DataType="text" Length="29" SASFieldName="DSDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">Standardized Disposition Term</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PROTMLST"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSTERM.1" Name="DSTERM" DataType="text" Length="200" SASFieldName="DSTERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Disposition Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="27 28" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DS.DSTERM.2" Name="DSTERM" DataType="text" Length="200" SASFieldName="DSTERM">
+        <Description>
+          <TranslatedText xml:lang="en">Reported Term for the Disposition Event</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FAORRES.1" Name="FAORRES" DataType="text" Length="8" SASFieldName="FAORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FASEV"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FAORRES.2" Name="FAORRES" DataType="text" Length="1" SASFieldName="FAORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FAOCCUR"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FASTRESC.1" Name="FASTRESC" DataType="text" Length="8" SASFieldName="FASTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FASEV"/>
+      </ItemDef>
+      <ItemDef OID="IT.FA.FASTRESC.2" Name="FASTRESC" DataType="text" Length="1" SASFieldName="FASTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FAOCCUR"/>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTORRES.1" Name="FTORRES" DataType="text" Length="12" SASFieldName="FTORRES">
+        <Description>
+          <TranslatedText xml:lang="en">AVLT-REY List A Item 1-15</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AVL02TR"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="17 18" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTORRES.2" Name="FTORRES" DataType="integer" Length="8" SASFieldName="FTORRES">
+        <Description>
+          <TranslatedText xml:lang="en">AVLT-REY List A Item 16-17</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="17 18" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTORRES.3" Name="FTORRES" DataType="text" Length="12" SASFieldName="FTORRES">
+        <Description>
+          <TranslatedText xml:lang="en">AVLT-REY List B Item 18-32</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.AVL02TR"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.FT.FTORRES.4" Name="FTORRES" DataType="integer" Length="8" SASFieldName="FTORRES">
+        <Description>
+          <TranslatedText xml:lang="en">AVLT-REY List B Item 33-34</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="17" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.1" Name="LBORRES" DataType="float" Length="3" SignificantDigits="1" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Set 1</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.2" Name="LBORRES" DataType="float" Length="4" SignificantDigits="1" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Set 2</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.3" Name="LBORRES" DataType="float" Length="5" SignificantDigits="2" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Set 3</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.4" Name="LBORRES" DataType="float" Length="5" SignificantDigits="3" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Specific Gravity</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.5" Name="LBORRES" DataType="integer" Length="1" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Set 4</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.6" Name="LBORRES" DataType="integer" Length="3" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Set 5</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.7" Name="LBORRES" DataType="integer" Length="4" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Set 6</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.8" Name="LBORRES" DataType="text" Length="6" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Color</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRES.9" Name="LBORRES" DataType="text" Length="3" SASFieldName="LBORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result or Finding in Original Units - Glucose</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.1" Name="LBORRESU" DataType="text" Length="3" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - ALT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.2" Name="LBORRESU" DataType="text" Length="4" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - ALB</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_g/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.3" Name="LBORRESU" DataType="text" Length="3" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - ALP</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.4" Name="LBORRESU" DataType="text" Length="3" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - AST</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.5" Name="LBORRESU" DataType="text" Length="6" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - BASO</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.6" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - BILI</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mg/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.7" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - CA</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mg/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.8" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - CL</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mEq/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.9" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - CHOL</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mg/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.10" Name="LBORRESU" DataType="text" Length="3" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - CK</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.11" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - CREAT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mg/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.12" Name="LBORRESU" DataType="text" Length="6" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - EOS</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.13" Name="LBORRESU" DataType="text" Length="2" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - MCH</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_pg"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.14" Name="LBORRESU" DataType="text" Length="4" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - MCHC</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_g/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.15" Name="LBORRESU" DataType="text" Length="2" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - MCV</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_fL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.16" Name="LBORRESU" DataType="text" Length="7" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - RBC</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^12/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.17" Name="LBORRESU" DataType="text" Length="3" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - GGT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.18" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - GLUC</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mg/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.19" Name="LBORRESU" DataType="text" Length="1" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - HCT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_PCT"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.20" Name="LBORRESU" DataType="text" Length="4" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - HGB</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_g/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.21" Name="LBORRESU" DataType="text" Length="6" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - WBC</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.22" Name="LBORRESU" DataType="text" Length="6" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - LYM</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.23" Name="LBORRESU" DataType="text" Length="6" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - MONO</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.24" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - PHOS</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mg/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.25" Name="LBORRESU" DataType="text" Length="6" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - PLAT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.26" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - K</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mEq/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.27" Name="LBORRESU" DataType="text" Length="4" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - PROT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_g/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.28" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - SODIUM</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mEq/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.29" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - TSH</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mIU/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.30" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - URATE</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mg/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.31" Name="LBORRESU" DataType="text" Length="5" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - UREAN</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mg/dL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBORRESU.32" Name="LBORRESU" DataType="text" Length="4" SASFieldName="LBORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Units - VITB12</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_ng/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.1" Name="LBSTRESC" DataType="float" Length="2" SignificantDigits="1" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - K</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.2" Name="LBSTRESC" DataType="float" Length="3" SignificantDigits="1" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - RBC</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.3" Name="LBSTRESC" DataType="float" Length="3" SignificantDigits="2" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - Set 1</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.4" Name="LBSTRESC" DataType="float" Length="4" SignificantDigits="2" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - BILI</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.5" Name="LBSTRESC" DataType="float" Length="4" SignificantDigits="3" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - Set 2</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.6" Name="LBSTRESC" DataType="float" Length="5" SignificantDigits="2" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - CREAT</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.7" Name="LBSTRESC" DataType="float" Length="6" SignificantDigits="3" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - URATE</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.8" Name="LBSTRESC" DataType="float" Length="6" SignificantDigits="4" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - MCHC</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.9" Name="LBSTRESC" DataType="float" Length="6" SignificantDigits="5" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - Set 3</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.10" Name="LBSTRESC" DataType="float" Length="7" SignificantDigits="4" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - VITB12</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.11" Name="LBSTRESC" DataType="float" Length="7" SignificantDigits="5" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - HGB</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.12" Name="LBSTRESC" DataType="integer" Length="1" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - Set 4</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.13" Name="LBSTRESC" DataType="integer" Length="2" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - Set 5</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.14" Name="LBSTRESC" DataType="integer" Length="3" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - Set 6</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.15" Name="LBSTRESC" DataType="integer" Length="4" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - CK</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.16" Name="LBSTRESC" DataType="text" Length="1" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - COLOR</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NORMABNM"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESC.17" Name="LBSTRESC" DataType="text" Length="8" SASFieldName="LBSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">Character Result/Finding in Std Format - GLUC</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.1" Name="LBSTRESU" DataType="text" Length="3" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - ALT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.2" Name="LBSTRESU" DataType="text" Length="3" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - ALB</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_g/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.3" Name="LBSTRESU" DataType="text" Length="3" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - ALP</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.4" Name="LBSTRESU" DataType="text" Length="3" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - AST</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.5" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - BASO</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.6" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - BILI</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_umol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.7" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - CA</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.8" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - CL</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.9" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - CHOL</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.10" Name="LBSTRESU" DataType="text" Length="3" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - CK</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.11" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - CREAT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_umol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.12" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - EOS</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.13" Name="LBSTRESU" DataType="text" Length="4" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - MCH</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_fmol"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.14" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - MCHC</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.15" Name="LBSTRESU" DataType="text" Length="2" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - MCV</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_fL"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.16" Name="LBSTRESU" DataType="text" Length="7" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - RBC</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^12/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.17" Name="LBSTRESU" DataType="text" Length="3" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - GGT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_U/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.18" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - GLUC</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.19" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - HGB</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.20" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - WBC</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.21" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - LYM</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.22" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - MONO</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.23" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - PHOS</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.24" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - PLAT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_10^9/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.25" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - K</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.26" Name="LBSTRESU" DataType="text" Length="3" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - PROT</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_g/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.27" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - SODIUM</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.28" Name="LBSTRESU" DataType="text" Length="4" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - TSH</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mU/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.29" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - URATE</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_umol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.30" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - UREAN</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_mmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.LB.LBSTRESU.31" Name="LBSTRESU" DataType="text" Length="6" SASFieldName="LBSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Lab Result Standard Units - VITB12</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_LB_pmol/L"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OEORRES.1" Name="OEORRES" DataType="text" Length="8" SASFieldName="OEORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NORMABNM"/>
+      </ItemDef>
+      <ItemDef OID="IT.OE.OEORRES.2" Name="OEORRES" DataType="text" Length="200" SASFieldName="OEORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Result or Finding in Original Units</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSORRES.1" Name="QSORRES" DataType="text" Length="23" SASFieldName="QSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">PHQ-9 Questions 1-9</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PHQ01R"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSORRES.2" Name="QSORRES" DataType="text" Length="20" SASFieldName="QSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">PHQ-9 Question 10</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PHQ01RQ10"/>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSORRES.3" Name="QSORRES" DataType="integer" Length="8" SASFieldName="QSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">PHQ-9 Question Total</TranslatedText>
+        </Description>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSSTRESC.1" Name="QSSTRESC" DataType="integer" Length="8" SASFieldName="QSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">PHQ-9 Questions 1-9, Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PHQ01RS"/>
+        <def:Origin Type="Derived" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSSTRESC.2" Name="QSSTRESC" DataType="text" Length="20" SASFieldName="QSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">PHQ-9 Question 10, Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.PHQ01RQ10"/>
+        <def:Origin Type="Derived" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.QSPH.QSSTRESC.3" Name="QSSTRESC" DataType="integer" Length="8" SASFieldName="QSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">PHQ-9 Question Total, Standardized</TranslatedText>
+        </Description>
+        <def:Origin Type="Predecessor">
+          <Description>
+            <TranslatedText xml:lang="en">QSORRES where QSTESTCD EQ PHQ0111</TranslatedText>
+          </Description>
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="15" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RACE.1" Name="RACE" DataType="text" Length="41" SASFieldName="RACE">
+        <Description>
+          <TranslatedText xml:lang="en">Race</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.DM.RACE.2" Name="RACE" DataType="text" Length="8" SASFieldName="RACE">
+        <Description>
+          <TranslatedText xml:lang="en">Race</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACEMULT"/>
+        <def:Origin Type="Assigned" Source="Sponsor">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.1" Name="RSORRES" DataType="text" Length="111" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 1</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD101"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.2" Name="RSORRES" DataType="text" Length="93" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 2</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD102"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.3" Name="RSORRES" DataType="text" Length="66" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 3</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD103"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.4" Name="RSORRES" DataType="text" Length="74" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 4</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD104"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.5" Name="RSORRES" DataType="text" Length="90" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 5</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD105"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.6" Name="RSORRES" DataType="text" Length="60" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 6</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD106"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.7" Name="RSORRES" DataType="text" Length="198" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 7</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD107"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.8" Name="RSORRES" DataType="text" Length="41" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 8</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD108"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.9" Name="RSORRES" DataType="text" Length="57" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 9</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD109"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.10" Name="RSORRES" DataType="text" Length="49" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 10</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD110"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.11" Name="RSORRES" DataType="text" Length="15" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 11</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD111"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.12" Name="RSORRES" DataType="text" Length="141" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 12</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD112"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.13" Name="RSORRES" DataType="text" Length="102" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 13</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD113"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.14" Name="RSORRES" DataType="text" Length="7" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 14</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD114"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.15" Name="RSORRES" DataType="text" Length="44" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 15</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD115"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.16" Name="RSORRES" DataType="text" Length="53" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 16A</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD116A"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.17" Name="RSORRES" DataType="text" Length="42" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 16B</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD116B"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.18" Name="RSORRES" DataType="text" Length="100" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 17</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD117"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSORRES.19" Name="RSORRES" DataType="integer" Length="8" SASFieldName="RSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 18</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.1" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 1 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD101S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.2" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 2 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD102S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.3" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 3 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD103S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.4" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 4 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD104S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.5" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 5 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD105S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.6" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 6 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD106S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.7" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 7 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD107S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.8" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 8 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD108S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.9" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 9 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD109S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.10" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 10 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD110S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.11" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 11 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD111S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.12" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 12 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD112S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.13" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 13 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD113S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.14" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 14 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD114S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.15" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 15 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD115S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.16" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 16A Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD116AS"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.17" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 16B Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD116BS"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.18" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 17 Standardized</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.HAMD117S"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.RS.RSSTRESC.19" Name="RSSTRESC" DataType="integer" Length="8" SASFieldName="RSSTRESC">
+        <Description>
+          <TranslatedText xml:lang="en">HAMD-17 Question 18 Standardized</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="19" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.1" Name="RACE1" DataType="text" Length="41" SASFieldName="RACE1">
+        <Description>
+          <TranslatedText xml:lang="en">Race 1</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.2" Name="RACE2" DataType="text" Length="41" SASFieldName="RACE2">
+        <Description>
+          <TranslatedText xml:lang="en">Race 2</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.3" Name="RACE3" DataType="text" Length="41" SASFieldName="RACE3">
+        <Description>
+          <TranslatedText xml:lang="en">Race 3</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.4" Name="RACE4" DataType="text" Length="41" SASFieldName="RACE4"
+        def:CommentOID="COM.DM3">
+        <Description>
+          <TranslatedText xml:lang="en">Race 4</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPDM.QVAL.5" Name="RACE5" DataType="text" Length="41" SASFieldName="RACE5"
+        def:CommentOID="COM.DM4">
+        <Description>
+          <TranslatedText xml:lang="en">Race 5</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.RACE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="5" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPEC.QVAL.1" Name="ECREASOC" DataType="text" Length="200" SASFieldName="ECREASOC">
+        <Description>
+          <TranslatedText xml:lang="en">Reason for Occur Value</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPNV.QVAL.1" Name="NVCLSIG" DataType="text" Length="1" SASFieldName="NVCLSIG">
+        <Description>
+          <TranslatedText xml:lang="en">Clinically Significant</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_YONLY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="20" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.SUPPOE.QVAL.1" Name="OECLSIG" DataType="text" Length="1" SASFieldName="OECLSIG">
+        <Description>
+          <TranslatedText xml:lang="en">Clinically Significant</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="21" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.1" Name="TSVAL" DataType="text" Length="1" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Summary Yes No Responses</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.NY_NY"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.2" Name="TSVAL" DataType="integer" Length="8" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Maximum Age of Subjects</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.3" Name="TSVAL" DataType="date" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Summary Date Responses</TranslatedText>
+        </Description>
+        <def:Origin Type="Assigned" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.4" Name="TSVAL" DataType="text" Length="9" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Form</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FRM_ECEX"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.5" Name="TSVAL" DataType="text" Length="2" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Dosing Frequency</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.FREQ_ECEX"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.6" Name="TSVAL" DataType="text" Length="2" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Dose Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.UNIT_EX"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.7" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Planned Country of Investigational Sites</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ISO3166"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.8" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Disease/Condition Indication</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SNOMED"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.9" Name="TSVAL" DataType="text" Length="8" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Intervention Model</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.INTMODEL"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.10" Name="TSVAL" DataType="text" Length="4" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Intervention Type</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.INTTYPE"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.11" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Length</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.12" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Primary Objective</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.13" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Secondary Objective</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.14" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Primary Outcome Measure</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.15" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Pharmacologic Class</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.16" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Randomization Quotient</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.17" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Registry Identifier</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.18" Name="TSVAL" DataType="text" Length="12" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.ROUTE_ECEX"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.19" Name="TSVAL" DataType="float" Length="2" SignificantDigits="1" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">SDTM IG Version</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.20" Name="TSVAL" DataType="text" Length="1" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Sex of Participants</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SEX"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.21" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Clinical Study Sponsor</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.22" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Study Stop Rules</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.23" Name="TSVAL" DataType="text" Length="14" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Study Type</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.STYPE"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.24" Name="TSVAL" DataType="text" Length="12" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Blinding Schema</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TBLIND"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.25" Name="TSVAL" DataType="text" Length="7" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Control Type</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TCNTRL"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.26" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Diagnosis Group</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.SNOMED"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.27" Name="TSVAL" DataType="text" Length="9" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Intent Type</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TINDTP"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.28" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Title</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.29" Name="TSVAL" DataType="text" Length="14" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Phase Classification</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TPHASE"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.30" Name="TSVAL" DataType="text" Length="200" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Investigational Therapy or Treatment</TranslatedText>
+        </Description>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.TS.TSVAL.31" Name="TSVAL" DataType="text" Length="15" SASFieldName="TSVAL">
+        <Description>
+          <TranslatedText xml:lang="en">Trial Type</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.TTYPE"/>
+        <def:Origin Type="Protocol" Source="Sponsor"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.1" Name="VSORRES" DataType="integer" Length="8" SASFieldName="VSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Blood Pressure</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13 14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.2" Name="VSORRES" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Height</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.3" Name="VSORRES" DataType="integer" Length="8" SASFieldName="VSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Pulse Rate</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13 14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.5" Name="VSORRES" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Temperature</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13 14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRES.6" Name="VSORRES" DataType="float" Length="8" SignificantDigits="2" SASFieldName="VSORRES">
+        <Description>
+          <TranslatedText xml:lang="en">Weight</TranslatedText>
+        </Description>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 12 13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.1" Name="VSORRESU" DataType="text" Length="4" SASFieldName="VSORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Blood Pressure Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_BP"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13 14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.2" Name="VSORRESU" DataType="text" Length="2" SASFieldName="VSORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Height Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_HEIGHT"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.3" Name="VSORRESU" DataType="text" Length="9" SASFieldName="VSORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Pulse Rate Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_PULSE"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13 14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.5" Name="VSORRESU" DataType="text" Length="1" SASFieldName="VSORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Temperature Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_TEMP"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 10 11 12 13 14" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSORRESU.6" Name="VSORRESU" DataType="text" Length="2" SASFieldName="VSORRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Weight Units</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_WT"/>
+        <def:Origin Type="Collected" Source="Investigator">
+          <def:DocumentRef leafID="LF.acrf">
+            <def:PDFPageRef PageRefs="8 9 12 13" Type="PhysicalRef"/>
+          </def:DocumentRef>
+        </def:Origin>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESU.1" Name="VSSTRESU" DataType="text" Length="4" SASFieldName="VSSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Blood Pressure Units Std</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_BP_STD"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESU.2" Name="VSSTRESU" DataType="text" Length="2" SASFieldName="VSSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Height Units Std</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_HEIGHT_STD"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESU.3" Name="VSSTRESU" DataType="text" Length="9" SASFieldName="VSSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Pulse Rate Units Std</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_PULSE_STD"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESU.5" Name="VSSTRESU" DataType="text" Length="1" SASFieldName="VSSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Temperature Units Std</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_TEMP_STD"/>
+      </ItemDef>
+      <ItemDef OID="IT.VS.VSSTRESU.6" Name="VSSTRESU" DataType="text" Length="2" SASFieldName="VSSTRESU">
+        <Description>
+          <TranslatedText xml:lang="en">Weight Units Std</TranslatedText>
+        </Description>
+        <CodeListRef CodeListOID="CL.VS_UNIT_WT_STD"/>
+      </ItemDef>
+
+
+      <!-- ******************************** -->
+      <!-- Code List Definitions Section    -->
+      <!-- ******************************** -->
+
+      <CodeList OID="CL.ACN" Name="Action Taken with Study Treatment" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT1">
+        <CodeListItem CodedValue="DOSE INCREASED" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Dose Increased</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49503"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSE NOT CHANGED" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Dose Not Changed</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49504"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSE REDUCED" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Dose Reduced</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49505"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DRUG INTERRUPTED" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Drug Interrupted</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49501"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DRUG WITHDRAWN" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Drug Withdrawn</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49502"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NOT APPLICABLE" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Not Applicable</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48660"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="UNKNOWN" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">Unknown</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C17998"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66767"/>
+      </CodeList>
+      <CodeList OID="CL.AEREL" Name="Relationship" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT2">
+        <CodeListItem CodedValue="RELATED" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Related</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="UNLIKELY RELATED" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Unlikely Related</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="POSSIBLY RELATED" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Possibly Related</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="NOT RELATED" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Not Related</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.AESEV" Name="Severity/Intensity Scale for Adverse Events" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT3">
+        <CodeListItem CodedValue="MILD" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Mild</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41338"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MODERATE" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Moderate</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41339"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SEVERE" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Severe</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41340"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66769"/>
+      </CodeList>
+      <CodeList OID="CL.AGEU_YEARS" Name="Age Unit in Years" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT4">
+        <CodeListItem CodedValue="YEARS" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Years</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C29848"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66781"/>
+      </CodeList>
+      <CodeList OID="CL.ARM" Name="Arm" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Placebo" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Zanomaline Low Dose (54 mg)" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Zanomaline High Dose (81 mg)" OrderNumber="3"/>
+      </CodeList>
+      <CodeList OID="CL.ARMCD" Name="Arm Code" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT6">
+        <CodeListItem CodedValue="PLACEBO" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Placebo</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="ZAN_LOW" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Zanomaline Low Dose (54 mg)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="ZAN_HIGH" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Zanomaline High Dose (81 mg)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.ARMNRS" Name="Arm Null Reason" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT7">
+        <CodeListItem CodedValue="SCREEN FAILURE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Screen Failure</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49628"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C142179"/>
+      </CodeList>
+      <CodeList OID="CL.AVL02TC" Name="Rey Auditory Verbal Learning Test Functional Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT8">
+        <CodeListItem CodedValue="AVL0201" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 1</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123683"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0202" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 2</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123684"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0203" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 3</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123685"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0204" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 4</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123686"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0205" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 5</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123687"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0206" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 6</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123688"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0207" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 7</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123689"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0208" OrderNumber="8">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 8</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123690"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0209" OrderNumber="9">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 9</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123691"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0210" OrderNumber="10">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 10</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123692"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0211" OrderNumber="11">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 11</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123693"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0212" OrderNumber="12">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 12</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123694"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0213" OrderNumber="13">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 13</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123695"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0214" OrderNumber="14">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 14</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123696"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0215" OrderNumber="15">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Word 15</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123697"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0216" OrderNumber="16">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Total</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123698"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0217" OrderNumber="17">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List A Intrusions</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123699"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0218" OrderNumber="18">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 1</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123700"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0219" OrderNumber="19">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 2</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123701"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0220" OrderNumber="20">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 3</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123702"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0221" OrderNumber="21">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 4</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123703"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0222" OrderNumber="22">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 5</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123704"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0223" OrderNumber="23">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 6</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123705"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0224" OrderNumber="24">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 7</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123706"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0225" OrderNumber="25">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 8</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123707"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0226" OrderNumber="26">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 9</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123708"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0227" OrderNumber="27">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 10</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123709"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0228" OrderNumber="28">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 11</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123710"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0229" OrderNumber="29">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 12</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123711"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0230" OrderNumber="30">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 13</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123712"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0231" OrderNumber="31">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 14</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123713"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0232" OrderNumber="32">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Word 15</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123714"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0233" OrderNumber="33">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Total</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123715"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AVL0234" OrderNumber="34">
+          <Decode>
+            <TranslatedText xml:lang="en">AVLT-REY - List B Intrusions</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123716"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C123655"/>
+      </CodeList>
+      <CodeList OID="CL.AVL02TR" Name="Rey Auditory Verbal Learning Test Functional Test Response" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT9">
+        <CodeListItem CodedValue="RECALLED" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Recalled</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="NOT RECALLED" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Not Recalled</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.AVL02TT" Name="Rey Auditory Verbal Learning Test Functional Test Name" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="AVL02- List B Total" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C123715"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Intrusions" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C123699"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Total" OrderNumber="3">
+          <Alias Context="nci:ExtCodeID" Name="C123698"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 1" OrderNumber="4">
+          <Alias Context="nci:ExtCodeID" Name="C123683"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 10" OrderNumber="5">
+          <Alias Context="nci:ExtCodeID" Name="C123692"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 11" OrderNumber="6">
+          <Alias Context="nci:ExtCodeID" Name="C123693"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 12" OrderNumber="7">
+          <Alias Context="nci:ExtCodeID" Name="C123694"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 13" OrderNumber="8">
+          <Alias Context="nci:ExtCodeID" Name="C123695"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 14" OrderNumber="9">
+          <Alias Context="nci:ExtCodeID" Name="C123696"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 15" OrderNumber="10">
+          <Alias Context="nci:ExtCodeID" Name="C123697"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 2" OrderNumber="11">
+          <Alias Context="nci:ExtCodeID" Name="C123684"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 3" OrderNumber="12">
+          <Alias Context="nci:ExtCodeID" Name="C123685"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 4" OrderNumber="13">
+          <Alias Context="nci:ExtCodeID" Name="C123686"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 5" OrderNumber="14">
+          <Alias Context="nci:ExtCodeID" Name="C123687"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 6" OrderNumber="15">
+          <Alias Context="nci:ExtCodeID" Name="C123688"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 7" OrderNumber="16">
+          <Alias Context="nci:ExtCodeID" Name="C123689"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 8" OrderNumber="17">
+          <Alias Context="nci:ExtCodeID" Name="C123690"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List A Word 9" OrderNumber="18">
+          <Alias Context="nci:ExtCodeID" Name="C123691"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Intrusions" OrderNumber="19">
+          <Alias Context="nci:ExtCodeID" Name="C123716"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 1" OrderNumber="20">
+          <Alias Context="nci:ExtCodeID" Name="C123700"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 10" OrderNumber="21">
+          <Alias Context="nci:ExtCodeID" Name="C123709"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 11" OrderNumber="22">
+          <Alias Context="nci:ExtCodeID" Name="C123710"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 12" OrderNumber="23">
+          <Alias Context="nci:ExtCodeID" Name="C123711"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 13" OrderNumber="24">
+          <Alias Context="nci:ExtCodeID" Name="C123712"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 14" OrderNumber="25">
+          <Alias Context="nci:ExtCodeID" Name="C123713"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 15" OrderNumber="26">
+          <Alias Context="nci:ExtCodeID" Name="C123714"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 2" OrderNumber="27">
+          <Alias Context="nci:ExtCodeID" Name="C123701"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 3" OrderNumber="28">
+          <Alias Context="nci:ExtCodeID" Name="C123702"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 4" OrderNumber="29">
+          <Alias Context="nci:ExtCodeID" Name="C123703"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 5" OrderNumber="30">
+          <Alias Context="nci:ExtCodeID" Name="C123704"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 6" OrderNumber="31">
+          <Alias Context="nci:ExtCodeID" Name="C123705"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 7" OrderNumber="32">
+          <Alias Context="nci:ExtCodeID" Name="C123706"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 8" OrderNumber="33">
+          <Alias Context="nci:ExtCodeID" Name="C123707"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="AVL02-List B Word 9" OrderNumber="34">
+          <Alias Context="nci:ExtCodeID" Name="C123708"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C123654"/>
+      </CodeList>
+      <CodeList OID="CL.DDTEST" Name="Death Details Tests" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="Primary Cause of Death" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C99531"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C116107"/>
+      </CodeList>
+      <CodeList OID="CL.DDTESTCD" Name="Death Details Test Codes" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT12">
+        <CodeListItem CodedValue="PRCDTH" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Primary Cause of Death</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C99531"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C116108"/>
+      </CodeList>
+      <CodeList OID="CL.DIPARM" Name="Device Identifier Element Name" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="Device Type" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C53265"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Serial Number" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C73518"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C106480"/>
+      </CodeList>
+      <CodeList OID="CL.DIPARMCD" Name="Device Identifier Element Short Name" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT14">
+        <CodeListItem CodedValue="DEVTYPE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Device Type</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C53265"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SERIAL" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Serial Number</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C73518"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C106481"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_AE" Name="SDTM Domain Abbreviation, subset used for Adverse Events" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT15">
+        <CodeListItem CodedValue="AE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Adverse Events</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49562"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_CM" Name="SDTM Domain Abbreviation, subset used for Concomitant Meds" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT16">
+        <CodeListItem CodedValue="CM" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Concomitant/Prior Medications</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49568"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_DD" Name="SDTM Domain Abbreviation, subset used for Death Diagnosis" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT17">
+        <CodeListItem CodedValue="DD" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Death Details</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C95087"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_DI" Name="SDTM Domain Abbreviation, subset used for Device Identifiers" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT18">
+        <CodeListItem CodedValue="DI" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Device Identifiers</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C102618"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_DM" Name="SDTM Domain Abbreviation, subset used for Demographics" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT19">
+        <CodeListItem CodedValue="DM" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Demographics</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49572"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_DS" Name="SDTM Domain Abbreviation, subset used for Disposition" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT20">
+        <CodeListItem CodedValue="DS" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Disposition</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49576"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_EC" Name="SDTM Domain Abbreviation, subset used for Exposure as Collected" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT21">
+        <CodeListItem CodedValue="EC" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Exposure as Collected</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C117466"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_EX" Name="SDTM Domain Abbreviation, subset used for Exposure" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT22">
+        <CodeListItem CodedValue="EX" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Exposure</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49587"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_FA" Name="SDTM Domain Abbreviation, subset used for Findings About Events or Interventions" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT23">
+        <CodeListItem CodedValue="FA" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Findings About Events or Interventions</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C85442"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_FT" Name="SDTM Domain Abbreviation, subset used for Functional Tests" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT24">
+        <CodeListItem CodedValue="FT" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Functional Tests</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C117756"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_IE" Name="SDTM Domain Abbreviation, subset used for Inclusion/Exclusion" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT25">
+        <CodeListItem CodedValue="IE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Inclusion/Exclusion Criteria Not Met</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C61536"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_LB" Name="SDTM Domain Abbreviation, subset used for Laboratory Data" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT26">
+        <CodeListItem CodedValue="LB" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Laboratory Test Results</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49592"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_MH" Name="SDTM Domain Abbreviation, subset used for Medical History" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT27">
+        <CodeListItem CodedValue="MH" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Medical History</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49603"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_NV" Name="SDTM Domain Abbreviation, subset used for Nervous System Findings" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT28">
+        <CodeListItem CodedValue="NV" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Nervous Sysytem Findings</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49592"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_OE" Name="SDTM Domain Abbreviation, subset used for Ophthalmic Examinations" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT29">
+        <CodeListItem CodedValue="OE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Ophthalmic Examinations</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C147180"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_QS" Name="SDTM Domain Abbreviation, subset used for Questionnaires" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT30">
+        <CodeListItem CodedValue="QS" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Questionnaires</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49609"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_RS" Name="SDTM Domain Abbreviation, subset used for Disease Response and Clin Classification" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT31">
+        <CodeListItem CodedValue="RS" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Disease Response and Clin Classification</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C107097"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_SE" Name="SDTM Domain Abbreviation, subset used for Subject Element" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT32">
+        <CodeListItem CodedValue="SE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Subject Elements</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49616"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_SV" Name="SDTM Domain Abbreviation, subset used for Subject Visits" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT33">
+        <CodeListItem CodedValue="SV" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Subject Visits</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49617"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_TA" Name="SDTM Domain Abbreviation, subset used for Trial Arms" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT34">
+        <CodeListItem CodedValue="TA" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Arms</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49618"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_TE" Name="SDTM Domain Abbreviation, subset used for Trial Elements" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT35">
+        <CodeListItem CodedValue="TE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Elements</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49619"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_TI" Name="SDTM Domain Abbreviation, subset used for Trial Inclusion/Exclusion Criteria" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT36">
+        <CodeListItem CodedValue="TI" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Inclusion</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49620"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_TS" Name="SDTM Domain Abbreviation, subset used for Trial Summary" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT37">
+        <CodeListItem CodedValue="TS" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Summary</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C53483"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_TV" Name="SDTM Domain Abbreviation, subset used for Trial Visits" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT38">
+        <CodeListItem CodedValue="TV" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Visits</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49621"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DOMAIN_VS" Name="SDTM Domain Abbreviation, subset used for Vital Signs" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT39">
+        <CodeListItem CodedValue="VS" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Vital Signs</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49622"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.DSCAT" Name="Category for Disposition Event" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT40">
+        <CodeListItem CodedValue="DISPOSITION EVENT" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Disposition Event</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C74590"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PROTOCOL MILESTONE" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Protocol Milestone</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C74588"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C74558"/>
+      </CodeList>
+      <CodeList OID="CL.DSSCAT" Name="Subcategory for Disposition Event" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT41">
+        <CodeListItem CodedValue="STUDY TREATMENT" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Study Treatment</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="STUDY PARTICIPATION" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Study Participation</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.ELEMENT" Name="Element" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Screening" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Placebo" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Zanomaline 54 mg" OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Zanomaline 54 mg Titration" OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Zanomaline 81 mg" OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.ENRTPT_CM_AE" Name="Relation to Reference Period, subset used for AE and CM." DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT43">
+        <CodeListItem CodedValue="ONGOING" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Ongoing</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C53279"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66728"/>
+      </CodeList>
+      <CodeList OID="CL.EPOCH" Name="Epoch" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT44">
+        <CodeListItem CodedValue="SCREENING" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Screening</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48262"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TREATMENT" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Treatment</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C101526"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C99079"/>
+      </CodeList>
+      <CodeList OID="CL.ETCD" Name="Element Code" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT45">
+        <CodeListItem CodedValue="HIGH" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Zanomaline 81 mg</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="LOW" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Zanomaline 54 mg</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PLACEBO" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Placebo</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="SCREEN" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Screening</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="TITRATE" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Zanomaline 54 mg Titration</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.ETHNIC" Name="Ethnic Group Hispanic" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT46">
+        <CodeListItem CodedValue="HISPANIC OR LATINO" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Hispanic or Latino</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C17459"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NOT HISPANIC OR LATINO" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Not Hispanic or Latino</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C17459"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66790"/>
+      </CodeList>
+      <CodeList OID="CL.EXTRT" Name="Study Treatment" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT47">
+        <CodeListItem CodedValue="PLACEBO" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Placebo</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="ZANOMALINE" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Zanomaline</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.FACAT" Name="FA Category" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT48">
+        <CodeListItem CodedValue="INJECTION SITE REACTION" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Injection Site Reaction</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.FAOBJ" Name="FA Object" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT49">
+        <CodeListItem CodedValue="ERYTHEMA" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Erythema</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PAIN" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Pain</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INDURATION" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Induration</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="PRURITUS" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Pruritus</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EDEMA" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Edema</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.FAOCCUR" Name="Occurrence" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT50">
+        <CodeListItem CodedValue="N" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">No</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49487"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="Y" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Yes</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49488"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66742"/>
+      </CodeList>
+      <CodeList OID="CL.FASEV" Name="Severity" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT51">
+        <CodeListItem CodedValue="MILD" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Mild</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41338"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MODERATE" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Moderate</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41339"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SEVERE" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Severe</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41340"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66769"/>
+      </CodeList>
+      <CodeList OID="CL.FATEST" Name="Findings About Adverse Events Test Name" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Occurrence Indicator" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Severity/Intensity" OrderNumber="2"/>
+      </CodeList>
+      <CodeList OID="CL.FATESTCD" Name="Findings About Adverse Events Test Code" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT53">
+        <CodeListItem CodedValue="OCCUR" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Occurrence Indicator</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="SEV" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Severity/Intensity</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.FREQ_CM" Name="Frequency, subset used for CM" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT54">
+        <CodeListItem CodedValue="QD" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Daily</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25473"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PRN" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">As Needed</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64499"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="BID" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Twice Daily</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64496"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="Q4H" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Every Four Hours</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64518"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="QID" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Four Times Daily</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64530"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="Q6H" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Every Six Hours</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64520"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71113"/>
+      </CodeList>
+      <CodeList OID="CL.FREQ_ECEX" Name="Frequency, subset used for EC and EX" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT55">
+        <CodeListItem CodedValue="QD" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Daily</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25473"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71113"/>
+      </CodeList>
+      <CodeList OID="CL.FRM_ECEX" Name="Dose Form, subset used for EC and EX" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT56">
+        <CodeListItem CodedValue="INJECTION" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Injectable Dosage Form</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C42946"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66726"/>
+      </CodeList>
+      <CodeList OID="CL.FTCAT" Name="Category of Functional Test, subset used for FTCAT" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT57">
+        <CodeListItem CodedValue="AVLT-REY" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Rey Auditory Verbal Learning Functional Test</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C123668"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C115304"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD101" Name="Hamilton Depression Rating Scale - 17 Item - Question 1" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Absent." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="These feeling states indicated only on questioning." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="These feeling states spontaneously reported verbally." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Communicates feeling states non-verbally, i.e. through facial expression, posture, voice and tendency to weep." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Patient reports virtually only these feeling states in his/her spontaneous verbal and non-verbal communication." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD101S" Name="Hamilton Depression Rating Scale - 17 Item - Question 1 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT59">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Absent.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">These feeling states indicated only on questioning.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">These feeling states spontaneously reported verbally.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Communicates feeling states non-verbally, i.e. through facial expression, posture, voice and tendency to weep.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Patient reports virtually only these feeling states in his/her spontaneous verbal and non-verbal communication.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD102" Name="Hamilton Depression Rating Scale - 17 Item - Question 2" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Absent." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Self reproach, feels he/she has let people down." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Ideas of guilt or rumination over past errors or sinful deeds." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Present illness is a punishment. Delusions of guilt." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Hears accusatory or denunciatory voices and/or experiences threatening visual hallucinations." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD102S" Name="Hamilton Depression Rating Scale - 17 Item - Question 2 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT61">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Absent.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Self reproach, feels he/she has let people down.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Ideas of guilt or rumination over past errors or sinful deeds.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Present illness is a punishment. Delusions of guilt.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Hears accusatory or denunciatory voices and/or experiences threatening visual hallucinations.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD103" Name="Hamilton Depression Rating Scale - 17 Item - Question 3" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Absent." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Feels life is not worth living." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Wishes he/she were dead or any thoughts of possible death to self." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Ideas or gestures of suicide." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Attempts at suicide (any serious attempt rate 4)." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD103S" Name="Hamilton Depression Rating Scale - 17 Item - Question 3 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT63">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Absent.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Feels life is not worth living.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Wishes he/she were dead or any thoughts of possible death to self.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Ideas or gestures of suicide.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Attempts at suicide (any serious attempt rate 4).</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD104" Name="Hamilton Depression Rating Scale - 17 Item - Question 4" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="No difficulty falling asleep." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Complains of occasional difficulty falling asleep, i.e. more than 1/2 hour" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Complains of nightly difficulty falling asleep." OrderNumber="3"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD104S" Name="Hamilton Depression Rating Scale - 17 Item - Question 4 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT65">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">No difficulty falling asleep.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Complains of occasional difficulty falling asleep, i.e. more than 1/2 hour</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Complains of nightly difficulty falling asleep.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD105" Name="Hamilton Depression Rating Scale - 17 Item - Question 5" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="No difficulty." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Patient complains of being restless and disturbed during the night." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Waking during the night - any getting out of bed rates 2 (except for purposes of voiding)." OrderNumber="3"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD105S" Name="Hamilton Depression Rating Scale - 17 Item - Question 5 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT67">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">No difficulty.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Patient complains of being restless and disturbed during the night.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Waking during the night - any getting out of bed rates 2 (except for purposes of voiding).</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD106" Name="Hamilton Depression Rating Scale - 17 Item - Question 6" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="No difficulty." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Waking in early hours of the morning but goes back to sleep." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Unable to fall asleep again if he/she gets out of bed." OrderNumber="3"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD106S" Name="Hamilton Depression Rating Scale - 17 Item - Question 6 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT69">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">No difficulty.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Waking in early hours of the morning but goes back to sleep.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Unable to fall asleep again if he/she gets out of bed.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD107" Name="Hamilton Depression Rating Scale - 17 Item - Question 7" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="No difficulty." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Thoughts and feelings of incapacity, fatigue or weakness related to activities, work or hobbies." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Loss of interest in activity, hobbies or work - either directly reported by the patient or indirect in listlessness, indecision and vacillation (feels he/she has to push self to work or activities)." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Decrease in actual time spent in activities or decrease in productivity. Rate 3 if the patient does not spend at least three hours a day in activities (job or hobbies) excluding routine chores." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Stopped working because of present illness. Rate 4 if patient engages in no activities except routine chores, or if patient fails to perform routine chores unassisted." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD107S" Name="Hamilton Depression Rating Scale - 17 Item - Question 7 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT71">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">No difficulty.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Thoughts and feelings of incapacity, fatigue or weakness related to activities, work or hobbies.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Loss of interest in activity, hobbies or work - either directly reported by the patient or indirect in listlessness, indecision and vacillation (feels he/she has to push self to work or activities).</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Decrease in actual time spent in activities or decrease in productivity. Rate 3 if the patient does not spend at least three hours a day in activities (job or hobbies) excluding routine chores.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Stopped working because of present illness. Rate 4 if patient engages in no activities except routine chores, or if patient fails to perform routine chores unassisted.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD108" Name="Hamilton Depression Rating Scale - 17 Item - Question 8" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Normal speech and thought." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Slight retardation during the interview." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Obvious retardation during the interview." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Interview difficult." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Complete stupor." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD108S" Name="Hamilton Depression Rating Scale - 17 Item - Question 8 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT73">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Normal speech and thought.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Slight retardation during the interview.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Obvious retardation during the interview.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Interview difficult.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Complete stupor.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD109" Name="Hamilton Depression Rating Scale - 17 Item - Question 9" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="None." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Fidgetiness." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Playing with hands, hair, etc." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Moving about, cannot sit still." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Hand wringing, nail biting, hair-pulling, biting of lips." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD109S" Name="Hamilton Depression Rating Scale - 17 Item - Question 9 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT75">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">None.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Fidgetiness.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Playing with hands, hair, etc.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Moving about, cannot sit still.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Hand wringing, nail biting, hair-pulling, biting of lips.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD110" Name="Hamilton Depression Rating Scale - 17 Item - Question 10" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="No difficulty." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Subjective tension and irritability." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Worrying about minor matters." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Apprehensive attitude apparent in face or speech." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Fears expressed without questioning." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD110S" Name="Hamilton Depression Rating Scale - 17 Item - Question 10 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT77">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">No difficulty.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Subjective tension and irritability.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Worrying about minor matters.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Apprehensive attitude apparent in face or speech.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Fears expressed without questioning.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD111" Name="Hamilton Depression Rating Scale - 17 Item - Question 11" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Absent." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Mild." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Moderate." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Severe." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Incapacitating." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD111S" Name="Hamilton Depression Rating Scale - 17 Item - Question 11 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT79">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Absent.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Mild.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Moderate.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Severe.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Incapacitating.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD112" Name="Hamilton Depression Rating Scale - 17 Item - Question 12" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="None." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Loss of appetite but eating without staff encouragement. Heavy feelings in abdomen." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Difficulty eating without staff urging. Requests or requires laxatives or medication for bowels or medication for gastro-intestinal symptoms." OrderNumber="3"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD112S" Name="Hamilton Depression Rating Scale - 17 Item - Question 12 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT81">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">None.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Loss of appetite but eating without staff encouragement. Heavy feelings in abdomen.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Difficulty eating without staff urging. Requests or requires laxatives or medication for bowels or medication for gastro-intestinal symptoms.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD113" Name="Hamilton Depression Rating Scale - 17 Item - Question 13" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="None." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Heaviness in limbs, back or head. Backaches, headaches, muscle aches. Loss of energy and fatigability." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Any clear-cut symptom rates 2." OrderNumber="3"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD113S" Name="Hamilton Depression Rating Scale - 17 Item - Question 13 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT83">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">None.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Heaviness in limbs, back or head. Backaches, headaches, muscle aches. Loss of energy and fatigability.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Any clear-cut symptom rates 2.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD114" Name="Hamilton Depression Rating Scale - 17 Item - Question 14" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Absent." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Mild." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Severe." OrderNumber="3"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD114S" Name="Hamilton Depression Rating Scale - 17 Item - Question 14 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT85">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Absent.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Mild.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Severe.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD115" Name="Hamilton Depression Rating Scale - 17 Item - Question 15" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Not present." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Self-absorption (bodily)." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Preoccupation with health." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Frequent complaints, requests for help, etc." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Hypochondriacal delusions." OrderNumber="5"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD115S" Name="Hamilton Depression Rating Scale - 17 Item - Question 15 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT87">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Not present.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Self-absorption (bodily).</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Preoccupation with health.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Frequent complaints, requests for help, etc.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Hypochondriacal delusions.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD116A" Name="Hamilton Depression Rating Scale - 17 Item - Question 16A" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="No weight loss." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Probable weight loss associated with present illness." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Definite (according to patient) weight loss." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Not assessed." OrderNumber="4"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD116AS" Name="Hamilton Depression Rating Scale - 17 Item - Question 16A Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT89">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">No weight loss.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Probable weight loss associated with present illness.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Definite (according to patient) weight loss.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Not assessed.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD116B" Name="Hamilton Depression Rating Scale - 17 Item - Question 16B" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Less than 1 lb weight loss in week." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Greater than 1 lb weight loss within week." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Greater than 2 lb weight loss in week." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Not assessed." OrderNumber="4"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD116BS" Name="Hamilton Depression Rating Scale - 17 Item - Question 16B Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT91">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Less than 1 lb weight loss in week.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Greater than 1 lb weight loss within week.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Greater than 2 lb weight loss in week.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Not assessed.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD117" Name="Hamilton Depression Rating Scale - 17 Item - Question 17" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Acknowledges being depressed and ill." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Acknowledges illness but attributes cause to bad food, climate, overwork, virus, need for rest, etc." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Denies being ill at all." OrderNumber="3"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD117S" Name="Hamilton Depression Rating Scale - 17 Item - Question 17 Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT93">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Acknowledges being depressed and ill.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Acknowledges illness but attributes cause to bad food, climate, overwork, virus, need for rest, etc.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Denies being ill at all.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.HAMD17C" Name="Hamilton Depression Rating Scale - 17 Item Clinical Classification Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT94">
+        <CodeListItem CodedValue="HAMD101" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Depressed Mood</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100398"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD102" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Feelings of Guilt</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100399"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD103" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Suicide</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100400"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD104" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Insomnia Early - Early Night</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100401"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD105" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Insomnia Middle - Middle Night</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100402"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD106" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Insomnia Early Hours - Morning</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100403"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD107" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Work and Activities</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100404"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD108" OrderNumber="8">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Retardation</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100405"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD109" OrderNumber="9">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Agitation</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100406"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD110" OrderNumber="10">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Anxiety Psychic</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100407"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD111" OrderNumber="11">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Anxiety Somatic</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100408"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD112" OrderNumber="12">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Somatic Symptoms GI</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100409"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD113" OrderNumber="13">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-General Somatic Symptoms</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100410"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD114" OrderNumber="14">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Genital Symptoms</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100411"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD115" OrderNumber="15">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Hypochondriasis</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100412"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD116A" OrderNumber="16">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Loss of WT According to Patient</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100413"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD116B" OrderNumber="17">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Loss of WT According to WK Meas</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100414"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD117" OrderNumber="18">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Insight</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100415"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HAMD118" OrderNumber="19">
+          <Decode>
+            <TranslatedText xml:lang="en">HAMD1-Total Score</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100416"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C100138"/>
+      </CodeList>
+      <CodeList OID="CL.HAMD17T" Name="Hamilton Depression Rating Scale - 17 Item Clinical Classification Test Name" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="HAMD1-Depressed Mood" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C100398"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Feelings of Guilt" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C100399"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Suicide" OrderNumber="3">
+          <Alias Context="nci:ExtCodeID" Name="C100400"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Insomnia Early - Early Night" OrderNumber="4">
+          <Alias Context="nci:ExtCodeID" Name="C100401"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Insomnia Middle - Middle Night" OrderNumber="5">
+          <Alias Context="nci:ExtCodeID" Name="C100402"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Insomnia Early Hours - Morning" OrderNumber="6">
+          <Alias Context="nci:ExtCodeID" Name="C100403"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Work and Activities" OrderNumber="7">
+          <Alias Context="nci:ExtCodeID" Name="C100404"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Retardation" OrderNumber="8">
+          <Alias Context="nci:ExtCodeID" Name="C100405"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Agitation" OrderNumber="9">
+          <Alias Context="nci:ExtCodeID" Name="C100406"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Anxiety Psychic" OrderNumber="10">
+          <Alias Context="nci:ExtCodeID" Name="C100407"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Anxiety Somatic" OrderNumber="11">
+          <Alias Context="nci:ExtCodeID" Name="C100408"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Somatic Symptoms GI" OrderNumber="12">
+          <Alias Context="nci:ExtCodeID" Name="C100409"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-General Somatic Symptoms" OrderNumber="13">
+          <Alias Context="nci:ExtCodeID" Name="C100410"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Genital Symptoms" OrderNumber="14">
+          <Alias Context="nci:ExtCodeID" Name="C100411"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Hypochondriasis" OrderNumber="15">
+          <Alias Context="nci:ExtCodeID" Name="C100412"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Loss of WT According to Patient" OrderNumber="16">
+          <Alias Context="nci:ExtCodeID" Name="C100413"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Loss of WT According to WK Meas" OrderNumber="17">
+          <Alias Context="nci:ExtCodeID" Name="C100414"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Insight" OrderNumber="18">
+          <Alias Context="nci:ExtCodeID" Name="C100415"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="HAMD1-Total Score" OrderNumber="19">
+          <Alias Context="nci:ExtCodeID" Name="C100416"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C100137"/>
+      </CodeList>
+      <CodeList OID="CL.IECAT" Name="Category for Inclusion/Exclusion" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT96">
+        <CodeListItem CodedValue="EXCLUSION" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Exclusion</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25370"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCLUSION" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Inclusion</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25532"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66797"/>
+      </CodeList>
+      <CodeList OID="CL.IETEST" Name="Inclusion/Exclusion Criterion" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Males and postmenopausal females at least 50 years of age." OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Diagnosis of probable AD as defined by NINCDS and the ADRDA guidelines." OrderNumber="2"/>
+        <EnumeratedItem CodedValue="MMSE score of 10 to 23." OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Modified Hachinski Ischemic Scale score of &lt;= 4." OrderNumber="4"/>
+        <EnumeratedItem CodedValue="CNS imaging (CT scan or MRI of brain) compatible with AD within past 1 year. (See Protocol for incompatible findings.)" OrderNumber="5"/>
+        <EnumeratedItem CodedValue="Investigator has obtained informed consent signed by the patient (and/or legal representative) and by the caregiver." OrderNumber="6"/>
+        <EnumeratedItem CodedValue="Geographic proximity to investigator&apos;s site that allows adequate follow-up." OrderNumber="7"/>
+        <EnumeratedItem CodedValue="Caregiver will monitor administration of prescribed medications, and will be responsible for the overall care of the patient at home." OrderNumber="8"/>
+        <EnumeratedItem CodedValue="Persons who have previously completed or withdrawn from this study or any other investigating xanomeline TTS or the oral formulation of Zanomaline." OrderNumber="9"/>
+        <EnumeratedItem CodedValue="Use of any investigational agent or approved Alzheimer&apos;s therapeutic medication within 30 days prior to enrollment into the study." OrderNumber="10"/>
+        <EnumeratedItem CodedValue="Serious illness which required hospitalization within 3 months of screening." OrderNumber="11"/>
+        <EnumeratedItem CodedValue="Diagnosis of serious neurological conditions (See Protocol)" OrderNumber="12"/>
+        <EnumeratedItem CodedValue="Diagnosis of serious neurological conditions (See Amendment 1)" OrderNumber="13"/>
+        <EnumeratedItem CodedValue="Episode of depression meeting DSM-IV criteria within 3 months of screening." OrderNumber="14"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of the following: a) Schizophrenia b) Bipolar Disease c) Ethanol or psychoactive drug abuse or dependence." OrderNumber="15"/>
+        <EnumeratedItem CodedValue="A history of syncope within the last 5 years." OrderNumber="16"/>
+        <EnumeratedItem CodedValue="Evidence from ECG recording at screening of any of the following conditions: a) Left bundle branch block b) Bradycardia &lt;50 beats per minute c) Sinus pauses &gt;2 seconds (See Protocol for Remainder)" OrderNumber="17"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of a serious cardiovascular disorder, including a) Clinically significant arrhythmia (See Protocol for Remainder)" OrderNumber="18"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of a serious gastrointestinal disorder, including
+a) Chronic peptic/duodenal/gastric/esophageal ulcer that are untreated or refractory to treatment(See Protocol)" OrderNumber="19"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of a serious endocrine disorder, including
+a) Uncontrolled Insulin Dependent Diabetes Mellitus (IDDM) (See Protocol for other excluded disorders)" OrderNumber="20"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of a serious respiratory disorder, including a) Asthma with bronchospasm refractory to treatment b) Decompensated chronic obstructive pulmonary disease." OrderNumber="21"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of a serious genitourinary disorder, including a) Renal failure b) Uncontrolled urinary retention" OrderNumber="22"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of a serious rheumatologic disorder, including a) Lupus b) Temporal arteritis c) Severe rheumatoid arthritis" OrderNumber="23"/>
+        <EnumeratedItem CodedValue="A known history of human immunodeficiency virus (HIV) within the last 5 years." OrderNumber="24"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of a serious infectious disease including a) Neurosyphilis b) Meningitis c) Encephalitis" OrderNumber="25"/>
+        <EnumeratedItem CodedValue="A history within the last 5 years of a primary or recurrent malignant disease (See Exceptions in Protocol)." OrderNumber="26"/>
+        <EnumeratedItem CodedValue="Visual, hearing, or communication disabilities impairing the ability to participate in the study; (for example, inability to speak or understand English, illiteracy)." OrderNumber="27"/>
+        <EnumeratedItem CodedValue="Laboratory test values exceeding the Reference Range III for the patient&apos;s age in any of the following analytes: creatinine, total bilirubin, SGOT, SGPT, (See Protocol for Additional Analytes)" OrderNumber="28"/>
+        <EnumeratedItem CodedValue="Central laboratory test values below reference range for folate, and vitamin B12, and outside reference range for thyroid function tests." OrderNumber="29"/>
+        <EnumeratedItem CodedValue="Positive syphilis screening with confirmatory testing." OrderNumber="30"/>
+        <EnumeratedItem CodedValue="Central laboratory test value above reference range for glycosylated hemoglobin (A1C) (insulin dependent diabetes mellitus patients only)." OrderNumber="31"/>
+        <EnumeratedItem CodedValue="Treatment with medications within 1 month prior to enrollment (See Protocol)" OrderNumber="32"/>
+        <EnumeratedItem CodedValue="Treatment with medications within 1 month prior to enrollment a) Anticonvulsants b) Alpha receptor blockers c) Calcium channel blockers that are CNS active (See Amendment 1)" OrderNumber="33"/>
+      </CodeList>
+      <CodeList OID="CL.IETESTCD" Name="Incl/Excl Criterion Short Name" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT98">
+        <CodeListItem CodedValue="INCL01" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Males and postmenopausal females at least 50 years of age.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL02" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Diagnosis of probable AD as defined by NINCDS and the ADRDA guidelines.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL03" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">MMSE score of 10 to 23.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL04" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Modified Hachinski Ischemic Scale score of &lt;= 4.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL05" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">CNS imaging (CT scan or MRI of brain) compatible with AD within past 1 year. (See Protocol for incompatible findings.)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL06" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Investigator has obtained informed consent signed by the patient (and/or legal representative) and by the caregiver.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL07" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">Geographic proximity to investigator&apos;s site that allows adequate follow-up.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INCL08" OrderNumber="8">
+          <Decode>
+            <TranslatedText xml:lang="en">Caregiver will monitor administration of prescribed medications, and will be responsible for the overall care of the patient at home.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL09" OrderNumber="9">
+          <Decode>
+            <TranslatedText xml:lang="en">Persons who have previously completed or withdrawn from this study or any other investigating xanomeline TTS or the oral formulation of Zanomaline.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL10" OrderNumber="10">
+          <Decode>
+            <TranslatedText xml:lang="en">Use of any investigational agent or approved Alzheimer&apos;s therapeutic medication within 30 days prior to enrollment into the study.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL11" OrderNumber="11">
+          <Decode>
+            <TranslatedText xml:lang="en">Serious illness which required hospitalization within 3 months of screening.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL12" OrderNumber="12">
+          <Decode>
+            <TranslatedText xml:lang="en">Diagnosis of serious neurological conditions</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL13" OrderNumber="13">
+          <Decode>
+            <TranslatedText xml:lang="en">Episode of depression meeting DSM-IV criteria within 3 months of screening.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL14" OrderNumber="14">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of the following: a) Schizophrenia b) Bipolar Disease c) Ethanol or psychoactive drug abuse or dependence.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL15" OrderNumber="15">
+          <Decode>
+            <TranslatedText xml:lang="en">A history of syncope within the last 5 years.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL16" OrderNumber="16">
+          <Decode>
+            <TranslatedText xml:lang="en">Evidence from ECG recording at screening of any of the following conditions: a) Left bundle branch block b) Bradycardia &lt;50 beats per minute c) Sinus pauses &gt;2 seconds (See Protocol for Remainder)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL17" OrderNumber="17">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of a serious cardiovascular disorder, including a) Clinically significant arrhythmia (See Protocol for Remainder)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL18" OrderNumber="18">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of a serious gastrointestinal disorder, including
+a) Chronic peptic/duodenal/gastric/esophageal ulcer that are untreated or refractory to treatment(See Protocol)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL19" OrderNumber="19">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of a serious endocrine disorder, including
+a) Uncontrolled Insulin Dependent Diabetes Mellitus (IDDM) (See Protocol for other excluded disorders)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL20" OrderNumber="20">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of a serious respiratory disorder, including a) Asthma with bronchospasm refractory to treatment b) Decompensated chronic obstructive pulmonary disease.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL21" OrderNumber="21">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of a serious genitourinary disorder, including a) Renal failure b) Uncontrolled urinary retention</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL22" OrderNumber="22">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of a serious rheumatologic disorder, including a) Lupus b) Temporal arteritis c) Severe rheumatoid arthritis</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL23" OrderNumber="23">
+          <Decode>
+            <TranslatedText xml:lang="en">A known history of human immunodeficiency virus (HIV) within the last 5 years.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL24" OrderNumber="24">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of a serious infectious disease including a) Neurosyphilis b) Meningitis c) Encephalitis</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL25" OrderNumber="25">
+          <Decode>
+            <TranslatedText xml:lang="en">A history within the last 5 years of a primary or recurrent malignant disease (See Exceptions in Protocol).</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL26" OrderNumber="26">
+          <Decode>
+            <TranslatedText xml:lang="en">Visual, hearing, or communication disabilities impairing the ability to participate in the study; (for example, inability to speak or understand English, illiteracy).</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL27" OrderNumber="27">
+          <Decode>
+            <TranslatedText xml:lang="en">Laboratory test values exceeding the Reference Range III for the patient&apos;s age in any of the following analytes: creatinine, total bilirubin, SGOT, SGPT, (See Protocol for Additional Analytes)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL28" OrderNumber="28">
+          <Decode>
+            <TranslatedText xml:lang="en">Central laboratory test values below reference range for folate, and vitamin B12, and outside reference range for thyroid function tests.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL29" OrderNumber="29">
+          <Decode>
+            <TranslatedText xml:lang="en">Positive syphilis screening with confirmatory testing.</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL30" OrderNumber="30">
+          <Decode>
+            <TranslatedText xml:lang="en">Central laboratory test value above reference range for glycosylated hemoglobin (A1C) (insulin dependent diabetes mellitus patients only).</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL31" OrderNumber="31">
+          <Decode>
+            <TranslatedText xml:lang="en">Treatment with medications within 1 month prior to enrollment a) Anticonvulsants b) Alpha receptor blockers c) Calcium channel blockers that are CNS active</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL12A" OrderNumber="32">
+          <Decode>
+            <TranslatedText xml:lang="en">Diagnosis of serious neurological conditions (Amend 1)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="EXCL31A" OrderNumber="33">
+          <Decode>
+            <TranslatedText xml:lang="en">Treatment with medications within 1 month prior to enrollment a) Anticonvulsants b) Alpha receptor blockers c) Calcium channel blockers that are CNS active (Amend 1)</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.INTMODEL" Name="Intervention Model Response" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT99">
+        <CodeListItem CodedValue="PARALLEL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Parallel</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C82639"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C99076"/>
+      </CodeList>
+      <CodeList OID="CL.INTTYPE" Name="Intervention Type Response" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT100">
+        <CodeListItem CodedValue="DRUG" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Drug</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C1909"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C99078"/>
+      </CodeList>
+      <CodeList OID="CL.LAT_OE" Name="Laterality, subset to be used in OE" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT103">
+        <CodeListItem CodedValue="LEFT" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Left</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25229"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RIGHT" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Right</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25228"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C99073"/>
+      </CodeList>
+      <CodeList OID="CL.LBCAT" Name="Laboratory Test Category" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT104">
+        <CodeListItem CodedValue="CHEMISTRY" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Chemistry</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="HEMATOLOGY" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Hematology</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="URINALYSIS" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Urinalysis</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="OTHER" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Other</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.LBTEST" Name="Laboratory Test Name" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="Albumin" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C64431"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Alkaline Phosphatase" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C64432"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Alanine Aminotransferase" OrderNumber="3">
+          <Alias Context="nci:ExtCodeID" Name="C64433"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Anisocytes; Anisocytosis" OrderNumber="4">
+          <Alias Context="nci:ExtCodeID" Name="C74797"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Aspartate Aminotransferase" OrderNumber="5">
+          <Alias Context="nci:ExtCodeID" Name="C64467"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Basophils" OrderNumber="6">
+          <Alias Context="nci:ExtCodeID" Name="C64470"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Bilirubin" OrderNumber="7">
+          <Alias Context="nci:ExtCodeID" Name="C38037"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Calcium" OrderNumber="8">
+          <Alias Context="nci:ExtCodeID" Name="C64488"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Cholesterol" OrderNumber="9">
+          <Alias Context="nci:ExtCodeID" Name="C105586"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Creatine Kinase" OrderNumber="10">
+          <Alias Context="nci:ExtCodeID" Name="C64489"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Chloride" OrderNumber="11">
+          <Alias Context="nci:ExtCodeID" Name="C64495"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Color" OrderNumber="12">
+          <Alias Context="nci:ExtCodeID" Name="C64546"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Creatinine" OrderNumber="13">
+          <Alias Context="nci:ExtCodeID" Name="C64547"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Eosinophils" OrderNumber="14">
+          <Alias Context="nci:ExtCodeID" Name="C64550"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Gamma Glutamyl Transferase" OrderNumber="15">
+          <Alias Context="nci:ExtCodeID" Name="C64847"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Glucose" OrderNumber="16">
+          <Alias Context="nci:ExtCodeID" Name="C105585"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Hematocrit" OrderNumber="17">
+          <Alias Context="nci:ExtCodeID" Name="C64796"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Hemoglobin" OrderNumber="18">
+          <Alias Context="nci:ExtCodeID" Name="C64848"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Potassium" OrderNumber="19">
+          <Alias Context="nci:ExtCodeID" Name="C64853"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Ketones" OrderNumber="20">
+          <Alias Context="nci:ExtCodeID" Name="C64854"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Lymphocytes" OrderNumber="21">
+          <Alias Context="nci:ExtCodeID" Name="C51949"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Macrocytes" OrderNumber="22">
+          <Alias Context="nci:ExtCodeID" Name="C64821"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Ery. Mean Corpuscular Hemoglobin" OrderNumber="23">
+          <Alias Context="nci:ExtCodeID" Name="C64797"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Ery. Mean Corpuscular HGB Concentration" OrderNumber="24">
+          <Alias Context="nci:ExtCodeID" Name="C64798"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Ery. Mean Corpuscular Volume" OrderNumber="25">
+          <Alias Context="nci:ExtCodeID" Name="C64799"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Monocytes" OrderNumber="26">
+          <Alias Context="nci:ExtCodeID" Name="C64823"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="pH" OrderNumber="27">
+          <Alias Context="nci:ExtCodeID" Name="C45997"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Phosphate" OrderNumber="28">
+          <Alias Context="nci:ExtCodeID" Name="C64857"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Platelets" OrderNumber="29">
+          <Alias Context="nci:ExtCodeID" Name="C51951"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Poikilocytes" OrderNumber="30">
+          <Alias Context="nci:ExtCodeID" Name="C79602"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Protein" OrderNumber="31">
+          <Alias Context="nci:ExtCodeID" Name="C64858"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Erythrocytes" OrderNumber="32">
+          <Alias Context="nci:ExtCodeID" Name="C51946"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Sodium" OrderNumber="33">
+          <Alias Context="nci:ExtCodeID" Name="C64809"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Specific Gravity" OrderNumber="34">
+          <Alias Context="nci:ExtCodeID" Name="C64832"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Thyrotropin" OrderNumber="35">
+          <Alias Context="nci:ExtCodeID" Name="C64813"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Urate" OrderNumber="36">
+          <Alias Context="nci:ExtCodeID" Name="C64814"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Urea Nitrogen" OrderNumber="37">
+          <Alias Context="nci:ExtCodeID" Name="C125949"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Urobilinogen" OrderNumber="38">
+          <Alias Context="nci:ExtCodeID" Name="C64816"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Vitamin B12" OrderNumber="39">
+          <Alias Context="nci:ExtCodeID" Name="C64817"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Leukocytes" OrderNumber="40">
+          <Alias Context="nci:ExtCodeID" Name="C51948"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C67154"/>
+      </CodeList>
+      <CodeList OID="CL.LBTESTCD" Name="Laboratory Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT106">
+        <CodeListItem CodedValue="ALB" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Albumin Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64431"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ALP" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Alkaline Phosphatase Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64432"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ALT" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Alanine Aminotransferase Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64433"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ANISO" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Anisocyte Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C74797"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AST" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Aspartate Aminotransferase Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64467"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="BASO" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Total Basophil Count</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64470"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="BILI" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">Total Bilirubin Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38037"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="CA" OrderNumber="8">
+          <Decode>
+            <TranslatedText xml:lang="en">Calcium Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64488"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="CHOL" OrderNumber="9">
+          <Decode>
+            <TranslatedText xml:lang="en">Cholesterol Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C105586"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="CK" OrderNumber="10">
+          <Decode>
+            <TranslatedText xml:lang="en">Creatine Kinase Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64489"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="CL" OrderNumber="11">
+          <Decode>
+            <TranslatedText xml:lang="en">Chloride Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64495"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="COLOR" OrderNumber="12">
+          <Decode>
+            <TranslatedText xml:lang="en">Color Assessment</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64546"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="CREAT" OrderNumber="13">
+          <Decode>
+            <TranslatedText xml:lang="en">Creatinine Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64547"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="EOS" OrderNumber="14">
+          <Decode>
+            <TranslatedText xml:lang="en">Eosinophil Count</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64550"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="GGT" OrderNumber="15">
+          <Decode>
+            <TranslatedText xml:lang="en">Gamma Glutamyl Transpeptidase Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64847"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="GLUC" OrderNumber="16">
+          <Decode>
+            <TranslatedText xml:lang="en">Glucose Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C105585"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HCT" OrderNumber="17">
+          <Decode>
+            <TranslatedText xml:lang="en">Hematocrit Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64796"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HGB" OrderNumber="18">
+          <Decode>
+            <TranslatedText xml:lang="en">Hemoglobin Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64848"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="K" OrderNumber="19">
+          <Decode>
+            <TranslatedText xml:lang="en">Potassium Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64853"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="KETONES" OrderNumber="20">
+          <Decode>
+            <TranslatedText xml:lang="en">Ketone Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64854"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="LYM" OrderNumber="21">
+          <Decode>
+            <TranslatedText xml:lang="en">Lymphocyte Count</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C51949"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MACROCY" OrderNumber="22">
+          <Decode>
+            <TranslatedText xml:lang="en">Macrocyte Count</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64821"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MCH" OrderNumber="23">
+          <Decode>
+            <TranslatedText xml:lang="en">Erythrocyte Mean Corpuscular Hemoglobin</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64797"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MCHC" OrderNumber="24">
+          <Decode>
+            <TranslatedText xml:lang="en">Erythrocyte Mean Corpuscular Hemoglobin Concentration</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64798"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MCV" OrderNumber="25">
+          <Decode>
+            <TranslatedText xml:lang="en">Erythrocyte Mean Corpuscular Volume</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64799"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="MONO" OrderNumber="26">
+          <Decode>
+            <TranslatedText xml:lang="en">Monocyte Count</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64823"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PH" OrderNumber="27">
+          <Decode>
+            <TranslatedText xml:lang="en">pH</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C45997"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHOS" OrderNumber="28">
+          <Decode>
+            <TranslatedText xml:lang="en">Phosphate Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64857"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PLAT" OrderNumber="29">
+          <Decode>
+            <TranslatedText xml:lang="en">Platelet Count</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C51951"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="POIKILO" OrderNumber="30">
+          <Decode>
+            <TranslatedText xml:lang="en">Poikilocyte Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C79602"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PROT" OrderNumber="31">
+          <Decode>
+            <TranslatedText xml:lang="en">Total Protein Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64858"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RBC" OrderNumber="32">
+          <Decode>
+            <TranslatedText xml:lang="en">Erythrocyte Count</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C51946"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SODIUM" OrderNumber="33">
+          <Decode>
+            <TranslatedText xml:lang="en">Sodium Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64809"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SPGRAV" OrderNumber="34">
+          <Decode>
+            <TranslatedText xml:lang="en">Specific Gravity</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64832"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TSH" OrderNumber="35">
+          <Decode>
+            <TranslatedText xml:lang="en">Thyrotropin Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64813"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="URATE" OrderNumber="36">
+          <Decode>
+            <TranslatedText xml:lang="en">Urate Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64814"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="UREAN" OrderNumber="37">
+          <Decode>
+            <TranslatedText xml:lang="en">Urea Nitrogen Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C125949"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="UROBIL" OrderNumber="38">
+          <Decode>
+            <TranslatedText xml:lang="en">Urobilinogen Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64816"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="VITB12" OrderNumber="39">
+          <Decode>
+            <TranslatedText xml:lang="en">Vitamin B12 Measurement</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64817"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="WBC" OrderNumber="40">
+          <Decode>
+            <TranslatedText xml:lang="en">Leukocyte Count</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C51948"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C65047"/>
+      </CodeList>
+      <CodeList OID="CL.LOC" Name="Location" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="ARM" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C32141"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C74456"/>
+      </CodeList>
+      <CodeList OID="CL.LOC_OE" Name="Anatomical Location, subset used for OELOC" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT108">
+        <CodeListItem CodedValue="CONJUNCTIVA" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Conjunctiva</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C12341"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="EYE" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Eye</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C12401"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="EYE, ANTERIOR CHAMBER" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Anterior Chamber of the Eye</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C12667"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="IRIS" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Iris</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C12737"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="CORNEA" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Cornea</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C12342"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C74456"/>
+      </CodeList>
+      <CodeList OID="CL.LOC_VS" Name="Anatomical Location" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT109">
+        <CodeListItem CodedValue="EAR" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Ear</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C12394"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ORAL CAVITY" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Oral Cavity</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C12421"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C74456"/>
+      </CodeList>
+      <CodeList OID="CL.MHEVDTP" Name="Medical History Event Date Type, subset used for MHEVDTP" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT112">
+        <CodeListItem CodedValue="SYMPTOM ONSET" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Symptom Onset</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C124353"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C124301"/>
+      </CodeList>
+      <CodeList OID="CL.MHTERM" Name="Medical History Term" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT113">
+        <CodeListItem CodedValue="ALZHEIMER&apos;S DISEASE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Alzheimer&apos;s Disease</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.NCOMPLT" Name="Completion/Reason for Non-Completion" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT114">
+        <CodeListItem CodedValue="ADVERSE EVENT" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Adverse Event</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41331"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="COMPLETED" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Completed</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25250"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DEATH" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Death</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C28554"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="LACK OF EFFICACY" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Lack of Efficacy</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48226"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="LOST TO FOLLOW-UP" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Lost to Follow-Up</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48227"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OTHER" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Other</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C17649"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHYSICIAN DECISION" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">Physician Decision</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48250"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PREGNANCY" OrderNumber="8">
+          <Decode>
+            <TranslatedText xml:lang="en">Pregnancy</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25742"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PROTOCOL DEVIATION" OrderNumber="9">
+          <Decode>
+            <TranslatedText xml:lang="en">Protocol Deviation</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48251"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SCREEN FAILURE" OrderNumber="10">
+          <Decode>
+            <TranslatedText xml:lang="en">Screen Failure</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49628"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="STUDY TERMINATED BY SPONSOR" OrderNumber="11">
+          <Decode>
+            <TranslatedText xml:lang="en">Study Terminated By Sponsor</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49632"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="WITHDRAWAL BY PARENT/GUARDIAN" OrderNumber="12">
+          <Decode>
+            <TranslatedText xml:lang="en">Withdrawal By Parent/Guardian</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C102355"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="WITHDRAWAL BY SUBJECT" OrderNumber="13">
+          <Decode>
+            <TranslatedText xml:lang="en">Withdrawal By Subject</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49634"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66727"/>
+      </CodeList>
+      <CodeList OID="CL.ND" Name="Not Done" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT115">
+        <CodeListItem CodedValue="NOT DONE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Not Done</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49484"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66789"/>
+      </CodeList>
+      <CodeList OID="CL.NORMABNM" Name="Normal Abnormal Response, subset used in OE and NV." DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT116">
+        <CodeListItem CodedValue="ABNORMAL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Abnormal</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25401"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NORMAL" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Normal</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C14165"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C101834"/>
+      </CodeList>
+      <CodeList OID="CL.NRIND" Name="Normal Range Indicator" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT117">
+        <CodeListItem CodedValue="ABNORMAL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Abnormal</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C78802"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HIGH" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">High</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C78800"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="LOW" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Low</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C78801"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NORMAL" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Normal</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C78727"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C78736"/>
+      </CodeList>
+      <CodeList OID="CL.NVTEST" Name="Nervous System Test" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="Interpretation" OrderNumber="1" def:ExtendedValue="Yes"/>
+        <Alias Context="nci:ExtCodeID" Name="C116103"/>
+      </CodeList>
+      <CodeList OID="CL.NVTESTCD" Name="Nervous System Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT119">
+        <CodeListItem CodedValue="INTP" OrderNumber="1" def:ExtendedValue="Yes">
+          <Decode>
+            <TranslatedText xml:lang="en">Interpretation</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C116104"/>
+      </CodeList>
+      <CodeList OID="CL.NY_NY" Name="No Yes Response, subset for variables with only &quot;Y&quot; or &quot;N&quot; val" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT120">
+        <CodeListItem CodedValue="N" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">No</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49487"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="Y" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Yes</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49488"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66742"/>
+      </CodeList>
+      <CodeList OID="CL.NY_YONLY" Name="No Yes Response, subset for variables with only &quot;Y&quot; or null values" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT121">
+        <CodeListItem CodedValue="Y" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Yes</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49488"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66742"/>
+      </CodeList>
+      <CodeList OID="CL.OEFOCUS" Name="Ophthalmic Focus of Study Specific Interest" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT122">
+        <CodeListItem CodedValue="OD" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Right Eye</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C119333"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OS" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Left Eye</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C119334"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C119013"/>
+      </CodeList>
+      <CodeList OID="CL.OEMETHOD" Name="Method, subset used for OEMETHOD" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT123">
+        <CodeListItem CodedValue="SLIT LAMP" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Slit-lamp Examination</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C75583"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C85492"/>
+      </CodeList>
+      <CodeList OID="CL.OETEST" Name="Ophthalmic Exam Test" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="Abnormality Detail" OrderNumber="1" def:ExtendedValue="Yes"/>
+        <EnumeratedItem CodedValue="Interpretation" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C41255"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C117742"/>
+      </CodeList>
+      <CodeList OID="CL.OETESTCD" Name="Ophthalmic Exam Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT125">
+        <CodeListItem CodedValue="ABDETAIL" OrderNumber="1" def:ExtendedValue="Yes">
+          <Decode>
+            <TranslatedText xml:lang="en">Abnormality Detail</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="INTP" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Interpretation</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41255"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C117743"/>
+      </CodeList>
+      <CodeList OID="CL.OUT" Name="Outcome of Event" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT126">
+        <CodeListItem CodedValue="FATAL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Fatal</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48275"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NOT RECOVERED/NOT RESOLVED" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Not Recovered/Not Resolved</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49494"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RECOVERED/RESOLVED" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Recovered/Resolved</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49498"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RECOVERED/RESOLVED WITH SEQUELAE" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Recovered/Resolved With Sequelae</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49495"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RECOVERING/RESOLVING" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Recovering/Resolving</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49496"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="UNKNOWN" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Unknown</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C17998"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66768"/>
+      </CodeList>
+      <CodeList OID="CL.PHQ01C" Name="Patient Health Questionnaire - 9 Item Questionnaire Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT127">
+        <CodeListItem CodedValue="PHQ0101" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Little Interest/Pleasure in Things</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103705"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0102" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Feeling Down Depressed or Hopeless</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103706"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0103" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Trouble Falling or Staying Asleep</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103707"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0104" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Feeling Tired or Little Energy</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103708"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0105" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Poor Appetite or Overeating</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103709"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0106" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Feeling Bad About Yourself</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103710"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0107" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Trouble Concentrating on Things</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103711"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0108" OrderNumber="8">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Moving Slowly or Fidgety/Restless</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103712"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0109" OrderNumber="9">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Thoughts You Be Better Off Dead</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103713"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0110" OrderNumber="10">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Difficult to Work/Take Care Things</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103714"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHQ0111" OrderNumber="11">
+          <Decode>
+            <TranslatedText xml:lang="en">PHQ01-Total Score</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C113887"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C103481"/>
+      </CodeList>
+      <CodeList OID="CL.PHQ01R" Name="Patient Health Questionnaire Responses" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Not at all" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Several days" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="More than half the days" OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Nearly every day" OrderNumber="4"/>
+      </CodeList>
+      <CodeList OID="CL.PHQ01RQ10" Name="Patient Health Questionnaire Responses-Question 10" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Not difficult at all" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Somewhat difficult" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Very difficult" OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Extremely Difficult" OrderNumber="4"/>
+      </CodeList>
+      <CodeList OID="CL.PHQ01RS" Name="Patient Health Questionnaire Responses Standardized" DataType="integer" def:IsNonStandard="Yes" SASFormatName="$FMT130">
+        <CodeListItem CodedValue="0" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Not at all</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="1" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Several days</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">More than half the days</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Nearly every day</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.PHQ01T" Name="Patient Health Questionnaire - 9 Item Questionnaire Test Name" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="PHQ01-Difficult to Work/Take Care Things" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C103714"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Feeling Bad About Yourself" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C103710"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Feeling Down Depressed or Hopeless" OrderNumber="3">
+          <Alias Context="nci:ExtCodeID" Name="C103706"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Feeling Tired or Little Energy" OrderNumber="4">
+          <Alias Context="nci:ExtCodeID" Name="C103708"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Little Interest/Pleasure in Things" OrderNumber="5">
+          <Alias Context="nci:ExtCodeID" Name="C103705"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Moving Slowly or Fidgety/Restless" OrderNumber="6">
+          <Alias Context="nci:ExtCodeID" Name="C103712"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Poor Appetite or Overeating" OrderNumber="7">
+          <Alias Context="nci:ExtCodeID" Name="C103709"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Thoughts You Be Better Off Dead" OrderNumber="8">
+          <Alias Context="nci:ExtCodeID" Name="C103713"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Total Score" OrderNumber="9">
+          <Alias Context="nci:ExtCodeID" Name="C113887"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Trouble Concentrating on Things" OrderNumber="10">
+          <Alias Context="nci:ExtCodeID" Name="C103711"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="PHQ01-Trouble Falling or Staying Asleep" OrderNumber="11">
+          <Alias Context="nci:ExtCodeID" Name="C103707"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C103480"/>
+      </CodeList>
+      <CodeList OID="CL.POSITION_VS" Name="Position, subset to be used for VSPOS" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT132">
+        <CodeListItem CodedValue="STANDING" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Standing</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C62166"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SUPINE" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Supine</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C62167"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71148"/>
+      </CodeList>
+      <CodeList OID="CL.PROTMLST" Name="Protocol Milestone" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT133">
+        <CodeListItem CodedValue="INFORMED CONSENT OBTAINED" OrderNumber="13">
+          <Decode>
+            <TranslatedText xml:lang="en">Informed Consent</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C16735"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C114118"/>
+      </CodeList>
+      <CodeList OID="CL.QSCAT_PH" Name="Category of Questionnaire for PHQ-9" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT134">
+        <CodeListItem CodedValue="PHQ-9" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Patient Health Questionnaire - 9 Item</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C103526"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C100129"/>
+      </CodeList>
+      <CodeList OID="CL.QSCAT_SL" Name="Category of Questionnaire for SWLS" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT135">
+        <CodeListItem CodedValue="SWLS" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Satisfaction With Life Scale Questionnaire</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C115799"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C100129"/>
+      </CodeList>
+      <CodeList OID="CL.RACE" Name="Race" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT136">
+        <CodeListItem CodedValue="AMERICAN INDIAN OR ALASKA NATIVE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">American Indian Or Alaska Native</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41259"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ASIAN" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Asian</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41260"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="BLACK OR AFRICAN AMERICAN" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Black Or African American</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C16352"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Native Hawaiian Or Other Pacific Islander</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41219"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="WHITE" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">White</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41261"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C74457"/>
+      </CodeList>
+      <CodeList OID="CL.RACEMULT" Name="Race Multiple Selections" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT137">
+        <CodeListItem CodedValue="MULTIPLE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Multiple</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.RDOMAIN_RELREC" Name="SDTM Domain Abbreviation, subset used for RELREC" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT138">
+        <CodeListItem CodedValue="AE" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Adverse Events</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49562"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DS" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Disposition</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49576"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DD" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Death Details</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C95087"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="FA" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Findings About Events or Interventions</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C85442"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66734"/>
+      </CodeList>
+      <CodeList OID="CL.RELTYPE" Name="Relationship Type" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT139">
+        <CodeListItem CodedValue="MANY" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Many</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C78728"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ONE" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">One</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C66832"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C78737"/>
+      </CodeList>
+      <CodeList OID="CL.ROUTE_CM" Name="Route of Administration, subset to be used for CM" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT140">
+        <CodeListItem CodedValue="ORAL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Oral</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38288"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TOPICAL" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Topical</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38304"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="INTRAVENOUS" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Intravenous</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38276"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NASAL" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Nasal</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38284"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RESPIRATORY (INHALATION)" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Inhalation Route of Administration</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38216"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TRANSDERMAL" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Transdermal</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38305"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66729"/>
+      </CodeList>
+      <CodeList OID="CL.ROUTE_ECEX" Name="Route of Administration, subset to be used for EC and EX" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT141">
+        <CodeListItem CodedValue="SUBCUTANEOUS" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Subcutaneous Route of Administration</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38299"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66729"/>
+      </CodeList>
+      <CodeList OID="CL.RSCAT" Name="Category of Clinical Classification, subset to be used for RSCAT" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT142">
+        <CodeListItem CodedValue="HAMD 17" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Hamilton Depression Rating Scale 17 Item Clinical Classification</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C100767"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C118971"/>
+      </CodeList>
+      <CodeList OID="CL.SEX" Name="Sex Male Female" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT146">
+        <CodeListItem CodedValue="F" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Female</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C16576"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="M" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Male</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C20197"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66731"/>
+      </CodeList>
+      <CodeList OID="CL.SITEID" Name="Site Identifier" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="701" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="704" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="708" OrderNumber="3"/>
+        <EnumeratedItem CodedValue="710" OrderNumber="4"/>
+        <EnumeratedItem CodedValue="711" OrderNumber="5"/>
+        <EnumeratedItem CodedValue="718" OrderNumber="6"/>
+      </CodeList>
+      <CodeList OID="CL.STYPE" Name="Study Type Response" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT150">
+        <CodeListItem CodedValue="INTERVENTIONAL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Interventional</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98388"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C99077"/>
+      </CodeList>
+      <CodeList OID="CL.SWLS01TC" Name="Satisfaction With Life Scale Questionnaire Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT151">
+        <CodeListItem CodedValue="SWLS0101" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">SWLS01-Have Gotten Important Things</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C115895"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SWLS0102" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">SWLS01-I Am Satisfied with My Life</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C115896"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SWLS0103" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">SWLS01-Live Life Over Change Nothing</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C115897"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SWLS0104" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">SWLS01-My Life Conditions are Excellent</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C115898"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SWLS0105" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">SWLS01-My Life is Close to Ideal</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C115899"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C115408"/>
+      </CodeList>
+      <CodeList OID="CL.SWLS01TN" Name="Satisfaction With Life Scale Questionnaire Test Name" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="SWLS01-Have Gotten Important Things" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C115898"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SWLS01-I Am Satisfied with My Life" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C115897"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SWLS01-Live Life Over Change Nothing" OrderNumber="3">
+          <Alias Context="nci:ExtCodeID" Name="C115899"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SWLS01-My Life Conditions are Excellent" OrderNumber="4">
+          <Alias Context="nci:ExtCodeID" Name="C115896"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SWLS01-My Life is Close to Ideal" OrderNumber="5">
+          <Alias Context="nci:ExtCodeID" Name="C115895"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C115407"/>
+      </CodeList>
+      <CodeList OID="CL.SWLSR" Name="SWLS-Responses" DataType="text" def:IsNonStandard="Yes">
+        <EnumeratedItem CodedValue="Strongly disagree" OrderNumber="1"/>
+        <EnumeratedItem CodedValue="Disagree" OrderNumber="2"/>
+        <EnumeratedItem CodedValue="Slightly disagree" OrderNumber="3"/>
+        <EnumeratedItem CodedValue="Neither agree nor disagree" OrderNumber="4"/>
+        <EnumeratedItem CodedValue="Slightly agree" OrderNumber="5"/>
+        <EnumeratedItem CodedValue="Agree" OrderNumber="6"/>
+        <EnumeratedItem CodedValue="Strongly agree" OrderNumber="7"/>
+      </CodeList>
+      <CodeList OID="CL.SWLSR_S" Name="SWLS-Responses Standardized" DataType="text" def:IsNonStandard="Yes" SASFormatName="$FMT154">
+        <CodeListItem CodedValue="1" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Strongly disagree</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="2" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Disagree</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="3" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Slightly disagree</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="4" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Neither agree nor disagree</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="5" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Slightly agree</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="6" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Agree</TranslatedText>
+          </Decode>
+        </CodeListItem>
+        <CodeListItem CodedValue="7" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">Strongly agree</TranslatedText>
+          </Decode>
+        </CodeListItem>
+      </CodeList>
+      <CodeList OID="CL.TBLIND" Name="Trial Blinding Schema Response" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT155">
+        <CodeListItem CodedValue="DOUBLE BLIND" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Double Blind</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C15228"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66735"/>
+      </CodeList>
+      <CodeList OID="CL.TCNTRL" Name="Control Type Response" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT156">
+        <CodeListItem CodedValue="PLACEBO" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Placebo</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49648"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66785"/>
+      </CodeList>
+      <CodeList OID="CL.TINDTP" Name="Trial Intent Type Response" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT157">
+        <CodeListItem CodedValue="TREATMENT" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Treatment</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49656"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66736"/>
+      </CodeList>
+      <CodeList OID="CL.TPHASE" Name="Trial Phase Response" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT158">
+        <CodeListItem CodedValue="PHASE II TRIAL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Phase II Trial</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C15601"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66737"/>
+      </CodeList>
+      <CodeList OID="CL.TSPARM" Name="Trial Summary Parameter Test Name" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="Actual Number of Subjects" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C98703"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Adaptive Design" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C146995"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Added on to Existing Treatments" OrderNumber="3">
+          <Alias Context="nci:ExtCodeID" Name="C49703"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Planned Maximum Age of Subjects" OrderNumber="4">
+          <Alias Context="nci:ExtCodeID" Name="C49694"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Planned Minimum Age of Subjects" OrderNumber="5">
+          <Alias Context="nci:ExtCodeID" Name="C49693"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Data Cutoff Description" OrderNumber="6">
+          <Alias Context="nci:ExtCodeID" Name="C98718"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Data Cutoff Date" OrderNumber="7">
+          <Alias Context="nci:ExtCodeID" Name="C98717"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Dose per Administration" OrderNumber="8">
+          <Alias Context="nci:ExtCodeID" Name="C25488"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Dose Form" OrderNumber="9">
+          <Alias Context="nci:ExtCodeID" Name="C42636"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Dosing Frequency" OrderNumber="10">
+          <Alias Context="nci:ExtCodeID" Name="C89081"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Dose Units" OrderNumber="11">
+          <Alias Context="nci:ExtCodeID" Name="C73558"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Planned Country of Investigational Sites" OrderNumber="12">
+          <Alias Context="nci:ExtCodeID" Name="C98770"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Healthy Subject Indicator" OrderNumber="13">
+          <Alias Context="nci:ExtCodeID" Name="C98737"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Disease/Condition Indication" OrderNumber="14">
+          <Alias Context="nci:ExtCodeID" Name="C112038"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Intervention Model" OrderNumber="15">
+          <Alias Context="nci:ExtCodeID" Name="C98746"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Intervention Type" OrderNumber="16">
+          <Alias Context="nci:ExtCodeID" Name="C98747"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Length" OrderNumber="17">
+          <Alias Context="nci:ExtCodeID" Name="C49697"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Planned Number of Arms" OrderNumber="18">
+          <Alias Context="nci:ExtCodeID" Name="C98771"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Primary Objective" OrderNumber="19">
+          <Alias Context="nci:ExtCodeID" Name="C85826"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Secondary Objective" OrderNumber="20">
+          <Alias Context="nci:ExtCodeID" Name="C85827"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Primary Outcome Measure" OrderNumber="21">
+          <Alias Context="nci:ExtCodeID" Name="C98772"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Secondary Outcome Measure" OrderNumber="22">
+          <Alias Context="nci:ExtCodeID" Name="C98781"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Pharmacologic Class" OrderNumber="23">
+          <Alias Context="nci:ExtCodeID" Name="C98768"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Planned Number of Subjects" OrderNumber="24">
+          <Alias Context="nci:ExtCodeID" Name="C49692"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial is Randomized" OrderNumber="25">
+          <Alias Context="nci:ExtCodeID" Name="C25196"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Randomization Quotient" OrderNumber="26">
+          <Alias Context="nci:ExtCodeID" Name="C98775"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Registry Identifier" OrderNumber="27">
+          <Alias Context="nci:ExtCodeID" Name="C98714"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Route of Administration" OrderNumber="28">
+          <Alias Context="nci:ExtCodeID" Name="C38114"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SDTM IG Version" OrderNumber="29">
+          <Alias Context="nci:ExtCodeID" Name="C156604"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="SDTM Version" OrderNumber="30">
+          <Alias Context="nci:ExtCodeID" Name="C156605"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Study End Date" OrderNumber="31">
+          <Alias Context="nci:ExtCodeID" Name="C90462"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Sex of Participants" OrderNumber="32">
+          <Alias Context="nci:ExtCodeID" Name="C49696"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Clinical Study Sponsor" OrderNumber="33">
+          <Alias Context="nci:ExtCodeID" Name="C70793"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Study Start Date" OrderNumber="34">
+          <Alias Context="nci:ExtCodeID" Name="C69208"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Study Stop Rules" OrderNumber="35">
+          <Alias Context="nci:ExtCodeID" Name="C49698"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Study Type" OrderNumber="36">
+          <Alias Context="nci:ExtCodeID" Name="C142175"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Blinding Schema" OrderNumber="37">
+          <Alias Context="nci:ExtCodeID" Name="C49658"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Control Type" OrderNumber="38">
+          <Alias Context="nci:ExtCodeID" Name="C49647"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Diagnosis Group" OrderNumber="39">
+          <Alias Context="nci:ExtCodeID" Name="C49650"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Intent Type" OrderNumber="40">
+          <Alias Context="nci:ExtCodeID" Name="C49652"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Title" OrderNumber="41">
+          <Alias Context="nci:ExtCodeID" Name="C49802"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Phase Classification" OrderNumber="42">
+          <Alias Context="nci:ExtCodeID" Name="C48281"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Investigational Therapy or Treatment" OrderNumber="43">
+          <Alias Context="nci:ExtCodeID" Name="C41161"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Trial Type" OrderNumber="44">
+          <Alias Context="nci:ExtCodeID" Name="C49660"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C67152"/>
+      </CodeList>
+      <CodeList OID="CL.TSPARMCD" Name="Trial Summary Parameter Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT160">
+        <CodeListItem CodedValue="ACTSUB" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Actual Subject Number</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98703"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ADAPT" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Adaptive Study Design Indicator</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C146995"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ADDON" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Test Product Added to Existing Treatment</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49703"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AGEMAX" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Planned Maximum Age of Subjects</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49694"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="AGEMIN" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Planned Minimum Age of Subjects</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49693"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DCUTDESC" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Data Cutoff Date Description</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98718"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DCUTDTC" OrderNumber="7">
+          <Decode>
+            <TranslatedText xml:lang="en">Data Cutoff Date</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98717"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSE" OrderNumber="8">
+          <Decode>
+            <TranslatedText xml:lang="en">Dose</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25488"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSFRM" OrderNumber="9">
+          <Decode>
+            <TranslatedText xml:lang="en">Pharmaceutical Dosage Form</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C42636"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSFRQ" OrderNumber="10">
+          <Decode>
+            <TranslatedText xml:lang="en">Dose Frequency</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C89081"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="DOSU" OrderNumber="11">
+          <Decode>
+            <TranslatedText xml:lang="en">Dosage Form Unit</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C73558"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="FCNTRY" OrderNumber="12">
+          <Decode>
+            <TranslatedText xml:lang="en">Planned Country of Investigational Site</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98770"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HLTSUBJI" OrderNumber="13">
+          <Decode>
+            <TranslatedText xml:lang="en">Healthy Subject Indicator</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98737"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="INDIC" OrderNumber="14">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Indication</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C112038"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="INTMODEL" OrderNumber="15">
+          <Decode>
+            <TranslatedText xml:lang="en">Intervention Model</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98746"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="INTTYPE" OrderNumber="16">
+          <Decode>
+            <TranslatedText xml:lang="en">Intervention Type</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98747"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="LENGTH" OrderNumber="17">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Length</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49697"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="NARMS" OrderNumber="18">
+          <Decode>
+            <TranslatedText xml:lang="en">Planned Number of Arms</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98771"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OBJPRIM" OrderNumber="19">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Primary Objective</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C85826"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OBJSEC" OrderNumber="20">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Secondary Objective</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C85827"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OUTMSPRI" OrderNumber="21">
+          <Decode>
+            <TranslatedText xml:lang="en">Primary Outcome Measure</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98772"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="OUTMSSEC" OrderNumber="22">
+          <Decode>
+            <TranslatedText xml:lang="en">Secondary Outcome Measure</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98781"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PCLAS" OrderNumber="23">
+          <Decode>
+            <TranslatedText xml:lang="en">Pharmacological Class of Investigational Therapy</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98768"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PLANSUB" OrderNumber="24">
+          <Decode>
+            <TranslatedText xml:lang="en">Planned Subject Number</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49692"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RANDOM" OrderNumber="25">
+          <Decode>
+            <TranslatedText xml:lang="en">Randomization</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25196"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="RANDQT" OrderNumber="26">
+          <Decode>
+            <TranslatedText xml:lang="en">Randomization Quotient</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98775"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="REGID" OrderNumber="27">
+          <Decode>
+            <TranslatedText xml:lang="en">Clinical Trial Registry Identifier</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C98714"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ROUTE" OrderNumber="28">
+          <Decode>
+            <TranslatedText xml:lang="en">Route of Administration</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C38114"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SDTIGVER" OrderNumber="29">
+          <Decode>
+            <TranslatedText xml:lang="en">Study Data Tabulation Model Implementation Guide Version</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C156604"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SDTMVER" OrderNumber="30">
+          <Decode>
+            <TranslatedText xml:lang="en">Study Data Tabulation Model Version</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C156605"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SENDTC" OrderNumber="31">
+          <Decode>
+            <TranslatedText xml:lang="en">Clinical Study End Date</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C90462"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SEXPOP" OrderNumber="32">
+          <Decode>
+            <TranslatedText xml:lang="en">Sex of Study Group</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49696"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SPONSOR" OrderNumber="33">
+          <Decode>
+            <TranslatedText xml:lang="en">Clinical Study Sponsor</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C70793"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SSTDTC" OrderNumber="34">
+          <Decode>
+            <TranslatedText xml:lang="en">Study Start Date</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C69208"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="STOPRULE" OrderNumber="35">
+          <Decode>
+            <TranslatedText xml:lang="en">Study Stop Rule</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49698"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="STYPE" OrderNumber="36">
+          <Decode>
+            <TranslatedText xml:lang="en">Study Type</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C142175"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TBLIND" OrderNumber="37">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Blinding Schema</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49658"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TCNTRL" OrderNumber="38">
+          <Decode>
+            <TranslatedText xml:lang="en">Control Type</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49647"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TDIGRP" OrderNumber="39">
+          <Decode>
+            <TranslatedText xml:lang="en">Diagnosis Group</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49650"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TINDTP" OrderNumber="40">
+          <Decode>
+            <TranslatedText xml:lang="en">Clinical Study by Intent</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49652"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TITLE" OrderNumber="41">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Title</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49802"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TPHASE" OrderNumber="42">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Phase</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48281"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TRT" OrderNumber="43">
+          <Decode>
+            <TranslatedText xml:lang="en">Protocol Agent</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C41161"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TTYPE" OrderNumber="44">
+          <Decode>
+            <TranslatedText xml:lang="en">Trial Type</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49660"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66738"/>
+      </CodeList>
+      <CodeList OID="CL.TTYPE" Name="Trial Type Response" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT161">
+        <CodeListItem CodedValue="EFFICACY" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Efficacy</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49666"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PHARMACOKINETIC" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Pharmacokinetic</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49663"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SAFETY" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Safety</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49667"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66739"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_CM" Name="Unit, subset to be used for CMDOSU" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT162">
+        <CodeListItem CodedValue="mg" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Milligram</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C28253"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="ng" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Nanogram</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48516"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TABLET" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Tablet</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C42998"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_ECDOSU" Name="Unit, subset to be used for ECDOSU" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT163">
+        <CodeListItem CodedValue="mL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Milliliter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25613"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_ECPSTRGU" Name="Unit, subset to be used for ECPSTRGU" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT164">
+        <CodeListItem CodedValue="g/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Gram per Liter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C42576"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_EX" Name="Unit, subset to be used for EXDOSU" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT165">
+        <CodeListItem CodedValue="mg" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Milligram</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C28253"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_10^12/L" Name="Unit, subset to be used in VLM for tests with 10^12/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT166">
+        <CodeListItem CodedValue="10^12/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Million per Microliter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67308"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_10^9/L" Name="Unit, subset to be used in VLM for tests with 10^9/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT167">
+        <CodeListItem CodedValue="10^9/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Billion per Liter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67255"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_PCT" Name="Unit, subset to be used in VLM for tests with % as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT168">
+        <CodeListItem CodedValue="%" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Percentage</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25613"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_U/L" Name="Unit, subset to be used in VLM for tests with U/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT169">
+        <CodeListItem CodedValue="U/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Unit per Liter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67456"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_fL" Name="Unit, subset to be used in VLM for tests with fL as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT170">
+        <CodeListItem CodedValue="fL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Femtoliter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64780"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_fmol" Name="Unit, subset to be used in VLM for tests with fmol as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT171">
+        <CodeListItem CodedValue="fmol" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Femtomole</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C42576"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_g/L" Name="Unit, subset to be used in VLM for tests with g/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT172">
+        <CodeListItem CodedValue="g/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Femtomole</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C68854"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_g/dL" Name="Unit, subset to be used in VLM for tests with g/dL as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT173">
+        <CodeListItem CodedValue="g/dL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Gram per Deciliter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64783"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_mEq/L" Name="Unit, subset to be used in VLM for tests with mEq/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT174">
+        <CodeListItem CodedValue="mEq/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Milliequivalent Per Liter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67474"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_mIU/L" Name="Unit, subset to be used in VLM for tests with mIU/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT175">
+        <CodeListItem CodedValue="mIU/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Microinternational Unit per Milliliter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67405"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_mU/L" Name="Unit, subset to be used in VLM for tests with mU/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT176">
+        <CodeListItem CodedValue="mU/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Microunit per Milliliter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48508"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_mg/dL" Name="Unit, subset to be used in VLM for tests with mg/dL as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT177">
+        <CodeListItem CodedValue="mg/dL" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Milligram per Deciliter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67015"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_mmol/L" Name="Unit, subset to be used in VLM for tests with mmol/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT178">
+        <CodeListItem CodedValue="mmol/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Millimole per Liter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64387"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_ng/L" Name="Unit, subset to be used in VLM for tests with ng/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT179">
+        <CodeListItem CodedValue="ng/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Nanogram per Liter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67327"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_pg" Name="Unit, subset to be used in VLM for tests with pg as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT180">
+        <CodeListItem CodedValue="pg" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Picogram</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C64551"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_pmol/L" Name="Unit, subset to be used in VLM for tests with pmol/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT181">
+        <CodeListItem CodedValue="pmol/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Picomole per Liter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67434"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.UNIT_LB_umol/L" Name="Unit, subset to be used in VLM for tests with umol/L as the unit" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT182">
+        <CodeListItem CodedValue="umol/L" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Micromole per Liter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C67408"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C71620"/>
+      </CodeList>
+      <CodeList OID="CL.VSTEST" Name="Vital Signs Test Name" DataType="text" def:StandardOID="STD.3">
+        <EnumeratedItem CodedValue="Diastolic Blood Pressure" OrderNumber="1">
+          <Alias Context="nci:ExtCodeID" Name="C25299"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Pulse Rate" OrderNumber="2">
+          <Alias Context="nci:ExtCodeID" Name="C49676"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Height" OrderNumber="3">
+          <Alias Context="nci:ExtCodeID" Name="C25347"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Systolic Blood Pressure" OrderNumber="4">
+          <Alias Context="nci:ExtCodeID" Name="C25298"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Temperature" OrderNumber="5">
+          <Alias Context="nci:ExtCodeID" Name="C25206"/>
+        </EnumeratedItem>
+        <EnumeratedItem CodedValue="Weight" OrderNumber="6">
+          <Alias Context="nci:ExtCodeID" Name="C25208"/>
+        </EnumeratedItem>
+        <Alias Context="nci:ExtCodeID" Name="C67153"/>
+      </CodeList>
+      <CodeList OID="CL.VSTESTCD" Name="Vital Signs Test Code" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT185">
+        <CodeListItem CodedValue="DIABP" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Diastolic Blood Pressure</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25299"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="PULSE" OrderNumber="2">
+          <Decode>
+            <TranslatedText xml:lang="en">Pulse Rate</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49676"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="HEIGHT" OrderNumber="3">
+          <Decode>
+            <TranslatedText xml:lang="en">Height</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25347"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="SYSBP" OrderNumber="4">
+          <Decode>
+            <TranslatedText xml:lang="en">Systolic Blood Pressure</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25298"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="TEMP" OrderNumber="5">
+          <Decode>
+            <TranslatedText xml:lang="en">Temperature</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25206"/>
+        </CodeListItem>
+        <CodeListItem CodedValue="WEIGHT" OrderNumber="6">
+          <Decode>
+            <TranslatedText xml:lang="en">Weight</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C25208"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66741"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_BP" Name="Units for Vital Signs Results, subset for Blood Pressure" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT186">
+        <CodeListItem CodedValue="mmHg" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Millimeter of Mercury</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49670"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_BP_STD" Name="Units for Vital Signs Results, subset for Blood Pressure Std" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT187">
+        <CodeListItem CodedValue="mmHg" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Millimeter of Mercury</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49670"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_HEIGHT" Name="Units for Vital Signs Results, subset for Height" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT188">
+        <CodeListItem CodedValue="in" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Inch</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48500"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_HEIGHT_STD" Name="Units for Vital Signs Results, subset for Height Std" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT189">
+        <CodeListItem CodedValue="cm" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Centimeter</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49668"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_PULSE" Name="Units for Vital Signs Results, subset for Pulse" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT190">
+        <CodeListItem CodedValue="beats/min" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Beats per Minute</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49673"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_PULSE_STD" Name="Units for Vital Signs Results, subset for Pulse Std" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT191">
+        <CodeListItem CodedValue="beats/min" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Beats per Minute</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C49673"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_TEMP" Name="Units for Vital Signs Results, subset for Temperature" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT192">
+        <CodeListItem CodedValue="F" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Degree Fahrenheit</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C44277"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_TEMP_STD" Name="Units for Vital Signs Results, subset for Temperature Std" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT193">
+        <CodeListItem CodedValue="C" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Degree Celsius</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C42559"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_WT" Name="Units for Vital Signs Results, subset for Weight" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT194">
+        <CodeListItem CodedValue="LB" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Pound</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C48531"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.VS_UNIT_WT_STD" Name="Units for Vital Signs Results, subset for Weight Std" DataType="text" def:StandardOID="STD.3" SASFormatName="$FMT195">
+        <CodeListItem CodedValue="kg" OrderNumber="1">
+          <Decode>
+            <TranslatedText xml:lang="en">Kilogram</TranslatedText>
+          </Decode>
+          <Alias Context="nci:ExtCodeID" Name="C28252"/>
+        </CodeListItem>
+        <Alias Context="nci:ExtCodeID" Name="C66770"/>
+      </CodeList>
+      <CodeList OID="CL.ISO21090" Name="Null Flavors" DataType="text" def:IsNonStandard="Yes">
+        <ExternalCodeList Dictionary="ISO 21090 NullFlavor" Version="2017" href="https://www.iso.org/standard/35646.html"/>
+      </CodeList>
+      <CodeList OID="CL.ISO3166" Name="Country Codes" DataType="text" def:IsNonStandard="Yes">
+        <ExternalCodeList Dictionary="ISO 3166-1 Alpha-3" Version="2013-11-15" href="https://www.iso.org/obp/ui/#search"/>
+      </CodeList>
+      <CodeList OID="CL.MEDDRA" Name="Adverse Events Dictionary" DataType="text" def:IsNonStandard="Yes">
+        <ExternalCodeList Dictionary="MedDRA" Version="22.0" href="https://www.meddra.org/"/>
+      </CodeList>
+      <CodeList OID="CL.SNOMED" Name="Trial Summary Medical Dictionary" DataType="text" def:IsNonStandard="Yes">
+        <ExternalCodeList Dictionary="SNOMED" Version="2019-09-01" href="https://www.snomed.org/"/>
+      </CodeList>
+
+
+      <!-- ******************************** -->
+      <!-- Methods Definitions Section      -->
+      <!-- ******************************** -->
+
+      <MethodDef OID="MT.AEENTPT" Name="Algorithm to derive AEENTPT" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If AEENRTPT is populated, AEENTPT is DM.RFPENDTC for the subject.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.CMENTPT" Name="Algorithm to derive CMENTPT" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If CMENRTPT is populated, CMENTPT is DM.RFPENDTC for the subject.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DAYCALC" Name="Algorithm to derive DAYCALC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Study day relative to RFSTDTC. Date - RFSTDTC + 1 if on or after RFSTDTC. Date - RFSTDTC if date precedes RFSTDTC.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DISEQ" Name="Algorithm to derive DISEQ" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Starts at &quot;1&quot; for first device identifier and increments by one for each DIPARM</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.DTHFL" Name="Algorithm to derive DTHFL" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If DTHDTC is populated then DTHFL=&apos;Y&apos;</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EPOCH" Name="Algorithm to derive EPOCH" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">EPOCH from SE where date &gt;= SESTDTC and date &lt; SEENDTC</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.EXDOSE" Name="Algorithm to derive EXDOSE" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">EXDOSE = ECDOSE * ECPSTRG expressed in mg.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.FTSTRESN" Name="Algorithm to derive FTSTRESN" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If FTSTRESC is numeric then FTSTRESN=FTSTRESC in numeric format, else null.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.IEORRES" Name="Algorithm to derive IEORRES" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If IECAT=INCLUSION then IEORRES=N, else if IECAT=EXCLUSION then IEORRES=Y</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.LBSTRESC" Name="Algorithm to derive LBSTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">LBSTRESC is equal to LBORRES or the value in standard units if a conversion is necessary.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.LOBXFL" Name="Algorithm to derive LOBXFL" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Set to &quot;Y&quot; for last record with non-null original result on or before the first dose date (RFXSTDTC). Null otherwise.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.QSSTRESC_PH" Name="Algorithm to derive QSSTRESC_PH" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If QSORRES=&quot;Not at all&quot; then 0
+If QSORRES=&quot;Several days&quot; then 1
+If QSORRES=&quot;More than half the days&quot; then 2
+If QSORRES=&quot;Nearly every day&quot; then 3</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.QSSTRESC_PH_10_11" Name="Algorithm to derive QSSTRESC_PH_10_11" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">QSSTRESC=QSORRES</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.QSSTRESC_SL" Name="Algorithm to derive QSSTRESC_SL" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If QSORRES=&quot;Strongly disagree&quot; then 1
+If QSORRES=&quot;Disagree&quot; then 2
+If QSORRES=&quot;Slightly disagree&quot; then 3
+If QSORRES=&quot;Neither agree nor disagree&quot; then 4
+If QSORRES=&quot;Slightly agree&quot; then 5
+If QSORRES=&quot;Agree&quot; then 6
+If QSORRES=&quot;Strongly agree&quot; then 7</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.QSSTRESN" Name="Algorithm to derive QSSTRESN" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If QSSTRESC is numeric then QSSTRESN=QSSTRESC in numeric format, else null.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RFENDTC" Name="Algorithm to derive RFENDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">The Date of Study Completion or Early Termination. Null for screen failures.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RFPENDTC" Name="Algorithm to derive RFPENDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">The latest date of assessment for the subject as determined by the End of Study Form, any scheduled assessments, Adverse Events, or Concomitant Medications.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RFSTDTC" Name="Algorithm to derive RFSTDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">The first date/time of study drug. Null for screen failures.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RFXENDTC" Name="Algorithm to derive RFXENDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">The last date/time of study drug administration. Null for subjects with no treatment data.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RFXSTDTC" Name="Algorithm to derive RFXSTDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">The first date/time of study drug administration. Null for subjects with no treatment data.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.RSSTRESC" Name="Algorithm to derive RSSTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">RSSTRESC is the corresponding numeric value of RSORRES according the values shown on the HAMD-17 CRF page.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SEENDTC" Name="Algorithm to derive SEENDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">SEENDTC is set to the start of the next Element, or RFPENDTC for the last Element.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SEQ" Name="Algorithm to derive SEQ" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Unique sequence number within a subject, restarting at 1 for every subject, applied to sorted data.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SESTDTC" Name="Algorithm to derive SESTDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">SESTDTC if set to the --DTC for that subject which exists in the data for the defined start of the Element, such as DSSTDTC when DSDECOD=INFORMED CONSENT OBTAINED for Screening Elements or min(EXSTDTC) for Dosing Elements.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.STRESN" Name="Algorithm to derive STRESN" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">If --STRESC represents a numeric value then --STRESN is the numeric version of --STRESC, else null. &quot;--&quot; represents the domain code.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SVENDTC" Name="Algorithm to derive SVENDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">For each scheduled visit, SVENDTC = the last (max) date associated with a subject for that visit. For unplanned visits, SVENDTC is the date of the visit.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.SVSTDTC" Name="Algorithm to derive SVSTDTC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">For each scheduled visit, SVSTDTC = the first (min) date associated with a subject for that visit. For unplanned visits, SVSTDTC is the date of the visit.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.TSSEQ" Name="Algorithm to derive TSSEQ" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Unique sequence number within each TSPARM, restarting at 1 for per TSPARM, applied to sorted data.</TranslatedText>
+        </Description>
+      </MethodDef>
+      <MethodDef OID="MT.VSSTRESC" Name="Algorithm to derive VSSTRESC" Type="Computation">
+        <Description>
+          <TranslatedText xml:lang="en">Data collected in conventional units (i.e. F, lbs, inches) is converted using standard conversion factors to standard units (C, kg, cm).</TranslatedText>
+        </Description>
+      </MethodDef>
+
+
+      <!-- ******************************** -->
+      <!-- Comments Definitions Section     -->
+      <!-- ******************************** -->
+
+      <def:CommentDef OID="COM.AE2">
+        <Description>
+          <TranslatedText xml:lang="en">Even though the variable is 'Assigned' an annotation has been added to page 23 to clarify the assignment.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.AE3">
+        <Description>
+          <TranslatedText xml:lang="en">Coding variables are not populated due to the proprietary coding dictionary, but the variables are included as they are Expected or Required.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.AEDECOD">
+        <Description>
+          <TranslatedText xml:lang="en">Coding variables are not populated due to the proprietary coding dictionary, but the variables are included as they are Expected or Required. Note CDISC Conformance Rule CG0014 would fire for this variable due to the decision not to populate coding variables.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.AESER">
+        <Description>
+          <TranslatedText xml:lang="en">Subject CDISC003 had an AE of Epistaxis on 2013-09-30 with AESER set to 'Y' without any of the individual serious qualifiers set to 'Y' also. The site was queried several times but the data were not updated. Note Conformance Rule CG0041 would fire for this subject.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.CMINDC">
+        <Description>
+          <TranslatedText xml:lang="en">If the CM is not taken for a 'Primary Study Condition' then CMINDC would be 'Prophylaxis or Non-therapeutic use'</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.DM2">
+        <Description>
+          <TranslatedText xml:lang="en">Since no collected data was subjective then QEVAL was not populated. It is an 'Expected' variable and so is included.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.DM3">
+        <Description>
+          <TranslatedText xml:lang="en">Since no subjects had more than 3 Races, RACE4 was not used.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.DM4">
+        <Description>
+          <TranslatedText xml:lang="en">Since no subjects had more than 3 Races, RACE5 was not used.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.DS1">
+        <Description>
+          <TranslatedText xml:lang="en">Variable is Assigned but there are annotations to help understand the data and so references to the proper pages are included</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.DTC1">
+        <Description>
+          <TranslatedText xml:lang="en">DataType is 'partialDatetime' instead of 'datetime' since datetime values are planned to be collected without seconds for this study.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.FA1">
+        <Description>
+          <TranslatedText xml:lang="en">All values are null as the findings are not visit based. The variable is Expected and so is included.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.FA2">
+        <Description>
+          <TranslatedText xml:lang="en">The FA domain contains Findings About Injection Site Reaction Adverse Events</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.IE1">
+        <Description>
+          <TranslatedText xml:lang="en">IEDY is needed if IEDTC is included. Note RFSTDTC is not populated for not randomized subjects then IEDY could not be populated in those cases.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.IE2">
+        <Description>
+          <TranslatedText xml:lang="en">Please see Appendix 1 of the cSDRG for complete versions of IETESTCD and IETEST.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.MDV">
+        <Description>
+          <TranslatedText xml:lang="en">Standard's Conformance Notes:
+1) The SDTM v1.7/SDTMIG v3.3 datasets were evaluated manually and programmatically by the CDISC SDS MSG Team. At the completion of the SDTM-MSG v2.0, the CDISC SDTM v1.7/SDTMIG v3.3 conformance rules were recently published, but not available by any validation tools to validate.
+2) The Define-XML document was evaluated manually and programmatically by the CDISC SDS MSG Team. At the completion of the SDTM-MSG v2.0, the CDISC
+Define-XML v2.1 conformance rules were not published, nor available by any validation tools to validate. Please ensure that any official regulatory submission of an Define-XML v2.1 document and accompanying data is done in accordance to the respective regulatory health authorities requirements/guidance.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.NV1">
+        <Description>
+          <TranslatedText xml:lang="en">Per protocol, electroencephalograms are only performed after such an event were to occur. No subjects within the trial had an occurrence of an electroencephalogram event. Therefore, no data exists for the NV dataset and as such was not submitted.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.NV2">
+        <Description>
+          <TranslatedText xml:lang="en">Per protocol, electroencephalograms are only performed after such an event were to occur. No subjects within the trial had an occurrence of an electroencephalogram event. Therefore, no data exists for the NV dataset and as such SUPPNV was not submitted.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.OE1">
+        <Description>
+          <TranslatedText xml:lang="en">No subjects within the trial had an ophthalmic examination of clinical significance to report. Therefore, no data exists for the SUPPOE dataset and as such was not submitted.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.QS1">
+        <Description>
+          <TranslatedText xml:lang="en">QSPH contains the PATIENT HEALTH QUESTIONNAIRE-9 (PHQ-9) questionnaire data.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.QS2">
+        <Description>
+          <TranslatedText xml:lang="en">QSSL contains the SATISFACTION WITH LIFE SURVEY (SWLS) questionnaire data.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.ST1">
+        <Description>
+          <TranslatedText xml:lang="en">Study Data Tabulation Model Implementation Guide: Human Clinical Trials Version 3.3</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.ST2">
+        <Description>
+          <TranslatedText xml:lang="en">Study Data Tabulation Model Implementation Guide for Medical Devices Version 1.0</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.ST3">
+        <Description>
+          <TranslatedText xml:lang="en">This was the latest release of CDISC CT available when this sample submission was completed.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.ST4">
+        <Description>
+          <TranslatedText xml:lang="en">This was the CDISC CT Package associated to the CDISC Define-XML Specification Version 2.1 when this sample submission was completed.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+      <def:CommentDef OID="COM.VS1">
+        <Description>
+          <TranslatedText xml:lang="en">All vital signs were performed as expected, so VSSTAT was never populated. The variable is included as it was possible to populate it in this study.</TranslatedText>
+        </Description>
+      </def:CommentDef>
+
+
+      <!-- ******************************** -->
+      <!-- Leafs Definitions Section        -->
+      <!-- ******************************** -->
+
+      <def:leaf ID="LF.acrf" xlink:href="acrf.pdf">
+        <def:title>Annotated CRF</def:title>
+      </def:leaf>
+
+      <def:leaf ID="LF.csdrg" xlink:href="csdrg.pdf">
+        <def:title>Reviewers Guide</def:title>
+      </def:leaf>
+
+
+    <!-- ***********************************     -->
+    <!-- End of Metadata Definitions Section     -->
+    <!-- ***********************************     -->
+
+    </MetaDataVersion>
+  </Study>
+</ODM>

--- a/tests/unit/test_operations/test_define_variable_codelist.py
+++ b/tests/unit/test_operations/test_define_variable_codelist.py
@@ -1,0 +1,48 @@
+import pandas as pd
+from cdisc_rules_engine.config.config import ConfigService
+from pathlib import Path
+from cdisc_rules_engine.operations.define_variable_codelist import (
+    DefineVariableCodelist,
+)
+from cdisc_rules_engine.models.operation_params import OperationParams
+
+from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+from cdisc_rules_engine.services.data_services.data_service_factory import (
+    DataServiceFactory,
+)
+
+
+def test_get_define_variable_codelist_variable_in_domain(
+    operation_params: OperationParams,
+):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    resources_path: Path = Path(__file__).parent.parent.parent.joinpath("resources")
+    operation_params.directory_path = str(resources_path)
+    operation_params.domain = "AE"
+    operation_params.target = "AESER"
+    result = DefineVariableCodelist(
+        operation_params, pd.DataFrame.from_dict({"A": [1, 2, 3]}), cache, data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        val == "C49487"
+
+
+def test_get_define_variable_codelist_variable_not_in_domain(
+    operation_params: OperationParams,
+):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    resources_path: Path = Path(__file__).parent.parent.parent.joinpath("resources")
+    operation_params.directory_path = str(resources_path)
+    operation_params.domain = "AE"
+    operation_params.target = "VERYFAKEVARIABLE"
+    result = DefineVariableCodelist(
+        operation_params, pd.DataFrame.from_dict({"A": [1, 2, 3]}), cache, data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        val == ""


### PR DESCRIPTION
This PR adds an operation to get the codelist ccode for a specific variable from the provided define.xml. This is to support rules specified in #278.

Steps to test:

1. Run the unit tests
2. Run the following provided sample rule with the provided data and define xml:
[define.xml.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11499369/define.xml.txt)
[invalid_units_rule.json.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11499372/invalid_units_rule.json.txt)
[invalid_units_dataset.json.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/11499375/invalid_units_dataset.json.txt)

using the command: `python core.py test -s sdtmig -v 3-4 -r invalid_units_rule.json -dp invalid_units_dataset.json`

3. Verify that the results are correct given the CCODE for PPORRESU in the define.
4. Modify the CCODE for PPORRESU and verify the results change accordingly
