### PR TITLE
ISS-511: Update in memory cache to use LRU cache

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -79,7 +79,9 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
             raise KeyError("'datasets' required in request")
         validate_datasets_payload(datasets)
         define_xml = json_data.get("define_xml")
-        tester = RuleTester(datasets, define_xml, cache, standard, standard_version)
+        tester = RuleTester(
+            datasets, define_xml, cache, standard, standard_version, codelists
+        )
         result = tester.validate(rule)
         result_json = json.dumps(result)
         return func.HttpResponse(result_json)

--- a/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
@@ -1,4 +1,7 @@
 from abc import abstractmethod
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 import pandas as pd
 from cdisc_rules_engine.services.define_xml.define_xml_reader_factory import (
     DefineXMLReaderFactory,
@@ -28,6 +31,7 @@ class BaseDatasetBuilder:
         define_xml_path,
         standard,
         standard_version,
+        library_metadata=LibraryMetadataContainer(),
     ):
         self.data_service = data_service
         self.cache = cache_service
@@ -40,6 +44,7 @@ class BaseDatasetBuilder:
         self.define_xml_path = define_xml_path
         self.standard = standard
         self.standard_version = standard_version
+        self.library_metadata = library_metadata
 
     @abstractmethod
     def build(self) -> pd.DataFrame:
@@ -137,8 +142,9 @@ class BaseDatasetBuilder:
             standard=self.standard,
             standard_version=self.standard_version,
             domain=self.domain,
-            cache=self.cache,
             config=config,
+            cache=self.cache,
+            library_metadata=self.library_metadata,
         )
 
         # Rename columns:

--- a/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
+++ b/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
@@ -90,5 +90,6 @@ class DatasetBuilderFactory(FactoryInterface):
             kwargs.get("define_xml_path"),
             kwargs.get("standard"),
             kwargs.get("standard_version"),
+            kwargs.get("library_metadata"),
         )
         return builder

--- a/cdisc_rules_engine/dataset_builders/define_variables_with_library_metadata.py
+++ b/cdisc_rules_engine/dataset_builders/define_variables_with_library_metadata.py
@@ -43,5 +43,4 @@ class DefineVariablesWithLibraryMetadataDatasetBuilder(BaseDatasetBuilder):
             left_on="define_variable_name",
             right_on="library_variable_name",
         ).fillna("")
-        print(data.columns)
         return data

--- a/cdisc_rules_engine/models/library_metadata_container.py
+++ b/cdisc_rules_engine/models/library_metadata_container.py
@@ -1,0 +1,61 @@
+class LibraryMetadataContainer:
+    def __init__(
+        self,
+        standard_metadata={},
+        model_metadata={},
+        ct_package_metadata={},
+        variable_codelist_map={},
+        variables_metadata={},
+        published_ct_packages=[],
+    ):
+        self._standard_metadata = standard_metadata
+        self._model_metadata = model_metadata
+        self._ct_package_metadata = ct_package_metadata
+        self._variable_codelist_map = variable_codelist_map
+        self._variables_metadata = variables_metadata
+        self._published_ct_packages = published_ct_packages
+
+    @property
+    def standard_metadata(self):
+        return self._standard_metadata
+
+    @standard_metadata.setter
+    def standard_metadata(self, value):
+        self._standard_metadata = value
+
+    @property
+    def variable_codelist_map(self):
+        return self._variable_codelist_map
+
+    @variable_codelist_map.setter
+    def variable_codelist_map(self, value):
+        self._variable_codelist_map = value
+
+    @property
+    def variables_metadata(self):
+        return self._variables_metadata
+
+    @variables_metadata.setter
+    def variables_metadata(self, value):
+        self._variables_metadata = value
+
+    @property
+    def model_metadata(self):
+        return self._model_metadata
+
+    @model_metadata.setter
+    def model_metadata(self, value):
+        self._model_metadata = value
+
+    @property
+    def published_ct_packages(self):
+        return self._published_ct_packages
+
+    def get_ct_package_metadata(self, key):
+        return self._ct_package_metadata.get(key)
+
+    def get_all_ct_package_metadata(self):
+        return list(self._ct_package_metadata.values())
+
+    def set_ct_package_metadata(self, key, value):
+        self._ct_package_metadata[key] = value

--- a/cdisc_rules_engine/operations/domain_is_custom.py
+++ b/cdisc_rules_engine/operations/domain_is_custom.py
@@ -1,7 +1,4 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-)
 from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
 from cdisc_rules_engine import config
 
