### PR TITLE
Fixed schema branch merge

### DIFF
--- a/resources/schema/CORE-base.json
+++ b/resources/schema/CORE-base.json
@@ -371,76 +371,7 @@
     },
     "Operations": {
       "items": {
-        "additionalProperties": false,
-        "properties": {
-          "attribute_name": {
-            "$ref": "#/$defs/MetaVariables"
-          },
-          "domain": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Dataset"
-              },
-              {
-                "$ref": "#/$defs/DataStructure"
-              }
-            ]
-          },
-          "group": {
-            "items": {
-              "$ref": "#/$defs/VariableName"
-            },
-            "type": "array"
-          },
-          "id": {
-            "$ref": "#/$defs/OperationId"
-          },
-          "name": {
-            "type": "string"
-          },
-          "operator": {
-            "enum": [
-              "define_variable_metadata",
-              "distinct",
-              "domain_is_custom",
-              "domain_label",
-              "dy",
-              "extract_metadata",
-              "expected_variables",
-              "get_column_order_from_dataset",
-              "get_column_order_from_library",
-              "get_model_column_order",
-              "get_model_filtered_variables",
-              "get_parent_model_column_order",
-              "label_referenced_variable_metadata",
-              "max",
-              "max_date",
-              "mean",
-              "min",
-              "min_date",
-              "name_referenced_variable_metadata",
-              "permissible_variables",
-              "record_count",
-              "required_variables",
-              "study_domains",
-              "valid_codelist_dates",
-              "valid_meddra_code_references",
-              "valid_meddra_code_term_pairs",
-              "valid_meddra_term_references",
-              "valid_whodrug_references",
-              "variable_count",
-              "variable_exists",
-              "variable_is_null",
-              "variable_names",
-              "variable_permissibilities",
-              "variable_value_count",
-              "whodrug_code_hierarchy"
-            ],
-            "type": "string"
-          }
-        },
-        "required": ["id", "operator"],
-        "type": "object"
+        "$ref": "Operations.json"
       },
       "minItems": 1,
       "type": "array"

--- a/resources/schema/Operations.json
+++ b/resources/schema/Operations.json
@@ -58,6 +58,20 @@
     },
     {
       "properties": {
+        "operator": { "const": "get_codelist_attributes" }
+      },
+      "required": [
+        "id",
+        "operator",
+        "name",
+        "ct_attribute",
+        "ct_packages",
+        "ct_version"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
         "operator": {
           "const": "get_column_order_from_dataset"
         }
@@ -288,6 +302,18 @@
   "properties": {
     "attribute_name": {
       "$ref": "MetaVariables.json"
+    },
+    "ct_attribute": {
+      "type": "string"
+    },
+    "ct_packages": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "ct_version": {
+      "type": "string"
     },
     "domain": {
       "anyOf": [

--- a/resources/schema/Operations.md
+++ b/resources/schema/Operations.md
@@ -183,6 +183,20 @@ Example
 
   `Laboratory Test Results`
 
+## get_codelist_attributes
+
+Fetches attribute values for a codelist specified in a dataset (like TS)
+
+```yaml
+- id: $TERM_CCODES
+  name: TSVCDREF
+  operation: get_codelist_attributes
+  ct_attribute: Term CCODE
+  ct_version: TSVCDVER
+  ct_packages:
+    - sdtmct-2020-03-27
+```
+
 ## get_column_order_from_dataset
 
 Returns list of dataset columns in order

--- a/resources/schema/Operator.md
+++ b/resources/schema/Operator.md
@@ -574,7 +574,7 @@ This operator is technically compatible with COVALn. There is no similar rule fo
 
 ## variable_metadata_equal_to
 
-Could be useful, for example, in checking variable permissibility in conjunction with the variable_permissibilities operator:
+Could be useful, for example, in checking variable permissibility in conjunction with the `variable_library_metadata` operation:
 
 ```yaml
 Check:
@@ -585,7 +585,8 @@ Check:
     - operator: not_exists
 Operations:
   - id: $permissibility
-    operator: variable_permissibilities
+    operator: variable_library_metadata
+    name: core
 ```
 
 ## variable_metadata_not_equal_to


### PR DESCRIPTION
There is an issue with the authoring schema caused by the last branch merge into main.  When you open the rule editor, you see a tooltip error in the editor pane:
$ref '/$defs/OperationId' in 'https://rule-editor.cdisc.org/api/schema' can not be resolved.

This update reverts the change to CORE-base schema and adds the new Operation to Operations.json and Operations.md instead. Also, a minor wording update in Operator.md