### PR TITLE
Iss 256 as validator i want to cross check my study data against the study definexml for null values in variables that are mandatory so that i can stay compliant with sd1229

### DIFF
--- a/cdisc_rules_engine/dataset_builders/contents_define_vlm_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/contents_define_vlm_dataset_builder.py
@@ -22,23 +22,18 @@ class ContentsDefineVLMDatasetBuilder(ValuesDatasetBuilder):
         "define_vlm_label",
         "define_vlm_data_type",
         "define_vlm_role",
+        "define_vlm_mandatory",
         ...,
         """
         # get dataset contents and convert it from wide to long
         data_contents_df: pd.DataFrame = self.data_service.get_dataset(
             dataset_name=self.dataset_path
         )
-        print(f"\n xxx (data_contents 1): {data_contents_df}")
-
         self.add_row_number(data_contents_df)
-        print(f" xxx (data_contents 2): {data_contents_df}")
-
         data_contents_long_df: pd.DataFrame = ValuesDatasetBuilder.build(self)
-        print(f" xxx (data_contents_long_df): {data_contents_long_df}")
 
         # get Define XML VLM for domain
         vlm_df: pd.DataFrame = pd.DataFrame(self.get_define_xml_value_level_metadata())
-        print(f" xxx (VLM): {vlm_df.describe()}\nColumns:{vlm_df.columns} \n{vlm_df}")
 
         # merge dataset contents with define variable metadata
         # LUT columns: row_number, define_variable_name, define_vlm_name

--- a/cdisc_rules_engine/dataset_builders/contents_define_vlm_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/contents_define_vlm_dataset_builder.py
@@ -28,10 +28,18 @@ class ContentsDefineVLMDatasetBuilder(ValuesDatasetBuilder):
         data_contents_df: pd.DataFrame = self.data_service.get_dataset(
             dataset_name=self.dataset_path
         )
+        print(f"\n xxx (data_contents 1): {data_contents_df}")
+
         self.add_row_number(data_contents_df)
+        print(f" xxx (data_contents 2): {data_contents_df}")
+
         data_contents_long_df: pd.DataFrame = ValuesDatasetBuilder.build(self)
+        print(f" xxx (data_contents_long_df): {data_contents_long_df}")
+
         # get Define XML VLM for domain
         vlm_df: pd.DataFrame = pd.DataFrame(self.get_define_xml_value_level_metadata())
+        print(f" xxx (VLM): {vlm_df.describe()}\nColumns:{vlm_df.columns} \n{vlm_df}")
+
         # merge dataset contents with define variable metadata
         # LUT columns: row_number, define_variable_name, define_vlm_name
         lookup_table: pd.DataFrame = pd.concat(

--- a/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/define_variables_dataset_builder.py
@@ -23,6 +23,7 @@ class DefineVariablesDatasetBuilder(BaseDatasetBuilder):
         "define_variable_order_number",
         "define_variable_has_codelist",
         "define_variable_codelist_coded_values",
+        "define_variable_mandatory",
         """
         # get Define XML metadata for domain and use it as a rule comparator
         variable_metadata: List[dict] = self.get_define_xml_variables_metadata()

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
@@ -12,7 +12,6 @@ class VariablesMetadataDatasetBuilder(BaseDatasetBuilder):
         variable_size
         variable_data_type
         variable_format