@@ -13,14 +10,11 @@ class DomainIsCustom(BaseOperation):
         given domain is in standard domains.
         If no -> the domain is custom.
         """
-        cache_key = get_standard_details_cache_key(
-            self.params.standard, self.params.standard_version
-        )
-        standard_data: dict = self.cache.get(cache_key)
-        if standard_data is None:
+        standard_data: dict = self.library_metadata.standard_metadata
+        if not standard_data:
             cdisc_library_service = CDISCLibraryService(config, self.cache)
             standard_data = cdisc_library_service.get_standard_details(
                 self.params.standard.lower(), self.params.standard_version
             )
-            self.cache.add(cache_key, standard_data)
+            self.library_metadata.standard_metadata = standard_data
         return self.params.domain not in standard_data.get("domains", {})

--- a/cdisc_rules_engine/operations/get_codelist_attributes.py
+++ b/cdisc_rules_engine/operations/get_codelist_attributes.py
@@ -47,7 +47,9 @@ class CodeListAttributes(BaseOperation):
 
         # 2.0 build codelist from cache
         # -------------------------------------------------------------------
-        ct_cache = self._get_ct_from_cache(ct_key=ct_name, ct_val=ct_attribute)
+        ct_cache = self._get_ct_from_library_metadata(
+            ct_key=ct_name, ct_val=ct_attribute
+        )
 
         # 3.0 get dataset records
         # -------------------------------------------------------------------
@@ -61,7 +63,7 @@ class CodeListAttributes(BaseOperation):
         result = pd.Series([ct_list[ct_attribute].values[0] for _ in range(ds_len)])
         return result
 
-    def _get_ct_from_cache(self, ct_key: str, ct_val: str):
+    def _get_ct_from_library_metadata(self, ct_key: str, ct_val: str):
         """
         Retrieves the codelist information from the cache based on the given
         ct_key and ct_val.
@@ -78,7 +80,10 @@ class CodeListAttributes(BaseOperation):
         ct_term_maps = (
             []
             if ct_packages is None
-            else [self.cache.get(package) or {} for package in ct_packages]
+            else [
+                self.library_metadata.get_ct_package_metadata(package) or {}
+                for package in ct_packages
+            ]
         )
 
         # convert codelist to dataframe

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -132,6 +132,7 @@ class OperationsFactory(FactoryInterface):
             "original_dataset",
             "cache",
             "data_service",
