### PR TITLE
Add extra check for all keyword when determining rule applies to class

### DIFF
--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -171,14 +171,15 @@ class RuleProcessor:
         is_included = True
         is_excluded = False
         if included_classes:
+            if ALL_KEYWORD in included_classes:
+                return True
             dataset = self.data_service.get_dataset(dataset_name=file_path)
             class_name = self.data_service.get_dataset_class(
                 dataset, file_path, datasets, domain
             )
-            if (
-                (class_name not in included_classes)
-                and not (class_name == FINDINGS_ABOUT and FINDINGS in included_classes)
-            ) and ALL_KEYWORD not in included_classes:
+            if (class_name not in included_classes) and not (
+                class_name == FINDINGS_ABOUT and FINDINGS in included_classes
+            ):
                 is_included = False
 
         if excluded_classes:


### PR DESCRIPTION
Steps to test:

1. Make sure that the CDISC_LIBRARY_API_KEY environment variable is unset 
2. Run a rule using the test functionality that specifies the all keyword in the included class scope.
3. Ensure that the rule is run successfully for all expected domains