### PR TITLE
ISS-418: use define namespace to determine define version

### DIFF
--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -22,7 +22,6 @@ from cdisc_rules_engine.utilities.decorators import cached
 
 @dataclass
 class DefineXMLVersion:
-    version: str
     namespace: str
     model_package: str
 

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
@@ -9,7 +9,6 @@ class DefineXMLReader20(BaseDefineXMLReader):
     @staticmethod
     def class_define_xml_version() -> DefineXMLVersion:
         return DefineXMLVersion(
-            version="2.0.0",
             namespace="http://www.cdisc.org/ns/def/v2.0",
             model_package="define_2_0",
         )

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
@@ -9,7 +9,6 @@ class DefineXMLReader21(BaseDefineXMLReader):
     @staticmethod
     def class_define_xml_version() -> DefineXMLVersion:
         return DefineXMLVersion(
-            version="2.1.0",
             namespace="http://www.cdisc.org/ns/def/v2.1",
             model_package="define_2_1",
         )

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_factory.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_factory.py
@@ -80,10 +80,8 @@ class DefineXMLReaderFactory:
         pattern = compile(r"(\{(.*)\})?DefineVersion")
         define_version = next(
             iter(
-                cls._from_namespace_version(match.group(2), value)
-                for match, value in [
-                    (pattern.fullmatch(name), value) for name, value in elt.items()
-                ]
+                cls._from_namespace(match.group(2))
+                for match in [pattern.fullmatch(name) for name, _ in elt.items()]
                 if match
             ),
             None,
@@ -91,15 +89,12 @@ class DefineXMLReaderFactory:
         return define_version
 
     @classmethod
-    def _from_namespace_version(
-        cls, namespace: str, version: str
-    ) -> BaseDefineXMLReader:
+    def _from_namespace(cls, namespace: str) -> BaseDefineXMLReader:
         define_xml_reader = next(
             iter(
                 define_xml_reader
                 for define_xml_reader in cls._define_xml_readers
                 if namespace == define_xml_reader.class_define_xml_version().namespace
-                and version == define_xml_reader.class_define_xml_version().version
             ),
             None,
         )

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -15,18 +15,32 @@ from cdisc_rules_engine.services.define_xml.base_define_xml_reader import (
 from cdisc_rules_engine.services.define_xml.define_xml_reader_factory import (
     DefineXMLReaderFactory,
 )
+from cdisc_rules_engine.services.define_xml.define_xml_reader_2_1 import (
+    DefineXMLReader21,
+)
+from cdisc_rules_engine.services.define_xml.define_xml_reader_2_0 import (
+    DefineXMLReader20,
+)
 
 resources_path: Path = Path(__file__).parent.parent.joinpath("resources")
 test_define_2_0_file_path: Path = resources_path.joinpath("test_defineV20-SDTM.xml")
 test_define_file_path: Path = resources_path.joinpath("test_defineV22-SDTM.xml")
 
 
-def test_init_from_filename():
+def test_init_from_filename_v2_1():
     """
     Unit test for DefineXMLReader.from_filename constructor.
     """
     reader = DefineXMLReaderFactory.from_filename(test_define_file_path)
-    assert isinstance(reader, BaseDefineXMLReader)
+    assert isinstance(reader, DefineXMLReader21)
+
+
+def test_init_from_filename_v2_0():
+    """
+    Unit test for DefineXMLReader.from_filename constructor.
+    """
+    reader = DefineXMLReaderFactory.from_filename(test_define_2_0_file_path)
+    assert isinstance(reader, DefineXMLReader20)
 
 
 def test_init_from_file_contents():


### PR DESCRIPTION
Update define xml factory _get_define_reader to only use namespace rather than namespace and version