-        define_variable_mandatory
         """
         return self.data_service.get_variables_metadata(
             self.dataset_path, drop_duplicates=True

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
@@ -12,6 +12,7 @@ class VariablesMetadataDatasetBuilder(BaseDatasetBuilder):
         variable_size
         variable_data_type
         variable_format
+        define_variable_mandatory
         """
         return self.data_service.get_variables_metadata(
             self.dataset_path, drop_duplicates=True

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_dataset_builder.py
@@ -27,6 +27,7 @@ class VariablesMetadataWithDefineDatasetBuilder(BaseDatasetBuilder):
         define_variable_order_number,
         define_variable_has_codelist,
         define_variable_codelist_coded_values
+        define_variable_mandatory
         """
         # get Define XML metadata for domain and use it as a rule comparator
         variable_metadata: List[dict] = self.get_define_xml_variables_metadata()

--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -147,6 +147,9 @@ class BaseDefineXMLReader(ABC):
         domain_metadata = self._get_domain_metadata(metadata, domain_name)
         value_level_metadata_map = {}
         value_level_metadata = []
+
+        print(f"\n xxx: {item_def_map.get('IT.VS.VSORRES',{})}")
+
         for where_clause in metadata.WhereClauseDef:
             vlm = ValueLevelMetadata.from_where_clause_def(where_clause, item_def_map)
             value_level_metadata_map[vlm.id] = vlm

--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -239,10 +239,10 @@ class BaseDefineXMLReader(ABC):
             "define_variable_length": None,
             "define_variable_has_codelist": False,
             "define_variable_codelist_coded_values": [],
-            "define_vlm_mandatory": None,
+            "define_variable_mandatory": None,
         }
         if itemdef:
-            data["define_vlm_mandatory"] = itemref.Mandatory
+            data["define_variable_mandatory"] = itemref.Mandatory
             data["define_variable_name"] = itemdef.Name
             data["define_variable_size"] = itemdef.Length
             data["define_variable_role"] = itemref.Role

--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -148,8 +148,6 @@ class BaseDefineXMLReader(ABC):
         value_level_metadata_map = {}
         value_level_metadata = []
 
-        print(f"\n xxx: {item_def_map.get('IT.VS.VSORRES',{})}")
-
         for where_clause in metadata.WhereClauseDef:
             vlm = ValueLevelMetadata.from_where_clause_def(where_clause, item_def_map)
             value_level_metadata_map[vlm.id] = vlm
@@ -161,6 +159,7 @@ class BaseDefineXMLReader(ABC):
             for item in domain_variables
             if item.ValueListRef
         ]
+
         value_lists = {
             value_list_def.OID: value_list_def
             for value_list_def in metadata.ValueListDef
@@ -240,8 +239,10 @@ class BaseDefineXMLReader(ABC):
             "define_variable_length": None,
             "define_variable_has_codelist": False,
             "define_variable_codelist_coded_values": [],
+            "define_vlm_mandatory": None,
         }
         if itemdef:
+            data["define_vlm_mandatory"] = itemref.Mandatory
             data["define_variable_name"] = itemdef.Name
             data["define_variable_size"] = itemdef.Length
             data["define_variable_role"] = itemref.Role

--- a/resources/schema/MetaVariables.json
+++ b/resources/schema/MetaVariables.json
@@ -138,6 +138,12 @@
     },
     {
       "const": "variable_value_length"
+    },
+    {
+      "const": "define_vlm_mandatory"
+    },
+    {
+      "const": "define_variable_mandatory"
     }
   ]
 }

--- a/resources/schema/MetaVariables.json
+++ b/resources/schema/MetaVariables.json
@@ -60,6 +60,9 @@
       "const": "define_variable_length"
     },
     {
+      "const": "define_variable_mandatory"
+    },
+    {
       "const": "define_variable_name"
     },
     {
@@ -105,6 +108,9 @@
       "const": "define_vlm_length"
     },
     {
+      "const": "define_vlm_mandatory"
+    },
+    {
       "const": "define_vlm_name"
     },
     {
@@ -138,12 +144,6 @@
     },
     {
       "const": "variable_value_length"
-    },
-    {
-      "const": "define_vlm_mandatory"
-    },
-    {
-      "const": "define_variable_mandatory"
     }
   ]
 }

--- a/resources/schema/MetaVariables.md
+++ b/resources/schema/MetaVariables.md
@@ -84,7 +84,7 @@ ItemGroupDef.ItemDef.Length
 
 ## define_variable_mandatory
 
-ItemGroupDef.ItemRef.Mandatory
+[ItemGroupDef/ValueListDef].ItemRef.Mandatory
 
 ## define_variable_name
 

--- a/resources/schema/MetaVariables.md
+++ b/resources/schema/MetaVariables.md
@@ -84,7 +84,7 @@ ItemGroupDef.ItemDef.Length
 
 ## define_variable_mandatory
 
-[ItemGroupDef/ValueListDef].ItemRef.Mandatory
+ItemGroupDef.ItemRef.Mandatory
 
 ## define_variable_name
 

--- a/resources/schema/MetaVariables.md
+++ b/resources/schema/MetaVariables.md
@@ -82,6 +82,10 @@ ItemGroupDef.ItemDef.Description.TranslatedText
 
 ItemGroupDef.ItemDef.Length
 
+## define_variable_mandatory
+
+ItemGroupDef.ItemRef.Mandatory
+
 ## define_variable_name
 
 ItemGroupDef.ItemDef.Name
@@ -141,6 +145,10 @@ ValueListDef.ItemDef.Description.TranslatedText
 ## define_vlm_length
 
 ValueListDef.ItemDef.Length
+
+## define_vlm_mandatory
+
+ValueListDef.ItemRef.Mandatory
 
 ## define_vlm_name
 

--- a/resources/schema/Rule_Type.md
+++ b/resources/schema/Rule_Type.md
@@ -152,11 +152,26 @@ all:
 - `row_number`
 - `variable_name`
 - `variable_value`
-- `define_variable_name`
 - `define_vlm_name`
 - `define_vlm_label`
 - `define_vlm_data_type`
-- `define_vlm_`...
+- `define_vlm_is_collected`
+- `define_vlm_role`
+- `define_vlm_size`
+- `define_vlm_ccode`
+- `define_vlm_format`
+- `define_vlm_allowed_terms`
+- `define_vlm_origin_type`
+- `define_vlm_has_no_data`
+- `define_vlm_order_number`
+- `define_vlm_length`
+- `define_vlm_has_codelist`
+- `define_vlm_codelist_coded_values`
+- `define_vlm_mandatory`
+- `define_variable_name`
+- `type_check`
+- `length_check`
+- `variable_value_length`
 
 #### Example
 
@@ -172,6 +187,15 @@ all:
   - name: variable_value
     operator: is_not_contained_by
     value: define_vlm_codelist_coded_values
+```
+
+```yaml
+all:
+  - name: variable_value
+    operator: empty
+  - name: define_vlm_mandatory
+    operator: equal_to
+    value: Yes
 ```
 
 ## Value Level Metadata Check against Define XML

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -23,6 +23,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                     lambda row: row["VAR2"] == "2B",
                     lambda row: row["VAR2"] == "2C",
                 ],
+                "define_vlm_mandatory": "Yes",
             },
             {
                 "row_number": [2],
@@ -45,6 +46,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                     "VAR1B ROLE",
                 ],
                 "define_vlm_length": [1],
+                "define_vlm_mandatory": "Yes",
             },
         ),
     ],

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -82,4 +82,5 @@ def test_contents_define_vlm_dataset_builder(
     expected_df = pd.DataFrame.from_dict(expected)
     expected_df.sort_index(axis=1, inplace=True)
     result.sort_index(axis=1, inplace=True)
+    assert "define_vlm_mandatory" in result
     assert result.equals(expected_df)

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -23,7 +23,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                     lambda row: row["VAR2"] == "2B",
                     lambda row: row["VAR2"] == "2C",
                 ],
-                "define_vlm_mandatory": "Yes",
+                "define_vlm_mandatory": ["Yes", "No"],
             },
             {
                 "row_number": [2],
@@ -46,7 +46,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                     "VAR1B ROLE",
                 ],
                 "define_vlm_length": [1],
-                "define_vlm_mandatory": "Yes",
+                "define_vlm_mandatory": ["Yes"],
             },
         ),
     ],
@@ -82,6 +82,4 @@ def test_contents_define_vlm_dataset_builder(
     expected_df = pd.DataFrame.from_dict(expected)
     expected_df.sort_index(axis=1, inplace=True)
     result.sort_index(axis=1, inplace=True)
-    assert "define_vlm_mandatory" in result
-    assert result.define_vlm_mandatory[0] == 'Yes'
     assert result.equals(expected_df)

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -83,4 +83,5 @@ def test_contents_define_vlm_dataset_builder(
     expected_df.sort_index(axis=1, inplace=True)
     result.sort_index(axis=1, inplace=True)
     assert "define_vlm_mandatory" in result
+    assert result.define_vlm_mandatory[0]=='Yes'
     assert result.equals(expected_df)

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -83,5 +83,5 @@ def test_contents_define_vlm_dataset_builder(
     expected_df.sort_index(axis=1, inplace=True)
     result.sort_index(axis=1, inplace=True)
     assert "define_vlm_mandatory" in result
-    assert result.define_vlm_mandatory[0]=='Yes'
+    assert result.define_vlm_mandatory[0] == 'Yes'
     assert result.equals(expected_df)


### PR DESCRIPTION
1. Download the following test files:
[define.xml.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/12044703/define.xml.txt)
[dataset-large.json.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/12044709/dataset-large.json.txt)
[dataset-neg.json.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/12044712/dataset-neg.json.txt)
[rule-sd1229.json.txt](https://github.com/cdisc-org/cdisc-rules-engine/files/12044714/rule-sd1229.json.txt)

2. Put the files in your local computer such as ./dist/issue256

3. Remove the file extension .txt from file names

4. Run the test case and check the report: 
```
python core.py test -s sdtmig -v 3-4 -dp ./dist/issue256/dataset-neg.json -r ./dist/issue256/rule-sd1229.json -dv 2.1 
```
You should get two findings in the report.
 
5. Run the test case and check the report:
```
python core.py test -s sdtmig -v 3-4 -dp ./dist/issue256/dataset-large.json -r ./dist/issue256/rule-sd1229.json -dv 2.1 
```
You should not see any issues
