### PR TITLE
Populate "Dataset Details" tab in excel export

### DIFF
--- a/cdisc_rules_engine/dummy_models/dummy_dataset.py
+++ b/cdisc_rules_engine/dummy_models/dummy_dataset.py
@@ -21,9 +21,12 @@ class DummyDataset:
     def get_metadata(self):
         return {
             "dataset_size": [self.filesize or 1000],
-            "dataset_name": [self.filename.split(".")[0].upper() or "test"],
+            "dataset_name": [
+                self.filename.split(".")[0].upper() if self.filename else "test"
+            ],
             "dataset_label": [self.label or "test"],
             "filename": [self.filename],
+            "length": [len(self.data.index)],
         }
 
     def validate(self, dataset_data):

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -75,7 +75,8 @@ class DummyDataService(BaseDataService):
             modification_date=datetime.now().isoformat(),
             filename=dataset_metadata["filename"][0],
             size=dataset_metadata["dataset_size"][0],
-            records="",
+            full_path=dataset_metadata["filename"][0],
+            records=dataset_metadata["length"][0],
         )
 
     def get_variables_metadata(self, dataset_name: str, **params) -> pd.DataFrame:

--- a/cdisc_rules_engine/services/data_services/local_data_service.py
+++ b/cdisc_rules_engine/services/data_services/local_data_service.py
@@ -90,7 +90,7 @@ class LocalDataService(BaseDataService):
             filename=file_metadata["name"],
             full_path=file_metadata["path"],
             size=file_metadata["size"],
-            records="",
+            records=contents_metadata["dataset_length"],
         )
 
     @cached_dataset(DatasetTypes.VARIABLES_METADATA.value)

--- a/cdisc_rules_engine/services/dataset_metadata_reader.py
+++ b/cdisc_rules_engine/services/dataset_metadata_reader.py
@@ -46,6 +46,7 @@ class DatasetMetadataReader:
             ).to_dict(),
             "number_of_variables": len(dataset.columns),
             "dataset_label": dataset.dataset_label,
+            "dataset_length": dataset.shape[0],
             "domain_name": self._domain_name,
             "dataset_name": self._dataset_name,
             "dataset_modification_date": dataset.modified.isoformat(),

--- a/cdisc_rules_engine/services/reporting/base_report.py
+++ b/cdisc_rules_engine/services/reporting/base_report.py
@@ -16,12 +16,14 @@ class BaseReport(ABC):
 
     def __init__(
         self,
+        datasets: Iterable[dict],
         dataset_paths: Iterable[str],
         validation_results: List[RuleValidationResult],
         elapsed_time: float,
         args: Validation_args,
         template: Optional[IOBase] = None,
     ):
+        self._datasets = datasets
         self._dataset_paths: Iterable[str] = dataset_paths
         self._elapsed_time: float = elapsed_time
         self._results: List[RuleValidationResult] = validation_results

--- a/cdisc_rules_engine/services/reporting/excel_report.py
+++ b/cdisc_rules_engine/services/reporting/excel_report.py
@@ -26,6 +26,7 @@ class ExcelReport(BaseReport):
 
     def __init__(
         self,
+        datasets: Iterable[dict],
         dataset_paths: Iterable[str],
         validation_results: List[RuleValidationResult],
         elapsed_time: float,
@@ -33,7 +34,7 @@ class ExcelReport(BaseReport):
         template: Optional[BinaryIO] = None,
     ):
         super().__init__(
-            dataset_paths, validation_results, elapsed_time, args, template
+            datasets, dataset_paths, validation_results, elapsed_time, args, template
         )
         self._item_type = "list"
 
@@ -59,6 +60,23 @@ class ExcelReport(BaseReport):
         )
         wb["Conformance Details"]["B3"] = f"{round(self._elapsed_time, 2)} seconds"
         wb["Conformance Details"]["B4"] = __version__
