### PR TITLE
ISS-271: Compare variable value length with vlm metadata

### DIFF
--- a/cdisc_rules_engine/dataset_builders/contents_define_vlm_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/contents_define_vlm_dataset_builder.py
@@ -16,6 +16,7 @@ class ContentsDefineVLMDatasetBuilder(ValuesDatasetBuilder):
         "row_number",
         "variable_name",
         "variable_value",
+        "variable_value_length",
         "define_variable_name",
         "define_vlm_name",
         "define_vlm_label",
@@ -56,6 +57,9 @@ class ContentsDefineVLMDatasetBuilder(ValuesDatasetBuilder):
             how="inner",
             on="define_vlm_name",
         )
+        data_contents_with_vlm["variable_value_length"] = data_contents_with_vlm.apply(
+            self.calculate_variable_value_length, axis=1
+        )
         return data_contents_with_vlm
 
     @staticmethod
@@ -69,3 +73,10 @@ class ContentsDefineVLMDatasetBuilder(ValuesDatasetBuilder):
             how="cross",
         )
         return lut_subset
+
+    @staticmethod
+    def calculate_variable_value_length(df_row: dict) -> int:
+        if df_row["define_vlm_data_type"] == "Num":
+            return len(str(df_row["variable_value"]).lstrip("0").replace(".", ""))
+        else:
+            return len(df_row["variable_value"])

--- a/cdisc_rules_engine/dataset_builders/contents_define_vlm_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/contents_define_vlm_dataset_builder.py
@@ -58,7 +58,10 @@ class ContentsDefineVLMDatasetBuilder(ValuesDatasetBuilder):
             on="define_vlm_name",
         )
         data_contents_with_vlm["variable_value_length"] = data_contents_with_vlm.apply(
-            self.calculate_variable_value_length, axis=1
+            lambda row: self.calculate_variable_value_length(
+                row["variable_value"], row["define_vlm_data_type"]
+            ),
+            axis=1,
         )
         return data_contents_with_vlm
 
@@ -73,10 +76,3 @@ class ContentsDefineVLMDatasetBuilder(ValuesDatasetBuilder):
             how="cross",
         )
         return lut_subset
-
-    @staticmethod
-    def calculate_variable_value_length(df_row: dict) -> int:
-        if df_row["define_vlm_data_type"] == "Num":
-            return len(str(df_row["variable_value"]).lstrip("0").replace(".", ""))
-        else:
-            return len(df_row["variable_value"])

--- a/cdisc_rules_engine/dataset_builders/values_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/values_dataset_builder.py
@@ -24,3 +24,13 @@ class ValuesDatasetBuilder(BaseDatasetBuilder):
             value_name="variable_value",
         )
         return values_df
+
+    @staticmethod
+    def calculate_variable_value_length(variable_value, variable_data_type: str) -> int:
+        if variable_data_type == "integer":
+            return len(str(variable_value).lstrip("0"))
+        elif variable_data_type == "float":
+            return len(str(variable_value).lstrip("0").replace(".", ""))
+        elif variable_data_type == "text":
+            return len(variable_value)
+        return None

--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -243,9 +243,7 @@ class BaseDefineXMLReader(ABC):
             data["define_variable_size"] = itemdef.Length
             data["define_variable_role"] = itemref.Role
             data["define_variable_length"] = itemdef.Length
-            data["define_variable_data_type"] = self._get_variable_datatype(
-                itemdef.DataType
-            )
+            data["define_variable_data_type"] = itemdef.DataType
             data["define_variable_is_collected"] = self._get_variable_is_collected(
                 itemdef
             )
@@ -288,23 +286,6 @@ class BaseDefineXMLReader(ABC):
         if codelist:
             for codelist_item in codelist.CodeListItem + codelist.EnumeratedItem:
                 yield codelist_item.CodedValue
-
-    def _get_variable_datatype(self, data_type):
-        variable_type_map = {
-            "text": "Char",
-            "integer": "Num",
-            "float": "Num",
-            "datetime": "Char",
-            "date": "Char",
-            "time": "Char",
-            "partialDate": "Char",
-            "partialTime": "Char",
-            "partialDatetime": "Char",
-            "incompleteDatetime": "Char",
-            "durationDatetime": "Char",
-            "intervalDatetime": "Char",
-        }
-        return variable_type_map.get(data_type, data_type)
 
     @abstractmethod
     def _get_origin_type(self, itemdef):

--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -120,7 +120,6 @@ class BaseDefineXMLReader(ABC):
         logger.info(f"Extracted variables metadata = {variables_metadata}")
         return variables_metadata
 
