### PR TITLE
ISS-427: Engine detect include special purpose

### DIFF
--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -328,7 +328,7 @@ class BaseOperation:
         else:
             # Domain not found in the model. Detect class name from data
             class_name = self.data_service.get_dataset_class(
-                dataframe, self.params.dataset_path, self.params.datasets
+                dataframe, self.params.dataset_path, self.params.datasets, domain
             )
             class_name = convert_library_class_name_to_ct_class(class_name)
             class_details = self._get_class_metadata(model_details, class_name)

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -56,9 +56,9 @@ class RulesEngine:
     ):
         self.config = config_obj or default_config
         self.cache = cache or CacheServiceFactory(self.config).get_cache_service()
-        self.data_service = (
-            data_service or DataServiceFactory(self.config, self.cache).get_service()
-        )
+        self.data_service = data_service or DataServiceFactory(
+            self.config, self.cache
+        ).get_service(**kwargs)
         self.rule_processor = RuleProcessor(self.data_service, self.cache)
         self.data_processor = DataProcessor(self.data_service, self.cache)
         self.standard = kwargs.get("standard")

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -24,6 +24,7 @@ from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
 from cdisc_rules_engine.services.data_readers import DataReaderFactory
 from cdisc_rules_engine.utilities.utils import (
+    convert_library_class_name_to_ct_class,
     get_dataset_cache_key_from_path,
     get_directory_path,
     search_in_list_of_dicts,
@@ -166,7 +167,7 @@ class BaseDataService(DataServiceInterface, ABC):
                 class_data, _ = get_class_and_domain_metadata(standard_data, domain)
                 name = class_data.get("name")
                 if name:
-                    return name.replace("-", " ")
+                    return convert_library_class_name_to_ct_class(name)
                 else:
                     return None
             return None

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -21,12 +21,15 @@ from cdisc_rules_engine.constants.classes import (
 )
 from cdisc_rules_engine.models.dataset_types import DatasetTypes
 from cdisc_rules_engine.services import logger
+from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
 from cdisc_rules_engine.services.data_readers import DataReaderFactory
 from cdisc_rules_engine.utilities.utils import (
     get_dataset_cache_key_from_path,
     get_directory_path,
     search_in_list_of_dicts,
+    get_standard_details_cache_key,
 )
+from cdisc_rules_engine.utilities.sdtm_utilities import get_class_and_domain_metadata
 
 
 def cached_dataset(dataset_type: str):
@@ -87,6 +90,11 @@ class BaseDataService(DataServiceInterface, ABC):
         self.cache_service = cache_service
         self._reader_factory = reader_factory
         self._config = config
+        self.cdisc_library_service: CDISCLibraryService = CDISCLibraryService(
+            self._config.getValue("CDISC_LIBRARY_API_KEY"), self.cache_service
+        )
+        self.standard = kwargs.get("standard")
+        self.version = kwargs.get("standard_version")
 
     def get_dataset_by_type(
         self, dataset_name: str, dataset_type: str, **params
@@ -132,7 +140,7 @@ class BaseDataService(DataServiceInterface, ABC):
         return full_dataset
 
     def get_dataset_class(
-        self, dataset: pd.DataFrame, file_path: str, datasets: List[dict]
+        self, dataset: pd.DataFrame, file_path: str, datasets: List[dict], domain: str
     ) -> Optional[str]:
         if self._contains_topic_variable(dataset, "TERM"):
             return EVENTS
@@ -148,7 +156,19 @@ class BaseDataService(DataServiceInterface, ABC):
                 dataset, file_path, datasets
             )
         else:
-            # Default case, unknown class
+            if self.standard and self.standard_version:
+                cache_key = get_standard_details_cache_key(self.standard, self.version)
+                standard_data = self.cache_service.get(cache_key)
+                if not standard_data:
+                    standard_data = self.cdisc_library_service.get_standard_details(
+                        self.standard, self.version
+                    )
+                class_data, _ = get_class_and_domain_metadata(standard_data, domain)
+                name = class_data.get("name")
+                if name:
+                    return name.replace("-", " ")
+                else:
+                    return None
             return None
 
     def _is_associated_persons(self, dataset) -> bool:
@@ -182,7 +202,9 @@ class BaseDataService(DataServiceInterface, ABC):
                 raise ValueError("Filename for domain doesn't exist")
             if self._is_associated_persons(new_domain_dataset):
                 raise ValueError("Nested Associated Persons domain reference")
-            return self.get_dataset_class(new_domain_dataset, new_file_path, datasets)
+            return self.get_dataset_class(
+                new_domain_dataset, new_file_path, datasets, domain_details["domain"]
+            )
         else:
             return None
 

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Set, Union, Tuple
 import pandas as pd
 
 from cdisc_rules_engine.constants.classes import (
-    DETECTABLE_CLASSES,
     FINDINGS_ABOUT,
     FINDINGS,
 )
@@ -149,7 +148,7 @@ class RuleProcessor:
             is_supp_domain(dataset_domain) or is_ap_domain(dataset_domain)
         )
 