+
+        # write dataset metadata
+        datasets_data = [
+            [
+                dataset.get("filename"),
+                dataset.get("label"),
+                dataset.get("full_path"),
+                dataset.get("modification_date"),
+                dataset.get("size", 0) / 1000,
+                dataset.get("length"),
+            ]
+            for dataset in self._datasets
+        ]
+        excel_update_worksheet(
+            wb["Dataset Details"], datasets_data, dict(wrap_text=True)
+        )
+
         # write standards details
         wb["Conformance Details"]["B7"] = standard.upper()
         wb["Conformance Details"]["B8"] = f"V{version}"

--- a/cdisc_rules_engine/services/reporting/json_report.py
+++ b/cdisc_rules_engine/services/reporting/json_report.py
@@ -18,6 +18,7 @@ class JsonReport(BaseReport):
 
     def __init__(
         self,
+        datasets: Iterable[dict],
         dataset_paths: Iterable[str],
         validation_results: List[RuleValidationResult],
         elapsed_time: float,
@@ -25,7 +26,7 @@ class JsonReport(BaseReport):
         template: Optional[BinaryIO] = None,
     ):
         super().__init__(
-            dataset_paths, validation_results, elapsed_time, args, template
+            datasets, dataset_paths, validation_results, elapsed_time, args, template
         )
         self._item_type = "dict"
 

--- a/cdisc_rules_engine/services/reporting/report_factory.py
+++ b/cdisc_rules_engine/services/reporting/report_factory.py
@@ -25,13 +25,14 @@ class ReportFactory:
 
     def __init__(
         self,
-        dataset_paths: Iterable[str],
+        datasets: Iterable[dict],
         results: List[RuleValidationResult],
         elapsed_time: float,
         args: Validation_args,
         data_service: DataServiceInterface,
     ):
-        self._dataset_paths = dataset_paths
+        self._datasets = datasets
+        self._dataset_paths = [dataset.get("full_path") for dataset in datasets]
         self._results = results
         self._elapsed_time = elapsed_time
         self._args = args
@@ -47,6 +48,7 @@ class ReportFactory:
             output_type: str = output_type.upper()
             service_class: Type[BaseReport] = self._output_type_service_map[output_type]
             instance: BaseReport = service_class(
+                self._datasets,
                 self._dataset_paths,
                 self._results,
                 self._elapsed_time,

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -104,7 +104,6 @@ def run_validation(args: Validation_args):
     data_service = DataServiceFactory(config, shared_cache).get_data_service()
     datasets = get_datasets(data_service, args.dataset_paths)
     engine_logger.info(f"Running {len(rules)} rules against {len(datasets)} datasets")
-
     start = time.time()
     results = []
     # run each rule in a separate process
@@ -120,7 +119,7 @@ def run_validation(args: Validation_args):
     end = time.time()
     elapsed_time = end - start
     reporting_factory = ReportFactory(
-        args.dataset_paths, results, elapsed_time, args, data_service
+        datasets, results, elapsed_time, args, data_service
     )
     reporting_services: List[BaseReport] = reporting_factory.get_report_services()
     for reporting_service in reporting_services:

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -93,12 +93,16 @@ def get_datasets(
 ) -> List[dict]:
     datasets = []
     for dataset_path in dataset_paths:
-        metadata = data_service.get_dataset_metadata(dataset_name=dataset_path)
+        metadata = data_service.get_raw_dataset_metadata(dataset_name=dataset_path)
         datasets.append(
             {
-                "domain": metadata["dataset_name"].iloc[0],
-                "filename": metadata["dataset_location"].iloc[0],
+                "domain": metadata.domain_name,
+                "filename": metadata.filename,
                 "full_path": dataset_path,
+                "length": metadata.records,
+                "label": metadata.label,
+                "size": metadata.size,
+                "modification_date": metadata.modification_date,
             }
         )
 

--- a/scripts/test_rule.py
+++ b/scripts/test_rule.py
@@ -28,6 +28,7 @@ from scripts.script_utils import (
     fill_cache_with_dictionaries,
     fill_cache_with_provided_data,
     get_cache_service,
+    get_datasets,
 )
 from cdisc_rules_engine.utilities.utils import get_directory_path
 from cdisc_rules_engine.enums.progress_parameter_options import ProgressParameterOptions
@@ -99,10 +100,12 @@ def test(args: TestArgs):
     fill_cache_with_dictionaries(shared_cache, args)
     with open(args.rule, "r") as f:
         rules = [Rule.from_cdisc_metadata(json.load(f))]
-    data_service = DataServiceFactory(config, shared_cache).get_data_service()
     with open(args.dataset_path, "r") as f:
         data_json = json.load(f)
     datasets = [DummyDataset(data) for data in data_json.get("datasets", [])]
+    data_service_factory = DataServiceFactory(config, shared_cache)
+    dummy_data_service = data_service_factory.get_dummy_data_service(datasets)
+    data_service = data_service_factory.get_data_service()
 
     start = time.time()
     results = []
@@ -145,7 +148,11 @@ def test(args: TestArgs):
         ProgressParameterOptions.BAR.value,
     )
     reporting_factory = ReportFactory(
-        [args.dataset_path], results, elapsed_time, validation_args, data_service
+        get_datasets(dummy_data_service, [dataset.filename for dataset in datasets]),
+        results,
+        elapsed_time,
+        validation_args,
+        data_service,
     )
     reporting_services: List[BaseReport] = reporting_factory.get_report_services()
     for reporting_service in reporting_services:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1219,5 +1219,6 @@ def dataset_metadata() -> dict:
             "dataset_name": "AE",
             "domain_name": "AE",
             "dataset_modification_date": datetime.now().isoformat(),