-    @cached("define-value-level-metadata")
     def extract_value_level_metadata(self, domain_name: str = None) -> List[dict]:
         """
         Extracts all value level metadata for each variable in a given domain.
@@ -235,6 +234,7 @@ class BaseDefineXMLReader(ABC):
             "define_variable_origin_type": "",
             "define_variable_has_no_data": "",
             "define_variable_order_number": None,
+            "define_variable_length": None,
             "define_variable_has_codelist": False,
             "define_variable_codelist_coded_values": [],
         }
@@ -242,6 +242,7 @@ class BaseDefineXMLReader(ABC):
             data["define_variable_name"] = itemdef.Name
             data["define_variable_size"] = itemdef.Length
             data["define_variable_role"] = itemref.Role
+            data["define_variable_length"] = itemdef.Length
             data["define_variable_data_type"] = self._get_variable_datatype(
                 itemdef.DataType
             )
@@ -267,7 +268,6 @@ class BaseDefineXMLReader(ABC):
                 data["define_variable_origin_type"] = self._get_origin_type(itemdef)
             data["define_variable_has_no_data"] = getattr(itemref, "HasNoData", "")
             data["define_variable_order_number"] = itemref.OrderNumber
-
         return data
 
     def _get_codelist_ccode(self, codelist):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==22.6.0
-business-rules-enhanced==1.3.6
+business-rules-enhanced==1.3.7
 cdisc-library-client==0.1.4
 click==8.1.3
 flake8==5.0.4

--- a/resources/schema/MetaVariables.json
+++ b/resources/schema/MetaVariables.json
@@ -180,7 +180,7 @@
     },
     {
       "const": "variable_value_length",
-      "markdownDescription": "Calculated length of the length of the value at `row_number` and `variable_name`"
+      "markdownDescription": "Calculated length of the value at `row_number` and `variable_name`"
     }
   ]
 }

--- a/resources/schema/MetaVariables.json
+++ b/resources/schema/MetaVariables.json
@@ -74,6 +74,10 @@
       "markdownDescription": "ItemGroupDef.ItemDef.Description.TranslatedText"
     },
     {
+      "const": "define_variable_length",
+      "markdownDescription": "ItemGroupDef.ItemDef.Length"
+    },
+    {
       "const": "define_variable_name",
       "markdownDescription": "ItemGroupDef.ItemDef.Name"
     },
@@ -130,6 +134,10 @@
       "markdownDescription": "ValueListDef.ItemDef.Description.TranslatedText"
     },
     {
+      "const": "define_vlm_length",
+      "markdownDescription": "ValueListDef.ItemDef.Length"
+    },
+    {
       "const": "define_vlm_name",
       "markdownDescription": "ValueListDef.ItemDef.Name"
     },
@@ -169,6 +177,10 @@
     {
       "const": "variable_value",
       "markdownDescription": "Value at `row_number` and `variable_name`"
+    },
+    {
+      "const": "variable_value_length",
+      "markdownDescription": "Calculated length of the length of the value at `row_number` and `variable_name`"
     }
   ]
 }

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     python_requires=">=3.8",
     install_requires=[
         "pandas>=1.3.5",
-        "business-rules-enhanced==1.3.6",
+        "business-rules-enhanced==1.3.7",
         "python-dotenv==0.20.0",
         "cdisc-library-client==0.1.4",
         "odmlib==0.1.4",

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -18,6 +18,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                 "define_vlm_label": ["VAR1B Label", "VAR3C Label"],
                 "define_vlm_data_type": ["VAR1B Type", "VAR3C Type"],
                 "define_vlm_role": ["VAR1B ROLE", "VAR3C ROLE"],
+                "define_vlm_length": [1, 2],
                 "filter": [
                     lambda row: row["VAR2"] == "2B",
                     lambda row: row["VAR2"] == "2C",
@@ -27,6 +28,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                 "row_number": [2],
                 "variable_name": ["VAR1"],
                 "variable_value": ["1B"],
+                "variable_value_length": [2],
                 "define_variable_name": [
                     "VAR1",
                 ],
@@ -42,6 +44,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                 "define_vlm_role": [
                     "VAR1B ROLE",
                 ],
+                "define_vlm_length": [1],
             },
         ),
     ],
@@ -78,3 +81,16 @@ def test_contents_define_vlm_dataset_builder(
     expected_df.sort_index(axis=1, inplace=True)
     result.sort_index(axis=1, inplace=True)
     assert result.equals(expected_df)
+
+
+@pytest.mark.parametrize(
+    "row, expected_value",
+    [
+        ({"define_vlm_data_type": "Num", "variable_value": "0012"}, 2),
+        ({"define_vlm_data_type": "Num", "variable_value": 24.50}, 3),
+        ({"define_vlm_data_type": "Num", "variable_value": "023.55"}, 4),
+    ],
+)
+def test_calculate_variable_value_length(row: dict, expected_value: int):
+    result = ContentsDefineVLMDatasetBuilder.calculate_variable_value_length(row)
+    assert result == expected_value

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -16,7 +16,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                 "define_variable_name": ["VAR1", "VAR3"],
                 "define_vlm_name": ["VAR1B VLM Name", "VAR3C VLM Name"],
                 "define_vlm_label": ["VAR1B Label", "VAR3C Label"],
-                "define_vlm_data_type": ["VAR1B Type", "VAR3C Type"],
+                "define_vlm_data_type": ["text", "text"],
                 "define_vlm_role": ["VAR1B ROLE", "VAR3C ROLE"],
                 "define_vlm_length": [1, 2],
                 "filter": [
@@ -39,7 +39,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                     "VAR1B Label",
                 ],
                 "define_vlm_data_type": [
-                    "VAR1B Type",
+                    "text",
                 ],
                 "define_vlm_role": [
                     "VAR1B ROLE",
@@ -81,16 +81,3 @@ def test_contents_define_vlm_dataset_builder(
     expected_df.sort_index(axis=1, inplace=True)
     result.sort_index(axis=1, inplace=True)
     assert result.equals(expected_df)
-
-
-@pytest.mark.parametrize(
-    "row, expected_value",
-    [
-        ({"define_vlm_data_type": "Num", "variable_value": "0012"}, 2),
-        ({"define_vlm_data_type": "Num", "variable_value": 24.50}, 3),
-        ({"define_vlm_data_type": "Num", "variable_value": "023.55"}, 4),
-    ],
-)
-def test_calculate_variable_value_length(row: dict, expected_value: int):
-    result = ContentsDefineVLMDatasetBuilder.calculate_variable_value_length(row)
-    assert result == expected_value

--- a/tests/unit/test_dataset_builders/test_values_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_values_dataset_builder.py
@@ -1,0 +1,34 @@
+import pytest
+from cdisc_rules_engine.dataset_builders.values_dataset_builder import (
+    ValuesDatasetBuilder,
+)
+
+
+@pytest.mark.parametrize(
+    "variable_data_type, variable_value, expected_value",
+    [
+        ("integer", "0012", 2),
+        ("integer", "-12", 3),
+        ("integer", 12, 2),
+        ("float", 12.2, 3),
+        ("float", "0012.33", 4),
+        ("float", -12.33, 5),
+        ("text", "0012.33", 7),
+        ("datetime", "2023-06-07T00:00:00", None),
+        ("date", "2023-06-07", None),
+        ("time", "00:00:00", None),
+        ("partialDate", "2023-06", None),
+        ("partialDatetime", "2023-06-07T12:00", None),
+        ("partialTime", "12:20", None),
+        ("incompleteDatetime", "2023-06T12:00:24", None),
+        ("durationDatetime", "P3Y6M4DT12H30M5S", None),
+        ("intervalDatetime", "2023-06/2023-07", None),
+    ],
+)
+def test_calculate_variable_value_length(
+    variable_value, variable_data_type: str, expected_value: int
+):
+    result = ValuesDatasetBuilder.calculate_variable_value_length(
+        variable_value, variable_data_type
+    )
+    assert result == expected_value

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -124,7 +124,7 @@ def test_extract_variable_metadata():
         expected_exroute_metadata = {
             "define_variable_name": "EXROUTE",
             "define_variable_label": "Route of Administration",
-            "define_variable_data_type": "Char",
+            "define_variable_data_type": "text",
             "define_variable_size": 12,
             "define_variable_role": "Variable Qualifier",
             "define_variable_ccode": "C66729",


### PR DESCRIPTION
This PR updates the business rules library and adds a calculation method to the contents with vlm metadata dataset builder to calculate the length of a variables value.

Steps to test:
1. Run the test endpoint with the provided data: [vlm-check-variable-length.zip](https://github.com/cdisc-org/cdisc-rules-engine/files/11909639/vlm-check-variable-length.zip)
2. Verify the flagged errors are flagged appropriately.

Note: Float values that are whole numbers are currently being listed as having length 3. Is that appropriate?