+            "library_metadata",
         }
         if not required_args.issubset(kwargs.keys()):
             raise ValueError(
@@ -144,6 +145,7 @@ class OperationsFactory(FactoryInterface):
                 kwargs.get("original_dataset"),
                 kwargs.get("cache"),
                 kwargs.get("data_service"),
+                kwargs.get("library_metadata"),
             )
         raise ValueError(
             f"Operation name must be in  {list(self._operations_map.keys())}, "

--- a/cdisc_rules_engine/operations/valid_codelist_dates.py
+++ b/cdisc_rules_engine/operations/valid_codelist_dates.py
@@ -1,5 +1,4 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
-from cdisc_rules_engine.constants.cache_constants import PUBLISHED_CT_PACKAGES
 
 
 class ValidCodelistDates(BaseOperation):
@@ -15,7 +14,7 @@ class ValidCodelistDates(BaseOperation):
 
     def _execute_operation(self):
         # get metadata
-        ct_packages = self.cache.get(PUBLISHED_CT_PACKAGES)
+        ct_packages = self.library_metadata.published_ct_packages
         if not ct_packages:
             return []
         return [

--- a/cdisc_rules_engine/operations/variable_library_metadata.py
+++ b/cdisc_rules_engine/operations/variable_library_metadata.py
@@ -1,6 +1,5 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
-from cdisc_rules_engine.utilities.utils import get_library_variables_metadata_cache_key
 from cdisc_rules_engine import config
 
 
@@ -10,11 +9,8 @@ class VariableLibraryMetadata(BaseOperation):
         Get the variable permissibility values for all data in the current
         dataset.
         """
-        cache_key = get_library_variables_metadata_cache_key(
-            self.params.standard, self.params.standard_version
-        )
-        variable_details: dict = self.cache.get(cache_key)
-        if variable_details is None:
+        variable_details: dict = self.library_metadata.variables_metadata
+        if not variable_details:
             cdisc_library_service = CDISCLibraryService(config, self.cache)
             variable_details = cdisc_library_service.get_variables_details(
                 self.params.standard, self.params.standard_version

--- a/cdisc_rules_engine/operations/variable_names.py
+++ b/cdisc_rules_engine/operations/variable_names.py
@@ -1,5 +1,4 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
-from cdisc_rules_engine.utilities.utils import get_library_variables_metadata_cache_key
 from cdisc_rules_engine.services.cdisc_library_service import CDISCLibraryService
 from cdisc_rules_engine import config
 
@@ -9,11 +8,8 @@ class VariableNames(BaseOperation):
         """
         Return the set of variable names for the given standard
         """
-        cache_key = get_library_variables_metadata_cache_key(
-            self.params.standard, self.params.standard_version
-        )
-        variable_details: dict = self.cache.get(cache_key)
-        if variable_details is None:
+        variable_details = self.library_metadata.variables_metadata
+        if not variable_details:
             cdisc_library_service = CDISCLibraryService(config, self.cache)
             variable_details = cdisc_library_service.get_variables_details(
                 self.params.standard, self.params.standard_version

--- a/cdisc_rules_engine/services/cdisc_library_service.py
+++ b/cdisc_rules_engine/services/cdisc_library_service.py
@@ -8,6 +8,7 @@ from cdisc_rules_engine.models.rule import Rule
 from cdisc_rules_engine.utilities.utils import (
     get_metadata_cache_key,
     get_rules_cache_key,
+    get_variable_codelist_map_cache_key,
 )
 
 
@@ -170,7 +171,10 @@ class CDISCLibraryService:
         terms = standard_codelist_function_map.get(
             standard_type, self._get_tabulation_ig_codelists
         )(data)
-        return {"name": f"{standard_type}-{version}-codelists", **terms}
+        return {
+            "name": get_variable_codelist_map_cache_key(standard_type, version),
+            **terms,
+        }
 
     def get_variables_details(self, standard_type: str, version: str) -> dict:
         """

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -28,7 +28,6 @@ from cdisc_rules_engine.utilities.utils import (
     get_dataset_cache_key_from_path,
     get_directory_path,
     search_in_list_of_dicts,
-    get_standard_details_cache_key,
 )
 from cdisc_rules_engine.utilities.sdtm_utilities import get_class_and_domain_metadata
 
@@ -96,6 +95,7 @@ class BaseDataService(DataServiceInterface, ABC):
         )
         self.standard = kwargs.get("standard")
         self.version = (kwargs.get("standard_version") or "").replace(".", "-")
+        self.library_metadata = kwargs.get("library_metadata")
 
     def get_dataset_by_type(
         self, dataset_name: str, dataset_type: str, **params
@@ -159,8 +159,9 @@ class BaseDataService(DataServiceInterface, ABC):
         else:
             if self.standard is None or self.version is None:
                 raise Exception("Missing standard and version data")
-            cache_key = get_standard_details_cache_key(self.standard, self.version)
-            standard_data = self.cache_service.get(cache_key)
+            standard_data = None
+            if self.library_metadata:
+                standard_data = self.library_metadata.standard_metadata
             if not standard_data:
                 standard_data = self.cdisc_library_service.get_standard_details(
                     self.standard, self.version

--- a/cdisc_rules_engine/services/data_services/data_service_factory.py
+++ b/cdisc_rules_engine/services/data_services/data_service_factory.py
@@ -9,6 +9,9 @@ from cdisc_rules_engine.interfaces import (
 )
 
 from . import DummyDataService, LocalDataService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 
 class DataServiceFactory(FactoryInterface):
@@ -20,17 +23,22 @@ class DataServiceFactory(FactoryInterface):
         cache_service: CacheServiceInterface,
         standard: str = None,
         standard_version: str = None,
+        library_metadata: LibraryMetadataContainer = None,
     ):
         self.data_service_name = config.getValue("DATA_SERVICE_TYPE") or "local"
         self.config = config
         self.cache_service = cache_service
         self.standard = standard
         self.standard_version = standard_version
+        self.library_metadata = library_metadata
 
     def get_data_service(self) -> DataServiceInterface:
         """Get local data service"""
         return self.get_service(
-            "local", standard=self.standard, standard_version=self.standard_version
+            "local",
+            standard=self.standard,
+            standard_version=self.standard_version,
+            library_metadata=self.library_metadata,
         )
 
     def get_dummy_data_service(self, data: List[DummyDataset]) -> DataServiceInterface:
@@ -39,6 +47,7 @@ class DataServiceFactory(FactoryInterface):
             data=data,
             standard=self.standard,
             standard_version=self.standard_version,
+            library_metadata=self.library_metadata,
         )
 
     @classmethod

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -1,5 +1,8 @@
 import re
 from typing import List, Optional, Set, Union, Tuple
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 import pandas as pd
 
@@ -29,9 +32,12 @@ from cdisc_rules_engine.utilities.utils import (
 
 
 class RuleProcessor:
-    def __init__(self, data_service, cache):
+    def __init__(
+        self, data_service, cache, library_metadata: LibraryMetadataContainer = None
+    ):
         self.data_service = data_service
         self.cache = cache
+        self.library_metadata = library_metadata
 
     @classmethod
     def rule_applies_to_domain(
@@ -313,6 +319,7 @@ class RuleProcessor:
             original_dataset=dataset,
             cache=self.cache,
             data_service=self.data_service,
+            library_metadata=self.library_metadata,
         )
         result = operation.execute()
         if not DataProcessor.is_dummy_data(self.data_service):

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -266,6 +266,10 @@ def get_metadata_cache_key(metadata_key: str):
     return f"library/metadata{metadata_key}"
 
 
+def get_variable_codelist_map_cache_key(standard: str, version: str) -> str:
+    return f"{standard}-{version}-codelists"
+
+
 def get_meddra_code_term_pairs_cache_key(meddra_path: str) -> str:
     return f"meddra_valid_code_term_pairs_{meddra_path}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ redis==4.0.2
 requests~=2.28.1
 setuptools~=63.2.0
 xport==3.6.1
+cachetools==5.3.1
+Pympler==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ setuptools~=63.2.0
 xport==3.6.1
 cachetools==5.3.1
 Pympler==1.0.1
+psutil==5.9.5

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -1,5 +1,8 @@
 from typing import List
 from unittest.mock import Mock, patch, MagicMock
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 import pandas as pd
 import pytest
@@ -118,15 +121,18 @@ def test_get_raw_dataset_metadata(
 def test_get_dataset_class(datasets, data, expected_class, filename):
     df = pd.DataFrame.from_dict(data)
     mock_cache_service = MagicMock()
-    mock_cache_service.get.return_value = {
-        "classes": [{"name": "SPECIAL PURPOSE", "datasets": [{"name": "DM"}]}]
-    }
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata={
+            "classes": [{"name": "SPECIAL PURPOSE", "datasets": [{"name": "DM"}]}]
+        }
+    )
     data_service = LocalDataService(
         mock_cache_service,
         MagicMock(),
         MagicMock(),
         standard="sdtmig",
         standard_version="3-4",
+        library_metadata=library_metadata,
     )
     class_name = data_service.get_dataset_class(
         df, filename, datasets, datasets[0].get("domain")

--- a/tests/unit/test_dataset_builders/test_contents_define_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_dataset_builder.py
@@ -1,3 +1,6 @@
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 import pytest
 from unittest.mock import MagicMock, patch
 import pandas as pd
@@ -335,6 +338,7 @@ def test_contents_define_dataset_builder(
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        library_metadata=LibraryMetadataContainer(),
     ).build()
     col_names = ["dataset_name", "define_dataset_name"]
     assert result[col_names].equals(expected[col_names]) or (
@@ -373,6 +377,7 @@ def test_contents_define_dataset_columns(
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        library_metadata=LibraryMetadataContainer(),
     ).build()
     exp_columns = result.columns.tolist()
     req_columns = [

--- a/tests/unit/test_dataset_builders/test_contents_define_variables_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_variables_dataset_builder.py
@@ -1,3 +1,6 @@
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 import pytest
 from unittest.mock import MagicMock, patch
 import pandas as pd
@@ -101,5 +104,6 @@ def test_contents_define_variables_dataset_builder(
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        library_metadata=LibraryMetadataContainer(),
     ).build()
     assert result.equals(pd.DataFrame.from_dict(expected))

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -1,3 +1,6 @@
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 import pytest
 from unittest.mock import MagicMock, patch
 import pandas as pd
@@ -81,6 +84,7 @@ def test_contents_define_vlm_dataset_builder(
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        library_metadata=LibraryMetadataContainer(),
     ).build()
     expected_df = pd.DataFrame.from_dict(expected)
     expected_df.sort_index(axis=1, inplace=True)

--- a/tests/unit/test_dataset_builders/test_define_variables_with_library_metadata.py
+++ b/tests/unit/test_dataset_builders/test_define_variables_with_library_metadata.py
@@ -1,9 +1,9 @@
 from unittest.mock import MagicMock, patch
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 from cdisc_rules_engine.services.cache.in_memory_cache_service import (
     InMemoryCacheService,
-)
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
 )
 from pathlib import Path
 from cdisc_rules_engine.dataset_builders.define_variables_with_library_metadata import (
@@ -31,58 +31,55 @@ def test_define_variables_metadata_with_library_metadata_dataset_builder(
     cache = InMemoryCacheService()
     standard = "sdtmig"
     standard_version = "3-4"
-    cache_key = get_standard_details_cache_key(standard, standard_version)
-    cache.add(
-        cache_key,
-        {
-            "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
-            "classes": [
-                {
-                    "name": "Events",
-                    "datasets": [
-                        {
-                            "name": "AE",
-                            "label": "Adverse Events",
-                            "datasetVariables": [
-                                {
-                                    "name": "STUDYID",
-                                    "ordinal": "1",
-                                    "role": "Identifier",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "USUBJID",
-                                    "ordinal": "2",
-                                    "role": "Identifier",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "AETERM",
-                                    "ordinal": "9",
-                                    "role": "Topic",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "AESEQ",
-                                    "ordinal": "8",
-                                    "role": "Topic",
-                                    "label": "Sequence Number",
-                                    "simpleDatatype": "Num",
-                                    "core": "Req",
-                                },
-                            ],
-                        }
-                    ],
-                }
-            ],
-        },
-    )
+    standard_data = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {
+                                "name": "STUDYID",
+                                "ordinal": "1",
+                                "role": "Identifier",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "USUBJID",
+                                "ordinal": "2",
+                                "role": "Identifier",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "AETERM",
+                                "ordinal": "9",
+                                "role": "Topic",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": "8",
+                                "role": "Topic",
+                                "label": "Sequence Number",
+                                "simpleDatatype": "Num",
+                                "core": "Req",
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_data)
     result = DefineVariablesWithLibraryMetadataDatasetBuilder(
         rule=None,
         data_service=LocalDataService(MagicMock(), MagicMock(), MagicMock()),
@@ -95,6 +92,7 @@ def test_define_variables_metadata_with_library_metadata_dataset_builder(
         define_xml_path=test_define_file_path,
         standard=standard,
         standard_version=standard_version,
+        library_metadata=library_metadata,
     ).build()
 
     assert result.columns.tolist() == [

--- a/tests/unit/test_dataset_builders/test_variables_metadata_with_library_metadata_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_variables_metadata_with_library_metadata_dataset_builder.py
@@ -1,10 +1,9 @@
 from unittest.mock import MagicMock, patch
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 from cdisc_rules_engine.services.cache.in_memory_cache_service import (
     InMemoryCacheService,
-)
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
 )
 import pandas as pd
 from cdisc_rules_engine.dataset_builders.variables_metadata_with_library_metadata import (  # noqa: E501
@@ -44,58 +43,55 @@ def test_variable_metadata_with_library_metadata_dataset_builder(
     cache = InMemoryCacheService()
     standard = "sdtmig"
     standard_version = "3-4"
-    cache_key = get_standard_details_cache_key(standard, standard_version)
-    cache.add(
-        cache_key,
-        {
-            "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
-            "classes": [
-                {
-                    "name": "Events",
-                    "datasets": [
-                        {
-                            "name": "AE",
-                            "label": "Adverse Events",
-                            "datasetVariables": [
-                                {
-                                    "name": "STUDYID",
-                                    "ordinal": "1",
-                                    "role": "Identifier",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "USUBJID",
-                                    "ordinal": "2",
-                                    "role": "Identifier",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "AETERM",
-                                    "ordinal": "9",
-                                    "role": "Topic",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "AESEQ",
-                                    "ordinal": "8",
-                                    "role": "Topic",
-                                    "label": "Sequence Number",
-                                    "simpleDatatype": "Num",
-                                    "core": "Req",
-                                },
-                            ],
-                        }
-                    ],
-                }
-            ],
-        },
-    )
+    standard_data = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {
+                                "name": "STUDYID",
+                                "ordinal": "1",
+                                "role": "Identifier",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "USUBJID",
+                                "ordinal": "2",
+                                "role": "Identifier",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "AETERM",
+                                "ordinal": "9",
+                                "role": "Topic",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": "8",
+                                "role": "Topic",
+                                "label": "Sequence Number",
+                                "simpleDatatype": "Num",
+                                "core": "Req",
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_data)
     result = VariablesMetadataWithLibraryMetadataDatasetBuilder(
         rule=None,
         data_service=LocalDataService(MagicMock(), MagicMock(), MagicMock()),
@@ -108,6 +104,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder(
         define_xml_path=None,
         standard=standard,
         standard_version=standard_version,
+        library_metadata=library_metadata,
     ).build()
     assert result.columns.tolist() == [
         "variable_name",
@@ -163,120 +160,115 @@ def test_variable_metadata_with_library_metadata_dataset_builder_variable_only_i
     cache = InMemoryCacheService()
     standard = "sdtmig"
     standard_version = "3-4"
-    models_cache_key = get_model_details_cache_key("sdtm", "2-0")
-    cache_key = get_standard_details_cache_key(standard, standard_version)
-    cache.add(
-        cache_key,
-        {
-            "_links": {"model": {"href": "/mdr/sdtm/2-0"}},
-            "classes": [
-                {
-                    "name": "Events",
-                    "datasets": [
-                        {
-                            "name": "AE",
-                            "label": "Adverse Events",
-                            "datasetVariables": [
-                                {
-                                    "name": "STUDYID",
-                                    "ordinal": "1",
-                                    "role": "Identifier",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "USUBJID",
-                                    "ordinal": "2",
-                                    "role": "Identifier",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "AETERM",
-                                    "ordinal": "9",
-                                    "role": "Topic",
-                                    "label": "Reported Term for the adverse event",
-                                    "simpleDatatype": "Char",
-                                    "core": "Req",
-                                },
-                                {
-                                    "name": "AESEQ",
-                                    "ordinal": "8",
-                                    "role": "Topic",
-                                    "label": "Sequence Number",
-                                    "simpleDatatype": "Num",
-                                    "core": "Req",
-                                },
-                            ],
-                        }
-                    ],
-                }
-            ],
-        },
-    )
+    standard_data = {
+        "_links": {"model": {"href": "/mdr/sdtm/2-0"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {
+                                "name": "STUDYID",
+                                "ordinal": "1",
+                                "role": "Identifier",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "USUBJID",
+                                "ordinal": "2",
+                                "role": "Identifier",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "AETERM",
+                                "ordinal": "9",
+                                "role": "Topic",
+                                "label": "Reported Term for the adverse event",
+                                "simpleDatatype": "Char",
+                                "core": "Req",
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": "8",
+                                "role": "Topic",
+                                "label": "Sequence Number",
+                                "simpleDatatype": "Num",
+                                "core": "Req",
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
 
-    cache.add(
-        models_cache_key,
-        {
-            "datasets": [
-                {
-                    "_links": {"parentClass": {"title": "Events"}},
-                    "name": "AE",
-                    "datasetVariables": [
-                        {
-                            "name": "AETERM",
-                            "ordinal": 4,
-                        },
-                        {
-                            "name": "AESEQ",
-                            "ordinal": 3,
-                        },
-                    ],
-                }
-            ],
-            "classes": [
-                {
-                    "name": "Events",
-                    "label": "Events",
-                    "classVariables": [
-                        {"name": "--TERM", "ordinal": 1},
-                        {"name": "--SEQ", "ordinal": 2},
-                    ],
-                },
-                {
-                    "name": GENERAL_OBSERVATIONS_CLASS,
-                    "label": GENERAL_OBSERVATIONS_CLASS,
-                    "classVariables": [
-                        {
-                            "name": "DOMAIN",
-                            "role": VariableRoles.IDENTIFIER.value,
-                            "ordinal": 2,
-                            "simpleDatatype": "Char",
-                        },
-                        {
-                            "name": "STUDYID",
-                            "role": VariableRoles.IDENTIFIER.value,
-                            "ordinal": 1,
-                            "simpleDatatype": "Char",
-                        },
-                        {
-                            "name": "TIMING_VAR",
-                            "role": VariableRoles.TIMING.value,
-                            "ordinal": 33,
-                            "simpleDatatype": "Char",
-                        },
-                        {
-                            "name": "--MODELVAR",
-                            "simpleDatatype": "Num",
-                            "role": VariableRoles.TIMING.value,
-                            "ordinal": 2000,
-                        },
-                    ],
-                },
-            ],
-        },
+    model_metadata = {
+        "datasets": [
+            {
+                "_links": {"parentClass": {"title": "Events"}},
+                "name": "AE",
+                "datasetVariables": [
+                    {
+                        "name": "AETERM",
+                        "ordinal": 4,
+                    },
+                    {
+                        "name": "AESEQ",
+                        "ordinal": 3,
+                    },
+                ],
+            }
+        ],
+        "classes": [
+            {
+                "name": "Events",
+                "label": "Events",
+                "classVariables": [
+                    {"name": "--TERM", "ordinal": 1},
+                    {"name": "--SEQ", "ordinal": 2},
+                ],
+            },
+            {
+                "name": GENERAL_OBSERVATIONS_CLASS,
+                "label": GENERAL_OBSERVATIONS_CLASS,
+                "classVariables": [
+                    {
+                        "name": "DOMAIN",
+                        "role": VariableRoles.IDENTIFIER.value,
+                        "ordinal": 2,
+                        "simpleDatatype": "Char",
+                    },
+                    {
+                        "name": "STUDYID",
+                        "role": VariableRoles.IDENTIFIER.value,
+                        "ordinal": 1,
+                        "simpleDatatype": "Char",
+                    },
+                    {
+                        "name": "TIMING_VAR",
+                        "role": VariableRoles.TIMING.value,
+                        "ordinal": 33,
+                        "simpleDatatype": "Char",
+                    },
+                    {
+                        "name": "--MODELVAR",
+                        "simpleDatatype": "Num",
+                        "role": VariableRoles.TIMING.value,
+                        "ordinal": 2000,
+                    },
+                ],
+            },
+        ],
+    }
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_data, model_metadata=model_metadata
     )
     result = VariablesMetadataWithLibraryMetadataDatasetBuilder(
         rule=None,
@@ -290,6 +282,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder_variable_only_i
         define_xml_path=None,
         standard=standard,
         standard_version=standard_version,
+        library_metadata=library_metadata,
     ).build()
     assert set(result.columns.tolist()) == set(
         [

--- a/tests/unit/test_operations/test_domain_label.py
+++ b/tests/unit/test_operations/test_domain_label.py
@@ -1,11 +1,12 @@
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 import pandas as pd
 from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.domain_label import DomainLabel
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-)
 
 
 def test_get_domain_label_from_library(operation_params: OperationParams):
@@ -47,16 +48,17 @@ def test_get_domain_label_from_library(operation_params: OperationParams):
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
-    )
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
     # execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
     operation = DomainLabel(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     expected: pd.Series = pd.Series(
@@ -110,16 +112,18 @@ def test_get_domain_label_from_library_domain_not_found(
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
-    )
     # execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
+    # execute operation
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
     operation = DomainLabel(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     expected: pd.Series = pd.Series(
@@ -172,16 +176,18 @@ def test_get_domain_label_from_library_domain_missing_label(
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
-    )
     # execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
+    # execute operation
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
     operation = DomainLabel(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     expected: pd.Series = pd.Series(

--- a/tests/unit/test_operations/test_expected_variables.py
+++ b/tests/unit/test_operations/test_expected_variables.py
@@ -1,4 +1,8 @@
 from typing import List
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 import pandas as pd
 import pytest
@@ -9,10 +13,6 @@ from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.expected_variables import ExpectedVariables
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
-)
 
 
 @pytest.mark.parametrize(
@@ -113,18 +113,19 @@ def test_get_expected_variables(
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_metadata, model_metadata=model_metadata
     )
-    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
-
     # execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
     operation = ExpectedVariables(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     variables: List[str] = ["AENEW"]

--- a/tests/unit/test_operations/test_get_codelist_attributes.py
+++ b/tests/unit/test_operations/test_get_codelist_attributes.py
@@ -1,3 +1,7 @@
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 import pandas as pd
 import pytest
 
@@ -99,15 +103,22 @@ def test_get_codelist_attributes(
 
     # 2.0 add CT data to cache
     cache = InMemoryCacheService.get_instance()
+    library_metadata = LibraryMetadataContainer()
     for pkg in ct_data:
         cp = pkg.get("package")
-        cache.add(cp, pkg)
+        library_metadata.set_ct_package_metadata(cp, pkg)
 
     # 3.0 execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
 
     operation = CodeListAttributes(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
 
     result: pd.DataFrame = operation.execute()

--- a/tests/unit/test_operations/test_get_model_filtered_variables.py
+++ b/tests/unit/test_operations/test_get_model_filtered_variables.py
@@ -1,5 +1,8 @@
 # python -m pytest -s tests/unit/test_operations/test_get_model_filtered_variables.py
 
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 import pandas as pd
 import pytest
 
@@ -17,10 +20,6 @@ from cdisc_rules_engine.operations.get_model_filtered_variables import (
 )
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
-)
 from cdisc_rules_engine.config import ConfigService
 
 test_set1 = (
@@ -535,22 +534,20 @@ def test_get_model_filtered_variables(
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_metadata, model_metadata=model_metadata
     )
-
-    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
-
     # execute operation
     data_service = LocalDataService.get_instance(
         cache_service=cache, config=ConfigService()
     )
 
     operation = LibraryModelVariablesFilter(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
 
     result: pd.DataFrame = operation.execute()

--- a/tests/unit/test_operations/test_label_referenced_variable_metadata.py
+++ b/tests/unit/test_operations/test_label_referenced_variable_metadata.py
@@ -1,3 +1,7 @@
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 import pandas as pd
 from cdisc_rules_engine.constants.classes import GENERAL_OBSERVATIONS_CLASS
 from cdisc_rules_engine.enums.variable_roles import VariableRoles
@@ -7,10 +11,6 @@ from cdisc_rules_engine.operations.label_referenced_variable_metadata import (
 )
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
-)
 
 
 def test_get_label_referenced_variable_metadata(operation_params: OperationParams):
@@ -100,17 +100,20 @@ def test_get_label_referenced_variable_metadata(operation_params: OperationParam
     operation_params.operation_id = "$label_referenced_variable"
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
+
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_metadata, model_metadata=model_metadata
     )
-    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
     # execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
     operation = LabelReferencedVariableMetadata(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     expected_columns = [

--- a/tests/unit/test_operations/test_library_column_order.py
+++ b/tests/unit/test_operations/test_library_column_order.py
@@ -1,4 +1,8 @@
 from typing import List
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 import pandas as pd
 import pytest
@@ -9,10 +13,6 @@ from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.library_column_order import LibraryColumnOrder
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
-)
 
 
 @pytest.mark.parametrize(
@@ -113,18 +113,19 @@ def test_get_column_order_from_library(
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_metadata, model_metadata=model_metadata
     )
-    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
-
     # execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
     operation = LibraryColumnOrder(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     variables: List[str] = [

--- a/tests/unit/test_operations/test_library_model_column_order.py
+++ b/tests/unit/test_operations/test_library_model_column_order.py
@@ -1,4 +1,8 @@
 from typing import List
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 import pandas as pd
 import pytest
@@ -15,10 +19,6 @@ from cdisc_rules_engine.operations.library_model_column_order import (
 )
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
-)
 
 
 @pytest.mark.parametrize(
@@ -122,18 +122,19 @@ def test_get_column_order_from_library(
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_metadata, model_metadata=model_metadata
     )
-    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
-
     # execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
     operation = LibraryModelColumnOrder(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     variables: List[str] = [
@@ -264,18 +265,19 @@ def test_get_findings_class_column_order_from_library(
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_metadata, model_metadata=model_metadata
     )
-    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
-
     # execute operation
-    data_service = LocalDataService.get_instance(cache_service=cache)
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
     operation = LibraryModelColumnOrder(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     variables: List[str] = [

--- a/tests/unit/test_operations/test_operations_factory.py
+++ b/tests/unit/test_operations/test_operations_factory.py
@@ -1,3 +1,6 @@
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.operations_factory import OperationsFactory
 from cdisc_rules_engine.operations.base_operation import BaseOperation
@@ -27,6 +30,7 @@ def test_register_service(operation_params: OperationParams):
         cache=cache,
         data_service=data_service,
         original_dataset=pd.DataFrame(),
+        library_metadata=LibraryMetadataContainer(),
     )
     assert isinstance(op, DummyOperation)
 

--- a/tests/unit/test_operations/test_parent_library_model_column_order.py
+++ b/tests/unit/test_operations/test_parent_library_model_column_order.py
@@ -1,4 +1,8 @@
 from typing import List
+from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 import pandas as pd
 import pytest
@@ -17,10 +21,6 @@ from cdisc_rules_engine.operations.parent_library_model_column_order import (
 )
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
-)
 
 
 @pytest.mark.parametrize(
@@ -136,18 +136,19 @@ def test_get_parent_column_order_from_library(
 
         # save model metadata to cache
         cache = InMemoryCacheService.get_instance()
-        cache.add(
-            get_standard_details_cache_key(
-                operation_params.standard, operation_params.standard_version
-            ),
-            standard_metadata,
+        library_metadata = LibraryMetadataContainer(
+            standard_metadata=standard_metadata, model_metadata=model_metadata
         )
-        cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
-
         # execute operation
-        data_service = LocalDataService.get_instance(cache_service=cache)
+        data_service = LocalDataService.get_instance(
+            cache_service=cache, config=ConfigService()
+        )
         operation = ParentLibraryModelColumnOrder(
-            operation_params, operation_params.dataframe, cache, data_service
+            operation_params,
+            operation_params.dataframe,
+            cache,
+            data_service,
+            library_metadata,
         )
         result: pd.DataFrame = operation.execute()
         variables: List[str] = [
@@ -323,18 +324,20 @@ def test_get_parent_findings_class_column_order_from_library(
 
         # save model metadata to cache
         cache = InMemoryCacheService.get_instance()
-        cache.add(
-            get_standard_details_cache_key(
-                operation_params.standard, operation_params.standard_version
-            ),
-            standard_metadata,
-        )
-        cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
 
+        library_metadata = LibraryMetadataContainer(
+            standard_metadata=standard_metadata, model_metadata=model_metadata
+        )
         # execute operation
-        data_service = LocalDataService.get_instance(cache_service=cache)
+        data_service = LocalDataService.get_instance(
+            cache_service=cache, config=ConfigService()
+        )
         operation = ParentLibraryModelColumnOrder(
-            operation_params, operation_params.dataframe, cache, data_service
+            operation_params,
+            operation_params.dataframe,
+            cache,
+            data_service,
+            library_metadata,
         )
         result: pd.DataFrame = operation.execute()
         variables: List[str] = [

--- a/tests/unit/test_operations/test_permissible_variables.py
+++ b/tests/unit/test_operations/test_permissible_variables.py
@@ -1,4 +1,7 @@
 from typing import List
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 import pandas as pd
 import pytest
@@ -9,10 +12,6 @@ from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.permissible_variables import PermissibleVariables
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
-)
 
 
 @pytest.mark.parametrize(
@@ -112,20 +111,19 @@ def test_get_permissible_variables(
     operation_params.standard = "sdtmig"
     operation_params.standard_version = "3-4"
 
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_metadata, model_metadata=model_metadata
+    )
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
-    )
-    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
-
     # execute operation
     data_service = LocalDataService.get_instance(cache_service=cache)
     operation = PermissibleVariables(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     variables: List[str] = ["AEPERM", "TIMING_VAR"]

--- a/tests/unit/test_operations/test_required_variables.py
+++ b/tests/unit/test_operations/test_required_variables.py
@@ -1,4 +1,7 @@
 from typing import List
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 import pandas as pd
 import pytest
@@ -9,10 +12,6 @@ from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.required_variables import RequiredVariables
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
-from cdisc_rules_engine.utilities.utils import (
-    get_standard_details_cache_key,
-    get_model_details_cache_key,
-)
 
 
 @pytest.mark.parametrize(
@@ -118,18 +117,17 @@ def test_get_required_variables(
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    cache.add(
-        get_standard_details_cache_key(
-            operation_params.standard, operation_params.standard_version
-        ),
-        standard_metadata,
+    library_metadata = LibraryMetadataContainer(
+        standard_metadata=standard_metadata, model_metadata=model_metadata
     )
-    cache.add(get_model_details_cache_key("sdtm", "1-5"), model_metadata)
-
     # execute operation
     data_service = LocalDataService.get_instance(cache_service=cache)
     operation = RequiredVariables(
-        operation_params, operation_params.dataframe, cache, data_service
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
     )
     result: pd.DataFrame = operation.execute()
     variables: List[str] = sorted(["STUDYID", "DOMAIN", "AESEQ", "AETEST"])

--- a/tests/unit/test_operations/test_valid_codelist_dates.py
+++ b/tests/unit/test_operations/test_valid_codelist_dates.py
@@ -1,9 +1,11 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 from cdisc_rules_engine.operations.valid_codelist_dates import ValidCodelistDates
 from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
-from cdisc_rules_engine.constants.cache_constants import PUBLISHED_CT_PACKAGES
 import pytest
 
 
@@ -31,13 +33,14 @@ def test_variable_count(
     ]
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
-    cache.add(PUBLISHED_CT_PACKAGES, valid_codelists)
+    library_metadata = LibraryMetadataContainer(published_ct_packages=valid_codelists)
     operation_params.standard = standard
     result = ValidCodelistDates(
         operation_params,
         pd.DataFrame.from_dict({"test": [1, 2, 33]}),
         cache,
         mock_data_service,
+        library_metadata,
     ).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:

--- a/tests/unit/test_operations/test_variable_value_count.py
+++ b/tests/unit/test_operations/test_variable_value_count.py
@@ -1,4 +1,7 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 from cdisc_rules_engine.operations.variable_value_count import VariableValueCount
 from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
@@ -51,7 +54,11 @@ def test_variable_value_count(
     operation_params.original_target = target
     operation_params.dataset_path = dataset_path
     result = VariableValueCount(
-        operation_params, datasets_map["AE"], cache, mock_data_service
+        operation_params,
+        datasets_map["AE"],
+        cache,
+        mock_data_service,
+        LibraryMetadataContainer(),
     ).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:

--- a/tests/unit/test_services/test_cache/test_in_memory_cache.py
+++ b/tests/unit/test_services/test_cache/test_in_memory_cache.py
@@ -1,0 +1,44 @@
+from cdisc_rules_engine.services.cache.in_memory_cache_service import (
+    InMemoryCacheService,
+)
+
+
+def test_cache_value_exceeds_max_size():
+    cache = InMemoryCacheService(max_size=1)
+    cache.add("test", "this is a test")
+    assert cache.get("test") is None
+
+
+def test_get_all_by_prefix():
+    cache = InMemoryCacheService()
+    cache.add("test", "this is a test")
+    assert cache.get_all_by_prefix("te") == ["this is a test"]
+
+
+def test_clear():
+    cache = InMemoryCacheService()
+    cache.add("test", "this is a test")
+    cache.clear("test")
+    assert cache.get("test") is None
+
+
+def test_filter_cache():
+    cache = InMemoryCacheService()
+    cache.add("test", "this is a test")
+    assert cache.filter_cache("te") == {"test": "this is a test"}
+
+
+def test_get_by_regex():
+    cache = InMemoryCacheService()
+    cache.add("test", "this is a test")
+    cache.add("hi", "bye")
+    assert cache.get_by_regex("*t") == {"test": "this is a test"}
+
+
+def test_clear_all_with_prefix():
+    cache = InMemoryCacheService()
+    cache.add("test", "this is a test")
+    cache.add("hi", "bye")
+    cache.clear_all("te")
+    assert cache.exists("hi")
+    assert not cache.exists("test")


### PR DESCRIPTION
This PR makes the following notable changes:
1. The in memory cache now uses an LRU cache implementation from the cachetools library
2. Because of the eviction policy, library metadata is now stored outside of the cache for use by the rules engine, data services, rule processor, dataset builders and operations
3. Rules are no longer stored in the cache object

Steps to test:
1. Run a full validation and ensure the output is as expected
2. Run a test validation with a rule that requires library metadata and ensure the results are as expected.
3. Run `func start --python` from the root of the project to start the test endpoint
4. Make a request to the locally running test endpoint using a rule that requires library metadata and ensure the output is correct.