-    def rule_applies_to_class(self, rule, file_path, datasets: List[dict]):
+    def rule_applies_to_class(self, rule, file_path, datasets: List[dict], domain: str):
         """
         If included classes are specified and the class
         is not in the list of included classes return false.
@@ -168,14 +167,13 @@ class RuleProcessor:
         """
         classes = rule.get("classes") or {}
         included_classes = classes.get("Include", [])
-        included_classes = [c for c in included_classes if c in DETECTABLE_CLASSES]
         excluded_classes = classes.get("Exclude", [])
         is_included = True
         is_excluded = False
         if included_classes:
             dataset = self.data_service.get_dataset(dataset_name=file_path)
             class_name = self.data_service.get_dataset_class(
-                dataset, file_path, datasets
+                dataset, file_path, datasets, domain
             )
             if (
                 (class_name not in included_classes)
@@ -186,7 +184,7 @@ class RuleProcessor:
         if excluded_classes:
             dataset = self.data_service.get_dataset(dataset_name=file_path)
             class_name = self.data_service.get_dataset_class(
-                dataset, file_path, datasets
+                dataset, file_path, datasets, domain
             )
             if class_name and (
                 (class_name in excluded_classes)
@@ -430,7 +428,7 @@ class RuleProcessor:
         is_suitable: bool = (
             self.valid_rule_structure(rule)
             and self.rule_applies_to_domain(dataset_domain, rule, is_split_domain)
-            and self.rule_applies_to_class(rule, file_path, datasets)
+            and self.rule_applies_to_class(rule, file_path, datasets, dataset_domain)
         )
         logger.info(
             f"is_suitable_for_validation. rule id={rule.get('core_id')}, "

--- a/cdisc_rules_engine/utilities/sdtm_utilities.py
+++ b/cdisc_rules_engine/utilities/sdtm_utilities.py
@@ -1,0 +1,16 @@
+from cdisc_rules_engine.utilities.utils import (
+    search_in_list_of_dicts,
+)
+from typing import Tuple
+
+
+def get_class_and_domain_metadata(standard_details, domain: str) -> Tuple:
+    # Get domain and class details for domain. This logic is specific
+    # to SDTM based standards. Needs to be expanded for other models
+    for c in standard_details.get("classes", []):
+        domain_details = search_in_list_of_dicts(
+            c.get("datasets", []), lambda item: item["name"] == domain
+        )
+        if domain_details:
+            return c, domain_details
+    return {}, {}

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -74,7 +74,7 @@ def test_get_raw_dataset_metadata(
 
 
 @pytest.mark.parametrize(
-    "dataset, data, expected_class, filename",
+    "datasets, data, expected_class, filename",
     [
         (
             [{"domain": "AE", "filename": "ae.xpt"}],
@@ -107,12 +107,19 @@ def test_get_raw_dataset_metadata(
             "ae.xpt",
         ),
         ([{"domain": "AE", "filename": "ae.xpt"}], {"UNKNOWN": ["test"]}, None, "None"),
+        ([{"domain": "DM", "filename": "ae.xpt"}], {"UNKNOWN": ["test"]}, None, "None"),
     ],
 )
-def test_get_dataset_class(dataset, data, expected_class, filename):
-    dataset = pd.DataFrame.from_dict(data)
-    data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
-    class_name = data_service.get_dataset_class(dataset, filename, dataset)
+def test_get_dataset_class(datasets, data, expected_class, filename):
+    df = pd.DataFrame.from_dict(data)
+    mock_cache_service = MagicMock()
+    mock_cache_service.get.return_value = {
+        "classes": {"name": "SPECIAL PURPOSE", "datasets": [{"name": "DM"}]}
+    }
+    data_service = LocalDataService(mock_cache_service, MagicMock(), MagicMock())
+    class_name = data_service.get_dataset_class(
+        df, filename, datasets, datasets[0].get("domain")
+    )
     assert class_name == expected_class
 
 
@@ -135,7 +142,9 @@ def test_get_dataset_class_associated_domains():
     ):
         data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
         filepath = f"{data_bundle_path}/ce.xpt"
-        class_name = data_service.get_dataset_class(ap_dataset, filepath, datasets)
+        class_name = data_service.get_dataset_class(
+            ap_dataset, filepath, datasets, "CE"
+        )
         assert class_name == EVENTS
 
 

--- a/tests/unit/test_local_data_service.py
+++ b/tests/unit/test_local_data_service.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+from cdisc_rules_engine.config.config import ConfigService
 
 from cdisc_rules_engine.services.data_services import LocalDataService
 
@@ -45,7 +46,9 @@ def test_get_dataset():
     dataset_path = f"{os.path.dirname(__file__)}/../resources/test_dataset.xpt"
     mock_cache = MagicMock()
     mock_cache.get.return_value = None
-    data_service = LocalDataService.get_instance(cache_service=mock_cache)
+    data_service = LocalDataService.get_instance(
+        config=ConfigService(), cache_service=mock_cache
+    )
     data = data_service.get_dataset(dataset_name=dataset_path)
     assert isinstance(data, pd.DataFrame)
 
@@ -54,7 +57,9 @@ def test_get_variables_metdata():
     dataset_path = f"{os.path.dirname(__file__)}/../resources/test_adam_dataset.xpt"
     mock_cache = MagicMock()
     mock_cache.get.return_value = None
-    data_service = LocalDataService.get_instance(cache_service=mock_cache)
+    data_service = LocalDataService.get_instance(
+        config=ConfigService(), cache_service=mock_cache
+    )
     data = data_service.get_variables_metadata(dataset_name=dataset_path)
     assert isinstance(data, pd.DataFrame)
     expected_keys = [

--- a/tests/unit/test_utilities/test_rule_processor.py
+++ b/tests/unit/test_utilities/test_rule_processor.py
@@ -360,7 +360,8 @@ def test_rule_applies_to_class(
         return_value=dataset_mock,
     ):
         assert (
-            processor.rule_applies_to_class(rule_metadata, domain, datasets) == outcome
+            processor.rule_applies_to_class(rule_metadata, domain, datasets, domain)
+            == outcome
         )
 
 


### PR DESCRIPTION
This PR adds logic in the engine for handling when an included class is not one of the GENERAL OBSERVATIONS classes. It does this by checking library data and searching for the domain in each class.

Steps to test:

1. Write a rule that operates on a Special Purpose domain
2. Ensure that rule specifies that the SPECIAL PURPOSE class and at least one other GENERAL OBSERVATIONS class is included
3. Run the rule and verify that it runs on the appropriate datasets