### PR TITLE
Add function to get ordered key variables for dataset

### DIFF
--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -2,7 +2,7 @@ from abc import abstractmethod, ABC
 from dataclasses import dataclass
 from typing import List, Optional
 from functools import cache
-
+from heapq import heappush, heappop
 
 from odmlib.define_loader import XMLDefineLoader
 from odmlib.loader import ODMLoader
@@ -60,6 +60,16 @@ class BaseDefineXMLReader(ABC):
         self.cache_service = cache_service_obj
         self.study_id = study_id
         self.data_bundle_id = data_bundle_id
+
+    @cache
+    def get_item_def_map(self) -> dict:
+        metadata = self._odm_loader.MetaDataVersion()
+        return {item.OID: item for item in metadata.ItemDef}
+
+    @cache
+    def get_value_list_def_map(self) -> dict:
+        metadata = self._odm_loader.MetaDataVersion()
+        return {value_list.OID: value_list for value_list in metadata.ValueListDef}
 
     def read(self) -> List[dict]:
         """
@@ -180,6 +190,11 @@ class BaseDefineXMLReader(ABC):
             raise DomainNotFoundInDefineXMLError(
                 f"Domain {domain_name} is not found in Define XML"
             )
+
+    def _get_all_domain_metadata(self, metadata, domain_name):
+        # Returns all itemgroupdefs with domain = domain name.
+        # This will include and SUPP-- datasets and split datasets
+        return [item for item in metadata.ItemGroupDef if item.Domain == domain_name]
 
     def _get_codelist_def_map(self, codelist_defs):
         """
@@ -320,3 +335,73 @@ class BaseDefineXMLReader(ABC):
             if key.endswith("DefineVersion"):
                 return val
         return None
+
+    def get_domain_key_sequence(self, domain_name: str) -> List[str]:
+        """
+        Given a domain name, this function returns the key sequence variable names
+        in order of KeySequence number.
+
+        In the case that Supplemental qualifiers apply to a domain:
+
+        # TODO! How should this be handled - add to end of list
+        """
+        heap = []
+        existing_key_variables = set()
+        metadata = self._odm_loader.MetaDataVersion()
+        item_mapping = self.get_item_def_map()
+        value_list_mapping = self.get_value_list_def_map()
+        datasets = self._get_all_domain_metadata(metadata, domain_name)
+        for domain_metadata in datasets:
+            if domain_metadata.Name.startswith("SUPP"):
+                # handle supp vlm
+                key_variables = self._get_key_variables_for_supp_dataset(
+                    domain_metadata, item_mapping, value_list_mapping
+                )
+                [
+                    heappush(heap, key_variable)
+                    for key_variable in key_variables
+                    if key_variable[1] not in existing_key_variables
+                ]
+            else:
+                key_variables = self._get_key_variables_for_domain(
+                    domain_metadata, item_mapping
+                )
+                [
+                    heappush(heap, key_variable)
+                    for key_variable in key_variables
+                    if key_variable[1] not in existing_key_variables
+                ]
+
+        return [heappop(heap)[1] for _ in range(len(heap))]
+
+    def _get_key_variables_for_domain(self, domain_metadata, item_mapping):
+        key_variables = []
+        for item in domain_metadata.ItemRef:
+            if item.KeySequence:
+                item_def = item_mapping.get(item.ItemOID)
+                if item:
+                    key_variables.append((item.KeySequence, item_def.Name))
+        return key_variables
+
+    def _get_key_variables_for_supp_dataset(
+        self, domain_metadata, item_mapping, value_list_mapping
+    ):
+        key_variables = []
+        for item in domain_metadata.ItemRef:
+            item_def = item_mapping.get(item.ItemOID)
+            if item_def and item_def.ValueListRef:
+                value_list = value_list_mapping.get(item_def.ValueListRef.ValueListOID)
+                if value_list:
+                    key_variables.extend(
+                        self._get_key_variables_from_valuelist(value_list, item_mapping)
+                    )
+        return key_variables
+
+    def _get_key_variables_from_valuelist(self, value_list, item_mapping):
+        key_variables = []
+        for item_ref in value_list.ItemRef:
+            if item_ref.KeySequence:
+                key_item_def = item_mapping.get(item_ref.ItemOID)
+                if key_item_def:
+                    key_variables.append((item_ref.KeySequence, key_item_def.Name))
+        return key_variables

--- a/tests/resources/test_defineV22-SDTM.xml
+++ b/tests/resources/test_defineV22-SDTM.xml
@@ -587,7 +587,7 @@
         </ItemRef>
       </def:ValueListDef>
       <def:ValueListDef OID="VL.SUPPEC">
-        <ItemRef ItemOID="IT.SUPPEC.QVAL.1" OrderNumber="1" Mandatory="Yes"
+        <ItemRef ItemOID="IT.SUPPEC.QVAL.1" KeySequence="10" OrderNumber="1" Mandatory="Yes"
          Role="Variable Qualifier">
           <def:WhereClauseRef WhereClauseOID="WC.ECREASOC"/>
         </ItemRef>

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -297,5 +297,19 @@ def test_get_domain_key_sequence():
         contents: bytes = file.read()
         reader = DefineXMLReaderFactory.from_file_contents(contents)
         ec_key_sequence: dict = reader.get_domain_key_sequence(domain_name="EC")
-        print(ec_key_sequence)
         assert ec_key_sequence == ["STUDYID", "USUBJID", "ECTRT", "ECSTDTC", "ECREASOC"]
+
+
+def test_get_domain_key_sequence_for_supp():
+    with open(test_define_file_path, "rb") as file:
+        contents: bytes = file.read()
+        reader = DefineXMLReaderFactory.from_file_contents(contents)
+        suppec_key_sequence: dict = reader.get_domain_key_sequence(domain_name="SUPPEC")
+        assert suppec_key_sequence == [
+            "STUDYID",
+            "RDOMAIN",
+            "USUBJID",
+            "IDVAR",
+            "IDVARVAL",
+            "QNAM",
+        ]

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -290,3 +290,12 @@ def test_extract_variable_metadata_not_found():
         reader = DefineXMLReaderFactory.from_file_contents(contents)
         with pytest.raises(DomainNotFoundInDefineXMLError):
             reader.extract_variables_metadata(domain_name="not found domain")
+
+
+def test_get_domain_key_sequence():
+    with open(test_define_file_path, "rb") as file:
+        contents: bytes = file.read()
+        reader = DefineXMLReaderFactory.from_file_contents(contents)
+        ec_key_sequence: dict = reader.get_domain_key_sequence(domain_name="EC")
+        print(ec_key_sequence)
+        assert ec_key_sequence == ["STUDYID", "USUBJID", "ECTRT", "ECSTDTC", "ECREASOC"]


### PR DESCRIPTION
This PR adds a function to get the key variables for a domain. Currently it is a single function to be used in the future by other issues.

Steps to test:
1. Run the unit tests