### PR TITLE
ISS-261: Add valid_external_dictionary_value operation

### DIFF
--- a/cdisc_rules_engine/exceptions/custom_exceptions.py
+++ b/cdisc_rules_engine/exceptions/custom_exceptions.py
@@ -57,3 +57,13 @@ class InvalidDatasetFormat(Exception):
 
 class NumberOfAttemptsExceeded(Exception):
     pass
+
+
+class InvalidDictionaryVariable(Exception):
+    description = (
+        "Provided dictionary variable does not correspond to a dictionary term type"
+    )
+
+
+class UnsupportedDictionaryType(Exception):
+    description = "Specified dictionary type is not supported by the rules engine."

--- a/cdisc_rules_engine/models/dictionaries/abstract_dictionary_validator.py
+++ b/cdisc_rules_engine/models/dictionaries/abstract_dictionary_validator.py
@@ -4,7 +4,12 @@ from abc import ABC, abstractmethod
 class AbstractDictionaryValidator(ABC):
     @abstractmethod
     def is_valid_term(
-        self, term_dictionary: dict, term: str, variable: str = "", **kwargs
+        self,
+        term_dictionary: dict,
+        term: str,
+        term_type: str = "",
+        variable: str = "",
+        **kwargs
     ) -> bool:
         """
         Method to identify whether a term is valid based on its term type.
@@ -12,9 +17,8 @@ class AbstractDictionaryValidator(ABC):
         Args:
             term_dictionary: The dictionary of available terms.
             term: The dictionary term used
-            variable: The variable corresponding with the component of the
-            dictionary to validate against.
-              - only necessary for hierarchical dictionaries i.e meddra)
+            term_type: The component of the dictionary to validate against.
+            variable: The source variable of the term value.
             kwargs: Additional validator specific variables
 
         Returns:

--- a/cdisc_rules_engine/models/dictionaries/abstract_dictionary_validator.py
+++ b/cdisc_rules_engine/models/dictionaries/abstract_dictionary_validator.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractDictionaryValidator(ABC):
+    @abstractmethod
+    def is_valid_term(
+        self, term_dictionary: dict, term: str, variable: str = "", **kwargs
+    ) -> bool:
+        """
+        Method to identify whether a term is valid based on its term type.
+
+        Args:
+            term_dictionary: The dictionary of available terms.
+            term: The dictionary term used
+            variable: The variable corresponding with the component of the
+            dictionary to validate against.
+              - only necessary for hierarchical dictionaries i.e meddra)
+            kwargs: Additional validator specific variables
+
+        Returns:
+            True: The term is valid
+            False: The term is not valid
+
+            Note: The definition of "valid" may be different for each dictionary.
+
+        """
+        pass
+
+    @abstractmethod
+    def get_term_dictionary(self) -> dict:
+        """
+        Returns the term dictionary for the validator.
+        If the dictionary is not installed it will install and
+        cache the appropriate dictionary
+
+        Returns:
+            A dictionary of terms representative of the external dictionary
+        """
+        pass

--- a/cdisc_rules_engine/models/dictionaries/meddra/meddra_validator.py
+++ b/cdisc_rules_engine/models/dictionaries/meddra/meddra_validator.py
@@ -60,7 +60,7 @@ class MedDRAValidator(AbstractDictionaryValidator):
 
         return self.term_dictionary
 
-    def is_valid_term(self, term: str, variable: str, **kwargs) -> bool:
+    def is_valid_term(self, term: str, term_type: str, variable: str, **kwargs) -> bool:
         """
         Method to identify whether a term is valid based on its term type.
 
@@ -78,7 +78,8 @@ class MedDRAValidator(AbstractDictionaryValidator):
                     ...
                 }
             term: The dictionary term used
-            variable: The variable component of the dictionary to validate against
+            term_type: The term type to validate against
+            variable: The variable used to source the term data
             kwargs: Additional validator specific variables
 
         Returns:
@@ -86,27 +87,11 @@ class MedDRAValidator(AbstractDictionaryValidator):
             False: The term is not valid
         """
         term_dictionary = self.get_term_dictionary()
-        # Map variables to the appropriate term type for dictionary lookup
-        term_type_map = {
-            f"--{MedDRAVariables.DECOD.value}": TermTypes.PT.value,
-            f"--{MedDRAVariables.BODSYS.value}": TermTypes.SOC.value,
-            f"--{MedDRAVariables.PTCD.value}": TermTypes.PT.value,
-            f"--{MedDRAVariables.LLTCD.value}": TermTypes.LLT.value,
-            f"--{MedDRAVariables.LLT.value}": TermTypes.LLT.value,
-            f"--{MedDRAVariables.HLT.value}": TermTypes.HLT.value,
-            f"--{MedDRAVariables.HLTCD.value}": TermTypes.HLT.value,
-            f"--{MedDRAVariables.HLGTCD.value}": TermTypes.HLGT.value,
-            f"--{MedDRAVariables.HLGT.value}": TermTypes.HLGT.value,
-            f"--{MedDRAVariables.BDSYSCD.value}": TermTypes.SOC.value,
-            f"--{MedDRAVariables.SOC.value}": TermTypes.SOC.value,
-            f"--{MedDRAVariables.SOCCD.value}": TermTypes.SOC.value,
-        }
-
         case_sensitive_check = kwargs.get("case_sensitive")
-        term_type = term_type_map.get(variable)
-        if not term_type:
+        term_type = term_type.lower()
+        if term_type not in TermTypes.values():
             raise InvalidDictionaryVariable(
-                f"{variable} does not correspond to a MedDRA term type"
+                f"{term_type} does not correspond to a MedDRA term type"
             )
 
         if variable in self.code_variables:

--- a/cdisc_rules_engine/models/dictionaries/meddra/meddra_validator.py
+++ b/cdisc_rules_engine/models/dictionaries/meddra/meddra_validator.py
@@ -1,0 +1,127 @@
+from cdisc_rules_engine.exceptions.custom_exceptions import InvalidDictionaryVariable
+from cdisc_rules_engine.interfaces.cache_service_interface import CacheServiceInterface
+from cdisc_rules_engine.interfaces.data_service_interface import DataServiceInterface
+from cdisc_rules_engine.models.dictionaries.abstract_dictionary_validator import (
+    AbstractDictionaryValidator,
+)
+from cdisc_rules_engine.models.dictionaries.dictionary_types import DictionaryTypes
+from cdisc_rules_engine.models.dictionaries.meddra.meddra_variables import (
+    MedDRAVariables,
+)
+from cdisc_rules_engine.models.dictionaries.meddra.terms.term_types import TermTypes
+from cdisc_rules_engine.models.dictionaries.get_dictionary_terms import (
+    extract_dictionary_terms,
+)
+
+
+class MedDRAValidator(AbstractDictionaryValidator):
+    def __init__(
+        self,
+        data_service: DataServiceInterface = None,
+        cache_service: CacheServiceInterface = None,
+        **kwargs,
+    ):
+        self.code_variables = set(
+            [
+                f"--{MedDRAVariables.PTCD.value}",
+                f"--{MedDRAVariables.LLTCD.value}",
+                f"--{MedDRAVariables.HLTCD.value}",
+                f"--{MedDRAVariables.HLGTCD.value}",
+                f"--{MedDRAVariables.LLTCD.value}",
+                f"--{MedDRAVariables.SOCCD.value}",
+                f"--{MedDRAVariables.BDSYSCD.value}",
+            ]
+        )
+        self.cache_service = cache_service
+        self.data_service = data_service
+        self.path = kwargs.get("meddra_path")
+        self.term_dictionary = kwargs.get("terms")
+
+    def get_term_dictionary(self) -> dict:
+        if self.term_dictionary:
+            return self.term_dictionary
+
+        if self.cache_service is None:
+            raise Exception(
+                "External Dictionary validation requires cache access, none found"
+            )
+
+        terms_dictionary = self.cache_service.get(self.path)
+        if not terms_dictionary:
+            if self.data_service is None:
+                raise Exception(
+                    "External Dictionary validation requires data service. None found"
+                )
+            terms_dictionary = extract_dictionary_terms(
+                self.data_service, DictionaryTypes.MEDDRA, self.path
+            )
+        self.term_dictionary = terms_dictionary
+        self.cache_service.add(self.path, terms_dictionary)
+
+        return self.term_dictionary
+
+    def is_valid_term(self, term: str, variable: str, **kwargs) -> bool:
+        """
+        Method to identify whether a term is valid based on its term type.
+
+        Args:
+            term_dictionary: The dictionary of available terms. Ex:
+                {
+                    "soc": {
+                        <soc term code>: instance of MedDRATerm
+                        ...
+                    },
+                    "hlt": {
+                        <high level term code>: instance of MedDRATerm
+                        ...
+                    }
+                    ...
+                }
+            term: The dictionary term used
+            variable: The variable component of the dictionary to validate against
+            kwargs: Additional validator specific variables
+
+        Returns:
+            True: The term is valid
+            False: The term is not valid
+        """
+        term_dictionary = self.get_term_dictionary()
+        # Map variables to the appropriate term type for dictionary lookup
+        term_type_map = {
+            f"--{MedDRAVariables.DECOD.value}": TermTypes.PT.value,
+            f"--{MedDRAVariables.BODSYS.value}": TermTypes.SOC.value,
+            f"--{MedDRAVariables.PTCD.value}": TermTypes.PT.value,
+            f"--{MedDRAVariables.LLTCD.value}": TermTypes.LLT.value,
+            f"--{MedDRAVariables.LLT.value}": TermTypes.LLT.value,
+            f"--{MedDRAVariables.HLT.value}": TermTypes.HLT.value,
+            f"--{MedDRAVariables.HLTCD.value}": TermTypes.HLT.value,
+            f"--{MedDRAVariables.HLGTCD.value}": TermTypes.HLGT.value,
+            f"--{MedDRAVariables.HLGT.value}": TermTypes.HLGT.value,
+            f"--{MedDRAVariables.BDSYSCD.value}": TermTypes.SOC.value,
+            f"--{MedDRAVariables.SOC.value}": TermTypes.SOC.value,
+            f"--{MedDRAVariables.SOCCD.value}": TermTypes.SOC.value,
+        }
+
+        case_sensitive_check = kwargs.get("case_sensitive")
+        term_type = term_type_map.get(variable)
+        if not term_type:
+            raise InvalidDictionaryVariable(
+                f"{variable} does not correspond to a MedDRA term type"
+            )
+
+        if variable in self.code_variables:
+            return term in term_dictionary.get(term_type, {})
+
+        all_terms = term_dictionary.get(term_type, {}).values()
+        if case_sensitive_check:
+            valid_terms = [
+                meddra_term for meddra_term in all_terms if term == meddra_term.term
+            ]
+        else:
+            valid_terms = [
+                meddra_term
+                for meddra_term in all_terms
+                if term.lower() == meddra_term.term.lower()
+            ]
+
+        return len(valid_terms) > 0

--- a/cdisc_rules_engine/models/dictionaries/meddra/meddra_variables.py
+++ b/cdisc_rules_engine/models/dictionaries/meddra/meddra_variables.py
@@ -12,3 +12,5 @@ class MedDRAVariables(BaseEnum):
     HLGT = "HLGT"
     HLT = "HLT"
     LLT = "LLT"
+    BODSYS = "BODSYS"
+    BDSYSCD = "BDSYSCD"

--- a/cdisc_rules_engine/models/operation_params.py
+++ b/cdisc_rules_engine/models/operation_params.py
@@ -33,4 +33,5 @@ class OperationParams:
     key_value: str = None
     attribute_name: str = None
     external_dictionary_type: str = None
+    dictionary_term_type: str = None
     case_sensitive: bool = True

--- a/cdisc_rules_engine/models/operation_params.py
+++ b/cdisc_rules_engine/models/operation_params.py
@@ -32,3 +32,5 @@ class OperationParams:
     key_name: str = None
     key_value: str = None
     attribute_name: str = None
+    external_dictionary_type: str = None
+    case_sensitive: bool = True

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -64,6 +64,9 @@ from cdisc_rules_engine.operations.name_referenced_variable_metadata import (
 from cdisc_rules_engine.operations.define_variable_metadata import (
     DefineVariableMetadata,
 )
+from cdisc_rules_engine.operations.valid_external_dictionary_value import (
+    ValidExternalDictionaryValue,
+)
 
 
 class OperationsFactory(FactoryInterface):
@@ -104,6 +107,7 @@ class OperationsFactory(FactoryInterface):
         "label_referenced_variable_metadata": LabelReferencedVariableMetadata,
         "name_referenced_variable_metadata": NameReferencedVariableMetadata,
         "define_variable_metadata": DefineVariableMetadata,
+        "valid_external_dictionary_value": ValidExternalDictionaryValue,
     }
 
     @classmethod

--- a/cdisc_rules_engine/operations/valid_external_dictionary_value.py
+++ b/cdisc_rules_engine/operations/valid_external_dictionary_value.py
@@ -30,7 +30,9 @@ class ValidExternalDictionaryValue(BaseOperation):
 
         return self.params.dataframe.apply(
             lambda row: validator.is_valid_term(
-                term=row[self.params.target], variable=self.params.original_target
+                term=row[self.params.target],
+                term_type=self.params.dictionary_term_type,
+                variable=self.params.original_target,
             ),
             axis=1,
         )

--- a/cdisc_rules_engine/operations/valid_external_dictionary_value.py
+++ b/cdisc_rules_engine/operations/valid_external_dictionary_value.py
@@ -1,0 +1,36 @@
+from cdisc_rules_engine.exceptions.custom_exceptions import UnsupportedDictionaryType
+from cdisc_rules_engine.models.dictionaries.meddra.meddra_validator import (
+    MedDRAValidator,
+)
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+from cdisc_rules_engine.models.dictionaries.dictionary_types import DictionaryTypes
+
+
+class ValidExternalDictionaryValue(BaseOperation):
+    def _execute_operation(self):
+        if self.params.external_dictionary_type not in DictionaryTypes.values():
+            raise UnsupportedDictionaryType(
+                f"{self.params.external_dictionary_type} is not supported by the engine"
+            )
+
+        validator_map = {DictionaryTypes.MEDDRA.value: MedDRAValidator}
+
+        validator_type = validator_map.get(self.params.external_dictionary_type)
+        if not validator_type:
+            raise UnsupportedDictionaryType(
+                f"{self.params.external_dictionary_type} is not supported by the "
+                + "valid_external_dictionary_value operation"
+            )
+
+        validator = validator_type(
+            cache_service=self.cache,
+            meddra_path=self.params.meddra_path,
+            whodrug_path=self.params.whodrug_path,
+        )
+
+        return self.params.dataframe.apply(
+            lambda row: validator.is_valid_term(
+                term=row[self.params.target], variable=self.params.original_target
+            ),
+            axis=1,
+        )

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -255,6 +255,8 @@ class RuleProcessor:
                 attribute_name=operation.get("attribute_name", ""),
                 key_name=operation.get("key_name", ""),
                 key_value=operation.get("key_value", ""),
+                case_sensitive=operation.get("case_sensitive", True),
+                external_dictionary_type=operation.get("external_dictionary_type"),
             )
 
             # execute operation

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -257,6 +257,7 @@ class RuleProcessor:
                 key_value=operation.get("key_value", ""),
                 case_sensitive=operation.get("case_sensitive", True),
                 external_dictionary_type=operation.get("external_dictionary_type"),
+                dictionary_term_type=operation.get("dictionary_term_type"),
             )
 
             # execute operation

--- a/resources/schema/Operations.json
+++ b/resources/schema/Operations.json
@@ -213,7 +213,13 @@
           "const": "valid_external_dictionary_value"
         }
       },
-      "required": ["id", "operator", "name", "external_dictionary_type"],
+      "required": [
+        "id",
+        "operator",
+        "name",
+        "external_dictionary_type",
+        "dictionary_term_type"
+      ],
       "type": "object"
     },
     {
@@ -326,6 +332,9 @@
     },
     "ct_version": {
       "type": "string"
+    },
+    "dictionary_term_type": {
+      "enum": ["LLT", "PT", "HLT", "HLGT", "SOC"]
     },
     "domain": {
       "anyOf": [

--- a/resources/schema/Operations.json
+++ b/resources/schema/Operations.json
@@ -210,6 +210,15 @@
     {
       "properties": {
         "operator": {
+          "const": "valid_external_dictionary_value"
+        }
+      },
+      "required": ["id", "operator", "name", "external_dictionary_type"],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "operator": {
           "const": "valid_meddra_code_references"
         }
       },
@@ -303,6 +312,9 @@
     "attribute_name": {
       "$ref": "MetaVariables.json"
     },
+    "case_sensitive": {
+      "type": "boolean"
+    },
     "ct_attribute": {
       "type": "string"
     },
@@ -324,6 +336,9 @@
           "$ref": "CORE-base.json#/$defs/DataStructure"
         }
       ]
+    },
+    "external_dictionary_type": {
+      "enum": ["meddra"]
     },
     "group": {
       "items": {

--- a/resources/schema/Operations.md
+++ b/resources/schema/Operations.md
@@ -580,6 +580,7 @@ Input:
   name: --DECOD
   id: $is_valid_decod_value
   external_dictionary_type: meddra
+  dictionary_term_type: PT
   case_sensitive: false
 ```
 

--- a/resources/schema/Operations.md
+++ b/resources/schema/Operations.md
@@ -567,6 +567,28 @@ the operation will return
 ["2023-10-26", "2023-12-13"]
 ```
 
+## valid_external_dictionary_value
+
+Returns true if the target variable contains a valid external dictionary value, otherwise false
+
+Can be case insensitive by setting `case_sensitive` attribute to false. It is true by default.
+
+Input:
+
+```yaml
+- operation: valid_external_dictionary_values
+  name: --DECOD
+  id: $is_valid_decod_value
+  external_dictionary_type: meddra
+  case_sensitive: false
+```
+
+Output:
+
+```json
+[true, false, false, true]
+```
+
 ## valid_meddra_code_references
 
 Determines whether the values are valid in the following variables:

--- a/resources/schema/Operations.md
+++ b/resources/schema/Operations.md
@@ -576,7 +576,7 @@ Can be case insensitive by setting `case_sensitive` attribute to false. It is tr
 Input:
 
 ```yaml
-- operation: valid_external_dictionary_values
+- operation: valid_external_dictionary_value
   name: --DECOD
   id: $is_valid_decod_value
   external_dictionary_type: meddra

--- a/tests/unit/test_dictionaries/test_meddra/test_meddra_validator.py
+++ b/tests/unit/test_dictionaries/test_meddra/test_meddra_validator.py
@@ -11,27 +11,30 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "term, variable, expected_outcome",
+    "term, term_type, variable, expected_outcome",
     [
-        ("ABCD", f"--{MedDRAVariables.DECOD.value}", True),
-        ("abcd", f"--{MedDRAVariables.DECOD.value}", False),
-        ("1234", f"--{MedDRAVariables.PTCD.value}", True),
-        ("A32", f"--{MedDRAVariables.PTCD.value}", False),
-        ("A32", f"--{MedDRAVariables.SOCCD.value}", True),
-        ("A32", f"--{MedDRAVariables.BDSYSCD.value}", True),
-        ("SOC_TERM", f"--{MedDRAVariables.BODSYS.value}", False),
-        ("SOC_TERM", f"--{MedDRAVariables.SOC.value}", False),
-        ("soc_term", f"--{MedDRAVariables.BODSYS.value}", True),
-        ("soc_term", f"--{MedDRAVariables.SOC.value}", True),
-        ("HLT1", f"--{MedDRAVariables.HLTCD.value}", True),
-        ("HLGT1", f"--{MedDRAVariables.HLTCD.value}", False),
-        ("abcd", f"--{MedDRAVariables.HLT.value}", False),
-        ("abcd", f"--{MedDRAVariables.LLT.value}", False),
-        ("HLT_TERM", f"--{MedDRAVariables.HLT.value}", True),
-        ("llT_TERM", f"--{MedDRAVariables.LLT.value}", False),
+        ("ABCD", "PT", f"--{MedDRAVariables.DECOD.value}", True),
+        ("abcd", "PT", f"--{MedDRAVariables.DECOD.value}", False),
+        ("1234", "PT", f"--{MedDRAVariables.PTCD.value}", True),
+        ("A32", "PT", f"--{MedDRAVariables.PTCD.value}", False),
+        ("A32", "SOC", f"--{MedDRAVariables.SOCCD.value}", True),
+        ("A32", "SOC", f"--{MedDRAVariables.BDSYSCD.value}", True),
+        ("SOC_TERM", "SOC", f"--{MedDRAVariables.BODSYS.value}", False),
+        ("SOC_TERM", "SOC", f"--{MedDRAVariables.SOC.value}", False),
+        ("soc_term", "SOC", f"--{MedDRAVariables.BODSYS.value}", True),
+        ("soc_term", "SOC", f"--{MedDRAVariables.SOC.value}", True),
+        ("HLT1", "HLT", f"--{MedDRAVariables.HLTCD.value}", True),
+        ("HLGT1", "HLT", f"--{MedDRAVariables.HLTCD.value}", False),
+        ("abcd", "HLT", f"--{MedDRAVariables.HLT.value}", False),
+        ("abcd", "LLT", f"--{MedDRAVariables.LLT.value}", False),
+        ("HLT_TERM", "HLT", f"--{MedDRAVariables.HLT.value}", True),
+        ("llT_TERM", "LLT", f"--{MedDRAVariables.LLT.value}", False),
+        ("LLT_TERM", "SOC", f"--{MedDRAVariables.LLT.value}", False),
     ],
 )
-def test_is_valid_term_case_sensitive(term: str, variable: str, expected_outcome):
+def test_is_valid_term_case_sensitive(
+    term: str, term_type: str, variable: str, expected_outcome
+):
     terms_dictionary = {
         TermTypes.SOC.value: {"A32": MedDRATerm({"term": "soc_term"})},
         TermTypes.PT.value: {"1234": MedDRATerm({"term": "ABCD"})},
@@ -42,34 +45,37 @@ def test_is_valid_term_case_sensitive(term: str, variable: str, expected_outcome
 
     assert (
         MedDRAValidator(terms=terms_dictionary).is_valid_term(
-            term, variable, case_sensitive=True
+            term, term_type, variable, case_sensitive=True
         )
         == expected_outcome
     )
 
 
 @pytest.mark.parametrize(
-    "term, variable, expected_outcome",
+    "term, term_type, variable, expected_outcome",
     [
-        ("ABCD", f"--{MedDRAVariables.DECOD.value}", True),
-        ("abcd", f"--{MedDRAVariables.DECOD.value}", True),
-        ("1234", f"--{MedDRAVariables.PTCD.value}", True),
-        ("A32", f"--{MedDRAVariables.PTCD.value}", False),
-        ("A32", f"--{MedDRAVariables.SOCCD.value}", True),
-        ("A32", f"--{MedDRAVariables.BDSYSCD.value}", True),
-        ("SOC_TERM", f"--{MedDRAVariables.BODSYS.value}", True),
-        ("SOC_TERM", f"--{MedDRAVariables.SOC.value}", True),
-        ("soc_term", f"--{MedDRAVariables.BODSYS.value}", True),
-        ("soc_term", f"--{MedDRAVariables.SOC.value}", True),
-        ("HLT1", f"--{MedDRAVariables.HLTCD.value}", True),
-        ("HLGT1", f"--{MedDRAVariables.HLTCD.value}", False),
-        ("abcd", f"--{MedDRAVariables.HLT.value}", False),
-        ("abcd", f"--{MedDRAVariables.LLT.value}", False),
-        ("HLT_TERM", f"--{MedDRAVariables.HLT.value}", True),
-        ("llT_TERM", f"--{MedDRAVariables.LLT.value}", True),
+        ("ABCD", "PT", f"--{MedDRAVariables.DECOD.value}", True),
+        ("abcd", "PT", f"--{MedDRAVariables.DECOD.value}", True),
+        ("1234", "PT", f"--{MedDRAVariables.PTCD.value}", True),
+        ("A32", "PT", f"--{MedDRAVariables.PTCD.value}", False),
+        ("A32", "SOC", f"--{MedDRAVariables.SOCCD.value}", True),
+        ("A32", "SOC", f"--{MedDRAVariables.BDSYSCD.value}", True),
+        ("SOC_TERM", "SOC", f"--{MedDRAVariables.BODSYS.value}", True),
+        ("SOC_TERM", "SOC", f"--{MedDRAVariables.SOC.value}", True),
+        ("soc_term", "SOC", f"--{MedDRAVariables.BODSYS.value}", True),
+        ("soc_term", "SOC", f"--{MedDRAVariables.SOC.value}", True),
+        ("HLT1", "HLT", f"--{MedDRAVariables.HLTCD.value}", True),
+        ("HLGT1", "HLT", f"--{MedDRAVariables.HLTCD.value}", False),
+        ("abcd", "HLT", f"--{MedDRAVariables.HLT.value}", False),
+        ("abcd", "LLT", f"--{MedDRAVariables.LLT.value}", False),
+        ("HLT_TERM", "HLT", f"--{MedDRAVariables.HLT.value}", True),
+        ("llT_TERM", "LLT", f"--{MedDRAVariables.LLT.value}", True),
+        ("LLT_TERM", "SOC", f"--{MedDRAVariables.LLT.value}", False),
     ],
 )
-def test_is_valid_term_case_insensitive(term: str, variable: str, expected_outcome):
+def test_is_valid_term_case_insensitive(
+    term: str, term_type: str, variable: str, expected_outcome
+):
     terms_dictionary = {
         TermTypes.SOC.value: {"A32": MedDRATerm({"term": "soc_term"})},
         TermTypes.PT.value: {"1234": MedDRATerm({"term": "ABCD"})},
@@ -79,7 +85,7 @@ def test_is_valid_term_case_insensitive(term: str, variable: str, expected_outco
     }
 
     assert (
-        MedDRAValidator(terms=terms_dictionary).is_valid_term(term, variable)
+        MedDRAValidator(terms=terms_dictionary).is_valid_term(term, term_type, variable)
         == expected_outcome
     )
 
@@ -95,5 +101,5 @@ def test_is_valid_term_throws_error_on_invalid_variable():
 
     with pytest.raises(InvalidDictionaryVariable):
         MedDRAValidator(terms=terms_dictionary).is_valid_term(
-            "AAA", "--INVALID_VARIABLE"
+            "AAA", "TEST", "--INVALID_VARIABLE"
         )

--- a/tests/unit/test_dictionaries/test_meddra/test_meddra_validator.py
+++ b/tests/unit/test_dictionaries/test_meddra/test_meddra_validator.py
@@ -1,0 +1,99 @@
+from cdisc_rules_engine.exceptions.custom_exceptions import InvalidDictionaryVariable
+from cdisc_rules_engine.models.dictionaries.meddra.meddra_validator import (
+    MedDRAValidator,
+)
+from cdisc_rules_engine.models.dictionaries.meddra.terms.meddra_term import MedDRATerm
+from cdisc_rules_engine.models.dictionaries.meddra.meddra_variables import (
+    MedDRAVariables,
+)
+from cdisc_rules_engine.models.dictionaries.meddra.terms.term_types import TermTypes
+import pytest
+
+
+@pytest.mark.parametrize(
+    "term, variable, expected_outcome",
+    [
+        ("ABCD", f"--{MedDRAVariables.DECOD.value}", True),
+        ("abcd", f"--{MedDRAVariables.DECOD.value}", False),
+        ("1234", f"--{MedDRAVariables.PTCD.value}", True),
+        ("A32", f"--{MedDRAVariables.PTCD.value}", False),
+        ("A32", f"--{MedDRAVariables.SOCCD.value}", True),
+        ("A32", f"--{MedDRAVariables.BDSYSCD.value}", True),
+        ("SOC_TERM", f"--{MedDRAVariables.BODSYS.value}", False),
+        ("SOC_TERM", f"--{MedDRAVariables.SOC.value}", False),
+        ("soc_term", f"--{MedDRAVariables.BODSYS.value}", True),
+        ("soc_term", f"--{MedDRAVariables.SOC.value}", True),
+        ("HLT1", f"--{MedDRAVariables.HLTCD.value}", True),
+        ("HLGT1", f"--{MedDRAVariables.HLTCD.value}", False),
+        ("abcd", f"--{MedDRAVariables.HLT.value}", False),
+        ("abcd", f"--{MedDRAVariables.LLT.value}", False),
+        ("HLT_TERM", f"--{MedDRAVariables.HLT.value}", True),
+        ("llT_TERM", f"--{MedDRAVariables.LLT.value}", False),
+    ],
+)
+def test_is_valid_term_case_sensitive(term: str, variable: str, expected_outcome):
+    terms_dictionary = {
+        TermTypes.SOC.value: {"A32": MedDRATerm({"term": "soc_term"})},
+        TermTypes.PT.value: {"1234": MedDRATerm({"term": "ABCD"})},
+        TermTypes.HLT.value: {"HLT1": MedDRATerm({"term": "HLT_TERM"})},
+        TermTypes.HLGT.value: {"HLGT1": MedDRATerm({"term": "HLGT_TERM"})},
+        TermTypes.LLT.value: {"LLT1": MedDRATerm({"term": "LLT_TERM"})},
+    }
+
+    assert (
+        MedDRAValidator(terms=terms_dictionary).is_valid_term(
+            term, variable, case_sensitive=True
+        )
+        == expected_outcome
+    )
+
+
+@pytest.mark.parametrize(
+    "term, variable, expected_outcome",
+    [
+        ("ABCD", f"--{MedDRAVariables.DECOD.value}", True),
+        ("abcd", f"--{MedDRAVariables.DECOD.value}", True),
+        ("1234", f"--{MedDRAVariables.PTCD.value}", True),
+        ("A32", f"--{MedDRAVariables.PTCD.value}", False),
+        ("A32", f"--{MedDRAVariables.SOCCD.value}", True),
+        ("A32", f"--{MedDRAVariables.BDSYSCD.value}", True),
+        ("SOC_TERM", f"--{MedDRAVariables.BODSYS.value}", True),
+        ("SOC_TERM", f"--{MedDRAVariables.SOC.value}", True),
+        ("soc_term", f"--{MedDRAVariables.BODSYS.value}", True),
+        ("soc_term", f"--{MedDRAVariables.SOC.value}", True),
+        ("HLT1", f"--{MedDRAVariables.HLTCD.value}", True),
+        ("HLGT1", f"--{MedDRAVariables.HLTCD.value}", False),
+        ("abcd", f"--{MedDRAVariables.HLT.value}", False),
+        ("abcd", f"--{MedDRAVariables.LLT.value}", False),
+        ("HLT_TERM", f"--{MedDRAVariables.HLT.value}", True),
+        ("llT_TERM", f"--{MedDRAVariables.LLT.value}", True),
+    ],
+)
+def test_is_valid_term_case_insensitive(term: str, variable: str, expected_outcome):
+    terms_dictionary = {
+        TermTypes.SOC.value: {"A32": MedDRATerm({"term": "soc_term"})},
+        TermTypes.PT.value: {"1234": MedDRATerm({"term": "ABCD"})},
+        TermTypes.HLT.value: {"HLT1": MedDRATerm({"term": "HLT_TERM"})},
+        TermTypes.HLGT.value: {"HLGT1": MedDRATerm({"term": "HLGT_TERM"})},
+        TermTypes.LLT.value: {"LLT1": MedDRATerm({"term": "LLT_TERM"})},
+    }
+
+    assert (
+        MedDRAValidator(terms=terms_dictionary).is_valid_term(term, variable)
+        == expected_outcome
+    )
+
+
+def test_is_valid_term_throws_error_on_invalid_variable():
+    terms_dictionary = {
+        TermTypes.SOC.value: {"A32": MedDRATerm({"term": "soc_term"})},
+        TermTypes.PT.value: {"1234": MedDRATerm({"term": "ABCD"})},
+        TermTypes.HLT.value: {"HLT1": MedDRATerm({"term": "HLT_TERM"})},
+        TermTypes.HLGT.value: {"HLGT1": MedDRATerm({"term": "HLGT_TERM"})},
+        TermTypes.LLT.value: {"LLT1": MedDRATerm({"term": "LLT_TERM"})},
+    }
+
+    with pytest.raises(InvalidDictionaryVariable):
+        MedDRAValidator(terms=terms_dictionary).is_valid_term(
+            "AAA", "--INVALID_VARIABLE"
+        )

--- a/tests/unit/test_operations/test_valid_external_dictionary_value.py
+++ b/tests/unit/test_operations/test_valid_external_dictionary_value.py
@@ -1,0 +1,70 @@
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.exceptions.custom_exceptions import UnsupportedDictionaryType
+from cdisc_rules_engine.operations.valid_external_dictionary_value import (
+    ValidExternalDictionaryValue,
+)
+from cdisc_rules_engine.models.operation_params import OperationParams
+import pandas as pd
+from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+from cdisc_rules_engine.models.dictionaries.meddra.terms.term_types import TermTypes
+from cdisc_rules_engine.models.dictionaries.meddra.terms.meddra_term import MedDRATerm
+import pytest
+
+
+def test_valid_external_dictionary_value_with_meddra(
+    mock_data_service, operation_params: OperationParams
+):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    meddra_path = "meddra"
+    operation_params.external_dictionary_type = "meddra"
+    operation_params.original_target = "--DECOD"
+    operation_params.target = "AEDECOD"
+
+    data = pd.DataFrame.from_dict(
+        {
+            "AEDECOD": ["A", "B", "C"],
+        }
+    )
+
+    operation_params.dataframe = data
+    operation_params.meddra_path = meddra_path
+    terms_dictionary = {
+        TermTypes.PT.value: {
+            "1234": MedDRATerm({"term": "A"}),
+            "134": MedDRATerm({"term": "B"}),
+        },
+    }
+    cache.add(meddra_path, terms_dictionary)
+    result = ValidExternalDictionaryValue(
+        operation_params,
+        data,
+        cache,
+        mock_data_service,
+    ).execute()
+    assert result[operation_params.operation_id].tolist() == [True, True, False]
+
+
+def test_valid_external_dictionary_value_with_invalid_external_dictionary_type(
+    mock_data_service, operation_params: OperationParams
+):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    operation_params.external_dictionary_type = "invalid"
+    operation_params.original_target = "--DECOD"
+    operation_params.target = "AEDECOD"
+
+    data = pd.DataFrame.from_dict(
+        {
+            "AEDECOD": ["A", "B", "C"],
+        }
+    )
+
+    operation_params.dataframe = data
+    with pytest.raises(UnsupportedDictionaryType):
+        ValidExternalDictionaryValue(
+            operation_params,
+            data,
+            cache,
+            mock_data_service,
+        ).execute()

--- a/tests/unit/test_operations/test_valid_external_dictionary_value.py
+++ b/tests/unit/test_operations/test_valid_external_dictionary_value.py
@@ -18,6 +18,7 @@ def test_valid_external_dictionary_value_with_meddra(
     cache = CacheServiceFactory(config).get_cache_service()
     meddra_path = "meddra"
     operation_params.external_dictionary_type = "meddra"
+    operation_params.dictionary_term_type = "PT"
     operation_params.original_target = "--DECOD"
     operation_params.target = "AEDECOD"
 


### PR DESCRIPTION
This PR adds the following:

1. New AbstractDictionaryValidator class this class is meant to be implemented for each supported dictionary type to encapsulate dictionary specific validation logic
2. MedDRADictionaryValidator - Meddra implementation of the AbstractDictionaryValidator
3. Add case_sensitive and external_dictionary_type to operation params
4. Add valid_external_dictionary_value operation

Steps to test:

1. Run the attached rule and dataset using the test meddra dictionary found in `tests/resources/dictionaries/meddra`:
    ex: `python core.py test -s sdtmig -v 3-4 -r meddra_check.json -dp meddra_check_dataset.json --meddra tests/resources/dictionaries/meddra`
[meddra_check.zip](https://github.com/cdisc-org/cdisc-rules-engine/files/12295288/meddra_check.zip)