+            "dataset_length": 20,
         },
     }

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -68,7 +68,7 @@ def test_get_raw_dataset_metadata(
         filename=dataset_metadata["file_metadata"]["name"],
         full_path=dataset_metadata["file_metadata"]["path"],
         size=dataset_metadata["file_metadata"]["size"],
-        records="",
+        records=20,
     )
     assert actual_metadata == expected_metadata
 

--- a/tests/unit/test_services/test_reporting/test_excel_export.py
+++ b/tests/unit/test_services/test_reporting/test_excel_export.py
@@ -151,7 +151,7 @@ mock_validation_results = [
 def test_get_rules_report_data():
     with open(test_report_template, "rb") as f:
         report: ExcelReport = ExcelReport(
-            "test", mock_validation_results, 10.1, MagicMock(), f
+            [], "test", mock_validation_results, 10.1, MagicMock(), f
         )
         report_data = report.get_rules_report_data()
         expected_reports = []
@@ -176,7 +176,7 @@ def test_get_rules_report_data():
 def test_get_detailed_data():
     with open(test_report_template, "rb") as f:
         report: ExcelReport = ExcelReport(
-            "test", mock_validation_results, 10.1, MagicMock(), f
+            [], "test", mock_validation_results, 10.1, MagicMock(), f
         )
         detailed_data = report.get_detailed_data()
         errors = [
@@ -223,7 +223,7 @@ def test_get_detailed_data():
 def test_get_summary_data():
     with open(test_report_template, "rb") as f:
         report: ExcelReport = ExcelReport(
-            "test", mock_validation_results, 10.1, MagicMock(), f
+            [], "test", mock_validation_results, 10.1, MagicMock(), f
         )
         summary_data = report.get_summary_data()
         errors = [
@@ -251,8 +251,18 @@ def test_get_export():
         mock_args = MagicMock()
         mock_args.meddra = "test"
         mock_args.whodrug = "test"
+        datasets = [
+            {
+                "filename": "test.xpt",
+                "label": "Test Data",
+                "full_path": "tests/unit/text.xpt",
+                "modification_date": "2022-04-19T16:17:45",
+                "size": 20000,
+                "length": 700,
+            }
+        ]
         report: ExcelReport = ExcelReport(
-            ["test"], mock_validation_results, 10.1, mock_args, f
+            datasets, ["test"], mock_validation_results, 10.1, mock_args, f
         )
         cdiscCt = ["sdtmct-03-2021"]
         wb = report.get_export(
@@ -264,3 +274,13 @@ def test_get_export():
         assert wb["Conformance Details"]["B8"].value == "V3.4"
         assert wb["Conformance Details"]["B9"].value == ", ".join(cdiscCt)
         assert wb["Conformance Details"]["B10"].value == "2.1"
+
+        # Check dataset details tab
+        assert wb["Dataset Details"]["A2"].value == "test.xpt"  # filename
+        assert wb["Dataset Details"]["B2"].value == "Test Data"  # label
+        assert wb["Dataset Details"]["C2"].value == "tests/unit/text.xpt"  # Location
+        assert (
+            wb["Dataset Details"]["D2"].value == "2022-04-19T16:17:45"
+        )  # Modified Time Stamp
+        assert wb["Dataset Details"]["E2"].value == 20  # Size in kb
+        assert wb["Dataset Details"]["F2"].value == 700  # Number of records

--- a/tests/unit/test_services/test_reporting/test_json_export.py
+++ b/tests/unit/test_services/test_reporting/test_json_export.py
@@ -143,7 +143,9 @@ mock_validation_results = [
 
 
 def test_get_rules_report_data():
-    report: JsonReport = JsonReport("test", mock_validation_results, 10.1, MagicMock())
+    report: JsonReport = JsonReport(
+        [], "test", mock_validation_results, 10.1, MagicMock()
+    )
     report_data = report.get_rules_report_data()
     expected_reports = []
     for result in mock_validation_results:
@@ -165,7 +167,9 @@ def test_get_rules_report_data():
 
 
 def test_get_detailed_data():
-    report: JsonReport = JsonReport("test", mock_validation_results, 10.1, MagicMock())
+    report: JsonReport = JsonReport(
+        [], "test", mock_validation_results, 10.1, MagicMock()
+    )
     detailed_data = report.get_detailed_data()
     errors = [
         {
@@ -209,7 +213,9 @@ def test_get_detailed_data():
 
 
 def test_get_summary_data():
-    report: JsonReport = JsonReport("test", mock_validation_results, 10.1, MagicMock())
+    report: JsonReport = JsonReport(
+        [], "test", mock_validation_results, 10.1, MagicMock()
+    )
     summary_data = report.get_summary_data()
     errors = [
         {
@@ -232,7 +238,9 @@ def test_get_summary_data():
 
 
 def test_get_export():
-    report: JsonReport = JsonReport("test", mock_validation_results, 10.1, MagicMock())
+    report: JsonReport = JsonReport(
+        [], "test", mock_validation_results, 10.1, MagicMock()
+    )
     cdiscCt = ["sdtmct-03-2021"]
     export = report.get_export(
         define_version="2.1",

--- a/tests/unit/test_services/test_reporting/test_report_factory.py
+++ b/tests/unit/test_services/test_reporting/test_report_factory.py
@@ -11,10 +11,7 @@ def test_get_report_services():
     Unit test for ReportFactory.get_report_services
     """
     factory = ReportFactory(
-        dataset_paths=[
-            "dataset_path_1",
-            "dataset_path_2",
-        ],
+        datasets=[],
         results=[],
         elapsed_time=10.5,
         args=MagicMock(output_format=ReportTypes.values()),


### PR DESCRIPTION
This PR adds functionality to populate the dataset details tab in the excel export.

Steps to test:

1. Run the unit tests
2. Run a validation and verify the "Dataset Details" tab is populated with the information for all datasets
3. Run a test validation and verify the "Dataset Details" tab is populated with the appropriate details