### PR TITLE
ISS-526: Add dask functionality for rule operators

### DIFF
--- a/cdisc_rules_engine/models/dataset_variable.py
+++ b/cdisc_rules_engine/models/dataset_variable.py
@@ -1,4 +1,5 @@
-from business_rules.variables import BaseVariables, dataframe_rule_variable
+from business_rules.variables import BaseVariables, rule_variable
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
 from pandas import DataFrame
 
 
@@ -15,6 +16,6 @@ class DatasetVariable(BaseVariables):
         self.params = params
 
     # common variables
-    @dataframe_rule_variable(label="GET DATASET")
+    @rule_variable(DataframeType, label="GET DATASET")
     def get_dataset(self) -> dict:
         return {"value": self.dataset, **self.params}

--- a/cdisc_rules_engine/rule_operators/dask_dataframe_operators.py
+++ b/cdisc_rules_engine/rule_operators/dask_dataframe_operators.py
@@ -9,7 +9,7 @@ class DaskDataframeType(DataframeType):
 
     def get_comparator_data(
         self, comparator, value_is_literal: bool = False
-    ) -> Union[str, int, dd.Series]:
+    ) -> Union[str, int, dd.dataframe.Series]:
         if value_is_literal:
             return comparator
         elif comparator in self.value.columns:

--- a/cdisc_rules_engine/rule_operators/dask_dataframe_operators.py
+++ b/cdisc_rules_engine/rule_operators/dask_dataframe_operators.py
@@ -1,0 +1,120 @@
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
+from typing import Union
+import dask as dd
+import numpy as np
+
+
+class DaskDataframeType(DataframeType):
+    name = "dask"
+
+    def get_comparator_data(
+        self, comparator, value_is_literal: bool = False
+    ) -> Union[str, int, dd.Series]:
+        if value_is_literal:
+            return comparator
+        elif comparator in self.value.columns:
+            return self.value[comparator]
+        else:
+            return comparator
+
+    def _get_string_part_series(self, part_to_validate: str, length: int, target: str):
+        if not self.value[target].apply(type).eq(str).all().compute():
+            raise ValueError("The operator can't be used with non-string values")
+
+        if part_to_validate == "suffix":
+            series_to_validate = self.value[target].str.slice(-length)
+        elif part_to_validate == "prefix":
+            series_to_validate = self.value[target].str.slice(stop=length)
+        else:
+            raise ValueError(
+                f"Invalid part to validate: {part_to_validate}. \
+                  Valid values are: suffix, prefix"
+            )
+
+        return series_to_validate
+
+    def _convert_to_series(self, result):
+        if self._is_series(result):
+            return result
+        elif isinstance(result, np.ndarray):
+            return dd.dataframe.from_array(result)
+        return dd.dataframe.from_array(dd.array.from_array(result))
+
+    def _to_numeric(self, target, **kwargs):
+        return dd.dataframe.to_numeric(target, **kwargs)
+
+    def _is_series(self, data):
+        return isinstance(data, dd.dataframe.Series)
+
+    def _where_less_than(self, target, comparison):
+        return target.lt(comparison, fill_value=0)
+
+    def _where_less_than_or_equal_to(self, target, comparison):
+        return target.le(comparison, fill_value=0)
+
+    def _where_greater_than(self, target, comparison):
+        return target.gt(comparison, fill_value=0)
+
+    def _get_series_values(self, series):
+        return series.values.compute()
+
+    def _where_greater_than_or_equal_to(self, target, comparison):
+        return target.ge(comparison, fill_value=0)
+
+    def _series_is_in(self, target, comparison_data):
+        return comparison_data.isin(target.values.compute())
+
+    def validate_series_length(self, data, target: str, min_length: int):
+        value_counts = data[target].value_counts().to_dict()
+        return data[target].apply(lambda x: value_counts.get(x, 0) > min_length)
+
+    def present_on_multiple_rows_within(self, other_value: dict):
+        """
+        The operator ensures that the target is present on multiple rows
+        within a group_by column. The dataframe is grouped by a certain column
+        and the check is applied to each group.
+        """
+
+        target = self.replace_prefix(other_value.get("target"))
+        min_count: int = other_value.get("comparator") or 1
+        group_by_column = self.replace_prefix(other_value.get("within"))
+        grouped = self.value.groupby(group_by_column)
+        results = grouped.apply(
+            lambda x: self.validate_series_length(x, target, min_count),
+            meta=(target, self.value[target].dtype),
+        )
+        return results.reset_index(drop=True)
+
+    def is_not_unique_relationship(self, other_value):
+        """
+        Validates one-to-one relationship between two columns
+        (target and comparator) against a dataset.
+        One-to-one means that a pair of columns can be duplicated
+        but its integrity must not be violated:
+        one value of target always corresponds
+        to one value of comparator. Examples:
+
+        Valid dataset:
+        STUDYID  STUDYDESC
+        1        A
+        2        B
+        3        C
+        1        A
+        2        B
+
+        Invalid dataset:
+        STUDYID  STUDYDESC
+        1        A
+        2        A
+        3        C
+        """
+        target = other_value.get("target")
+        comparator = other_value.get("comparator")
+        # remove repeating rows
+        df_without_duplicates = self.value[[target, comparator]].drop_duplicates()
+        # we need to check if ANY of the columns (target or comparator) is duplicated
+        for col in [target, comparator]:
+            df = df_without_duplicates[col].value_counts().map(lambda x: x > 1)
+            if True in df:
+                return self._convert_to_series([True] * len(self.value))
+        return self._convert_to_series([False] * len(self.value))

--- a/cdisc_rules_engine/rule_operators/dask_dataframe_operators.py
+++ b/cdisc_rules_engine/rule_operators/dask_dataframe_operators.py
@@ -1,6 +1,7 @@
 from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
 from typing import Union
-import dask as dd
+import dask.dataframe as dd
+import dask.array as da
 import numpy as np
 
 
@@ -9,7 +10,7 @@ class DaskDataframeType(DataframeType):
 
     def get_comparator_data(
         self, comparator, value_is_literal: bool = False
-    ) -> Union[str, int, dd.dataframe.Series]:
+    ) -> Union[str, int]:
         if value_is_literal:
             return comparator
         elif comparator in self.value.columns:
@@ -37,14 +38,14 @@ class DaskDataframeType(DataframeType):
         if self._is_series(result):
             return result
         elif isinstance(result, np.ndarray):
-            return dd.dataframe.from_array(result)
-        return dd.dataframe.from_array(dd.array.from_array(result))
+            return dd.from_array(result)
+        return dd.from_array(da.from_array(result))
 
     def _to_numeric(self, target, **kwargs):
-        return dd.dataframe.to_numeric(target, **kwargs)
+        return dd.to_numeric(target, **kwargs)
 
     def _is_series(self, data):
-        return isinstance(data, dd.dataframe.Series)
+        return isinstance(data, dd.Series)
 
     def _where_less_than(self, target, comparison):
         return target.lt(comparison, fill_value=0)

--- a/cdisc_rules_engine/rule_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/rule_operators/dataframe_operators.py
@@ -1,0 +1,1289 @@
+from business_rules.operators import BaseType, type_operator
+import pandas as pd
+import numpy as np
+from typing import Union, Any, List, Tuple
+from business_rules.fields import FIELD_DATAFRAME
+from pandas.api.types import is_integer_dtype
+from business_rules.utils import (
+    flatten_list,
+    vectorized_is_valid,
+    vectorized_compare_dates,
+    vectorized_is_complete_date,
+    vectorized_get_dict_key,
+    vectorized_is_in,
+    vectorized_case_insensitive_is_in,
+    apply_regex,
+)
+import re
+import operator
+from uuid import uuid4
+
+
+class DataframeType(BaseType):
+
+    name = "dataframe"
+
+    def __init__(self, data):
+        self.value: pd.DataFrame = self._assert_valid_value_and_cast(data["value"])
+        self.column_prefix_map = data.get("column_prefix_map", {})
+        self.relationship_data = data.get("relationship_data", {})
+        self.value_level_metadata = data.get("value_level_metadata", [])
+        self.column_codelist_map = data.get("column_codelist_map", {})
+        self.codelist_term_maps = data.get("codelist_term_maps", [])
+
+    def _assert_valid_value_and_cast(self, value):
+        if not hasattr(value, "__iter__"):
+            raise AssertionError(
+                "{0} is not a valid select multiple type".format(value)
+            )
+        return value
+
+    def convert_string_data_to_lower(self, data):
+        if self._is_series(data):
+            data = data.str.lower()
+        else:
+            data = data.lower()
+        return data
+
+    def replace_prefix(self, value: str) -> Union[str, Any]:
+        if isinstance(value, str):
+            for prefix, replacement in self.column_prefix_map.items():
+                if value.startswith(prefix):
+                    return value.replace(prefix, replacement, 1)
+        return value
+
+    def replace_all_prefixes(self, values: List[str]) -> List[str]:
+        for i in range(len(values)):
+            values[i] = self.replace_prefix(values[i])
+        return values
+
+    def get_comparator_data(
+        self, comparator, value_is_literal: bool = False
+    ) -> Union[str, int, pd.Series]:
+        if value_is_literal:
+            return comparator
+        else:
+            return self.value.get(comparator, comparator)
+
+    def is_column_of_iterables(self, column):
+        return isinstance(column, pd.core.series.Series) and (
+            isinstance(column.iloc[0], list) or isinstance(column.iloc[0], set)
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def exists(self, other_value) -> pd.Series:
+        target_column = self.replace_prefix(other_value.get("target"))
+        return pd.Series([target_column in self.value] * len(self.value))
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_exists(self, other_value):
+        return ~self.exists(other_value)
+
+    def _check_equality(
+        self,
+        row,
+        target,
+        comparator,
+        value_is_literal: bool = False,
+        case_insensitive: bool = False,
+    ) -> bool:
+        """
+        Equality checks work slightly differently for clinical datasets.
+        See truth table below:
+        Operator       --A         --B         Outcome
+        equal_to       "" or null  "" or null  False
+        equal_to       "" or null  Populated   False
+        equal_to       Populated   "" or null  False
+        equal_to       Populated   Populated   A == B
+        """
+        comparison_data = (
+            comparator if comparator not in row or value_is_literal else row[comparator]
+        )
+        both_null = (comparison_data == "" or comparison_data is None) & (
+            row[target] == "" or row[target] is None
+        )
+        if both_null:
+            return False
+        if case_insensitive:
+            target_val = row[target].lower() if row[target] else None
+            comparison_val = comparison_data.lower() if comparison_data else None
+            return target_val == comparison_val
+        return row[target] == comparison_data
+
+    def _check_inequality(
+        self,
+        row,
+        target,
+        comparator,
+        value_is_literal: bool = False,
+        case_insensitive: bool = False,
+    ) -> bool:
+        """
+        Equality checks work slightly differently for clinical datasets.
+        See truth table below:
+        Operator       --A         --B         Outcome
+        not_equal_to   "" or null  "" or null  False
+        not_equal_to   "" or null  Populated   True
+        not_equal_to   Populated   "" or null  True
+        not_equal_to   Populated   Populated   A != B
+        """
+        comparison_data = (
+            comparator if comparator not in row or value_is_literal else row[comparator]
+        )
+        both_null = (comparison_data == "" or comparison_data is None) & (
+            row[target] == "" or row[target] is None
+        )
+        if both_null:
+            return False
+        if case_insensitive:
+            target_val = row[target].lower() if row[target] else None
+            comparison_val = comparison_data.lower() if comparison_data else None
+            return target_val != comparison_val
+        return row[target] != comparison_data
+
+    @type_operator(FIELD_DATAFRAME)
+    def equal_to(self, other_value) -> pd.Series:
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        return self.value.apply(
+            lambda row: self._check_equality(row, target, comparator, value_is_literal),
+            axis=1,
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def equal_to_case_insensitive(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        return self.value.apply(
+            lambda row: self._check_equality(
+                row, target, comparator, value_is_literal, case_insensitive=True
+            ),
+            axis=1,
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_equal_to_case_insensitive(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        return self.value.apply(
+            lambda row: self._check_inequality(
+                row, target, comparator, value_is_literal, case_insensitive=True
+            ),
+            axis=1,
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_equal_to(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        return self.value.apply(
+            lambda row: self._check_inequality(
+                row, target, comparator, value_is_literal
+            ),
+            axis=1,
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def suffix_equal_to(self, other_value: dict) -> pd.Series:
+        """
+        Checks if target suffix is equal to comparator.
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparator: Union[str, Any] = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data: Union[str, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        suffix: int = self.replace_prefix(other_value.get("suffix"))
+        return self._check_equality_of_string_part(
+            target, comparison_data, "suffix", suffix
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def suffix_not_equal_to(self, other_value: dict) -> pd.Series:
+        """
+        Checks if target suffix is not equal to comparator.
+        """
+        return ~self.suffix_equal_to(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def prefix_equal_to(self, other_value: dict) -> pd.Series:
+        """
+        Checks if target prefix is equal to comparator.
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparator: Union[str, Any] = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data: Union[str, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        prefix: int = self.replace_prefix(other_value.get("prefix"))
+        return self._check_equality_of_string_part(
+            target, comparison_data, "prefix", prefix
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def prefix_not_equal_to(self, other_value: dict) -> pd.Series:
+        """
+        Checks if target prefix is not equal to comparator.
+        """
+        return ~self.prefix_equal_to(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def prefix_is_contained_by(self, other_value: dict) -> pd.Series:
+        """
+        Checks if target prefix is contained by the comparator.
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparator: Union[str, Any] = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data: Union[str, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        prefix_length: int = other_value.get("prefix")
+        series_to_validate: pd.Series = self._get_string_part_series(
+            "prefix", prefix_length, target
+        )
+        return self._value_is_contained_by(series_to_validate, comparison_data)
+
+    @type_operator(FIELD_DATAFRAME)
+    def prefix_is_not_contained_by(self, other_value: dict) -> pd.Series:
+        return ~self.prefix_is_contained_by(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def suffix_is_contained_by(self, other_value: dict) -> pd.Series:
+        """
+        Checks if target prefix is equal to comparator.
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparator: Union[str, Any] = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data: Union[str, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        suffix_length: int = other_value.get("suffix")
+        series_to_validate: pd.Series = self._get_string_part_series(
+            "suffix", suffix_length, target
+        )
+        return self._value_is_contained_by(series_to_validate, comparison_data)
+
+    @type_operator(FIELD_DATAFRAME)
+    def suffix_is_not_contained_by(self, other_value: dict) -> pd.Series:
+        return ~self.suffix_is_contained_by(other_value)
+
+    def _get_string_part_series(self, part_to_validate: str, length: int, target: str):
+        if not self.value[target].apply(type).eq(str).all():
+            raise ValueError("The operator can't be used with non-string values")
+
+        if part_to_validate == "suffix":
+            series_to_validate: pd.Series = self.value[target].str.slice(-length)
+        elif part_to_validate == "prefix":
+            series_to_validate: pd.Series = self.value[target].str.slice(stop=length)
+        else:
+            raise ValueError(
+                f"Invalid part to validate: {part_to_validate}. \
+                    Valid values are: suffix, prefix"
+            )
+
+        return series_to_validate
+
+    def _value_is_contained_by(self, series: pd.Series, comparison_data) -> pd.Series:
+        if self.is_column_of_iterables(comparison_data):
+            results = vectorized_is_in(series, comparison_data)
+        else:
+            results = series.isin(comparison_data)
+        return pd.Series(results)
+
+    def _check_equality_of_string_part(
+        self,
+        target: str,
+        comparison_data: Union[str, pd.Series],
+        part_to_validate: str,
+        length: int,
+    ) -> pd.Series:
+        """
+        Checks if the given string part is equal to comparison data.
+        """
+        series_to_validate = self._get_string_part_series(
+            part_to_validate, length, target
+        )
+        return series_to_validate.eq(comparison_data)
+
+    def _where_less_than(self, target, comparison):
+        return np.where(target < comparison, True, False)
+
+    def _where_greater_than(self, target, comparison):
+        return np.where(target > comparison, True, False)
+
+    def _where_less_than_or_equal_to(self, target, comparison):
+        return np.where(target <= comparison, True, False)
+
+    def _where_greater_than_or_equal_to(self, target, comparison):
+        return np.where(target >= comparison, True, False)
+
+    def _convert_to_series(self, result):
+        return pd.Series(result)
+
+    def _to_numeric(self, target, **kwargs):
+        return pd.to_numeric(target, **kwargs)
+
+    def _is_series(self, data):
+        return isinstance(data, pd.Series)
+
+    @type_operator(FIELD_DATAFRAME)
+    def less_than(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        target_column = self._to_numeric(self.value[target], errors="coerce")
+        if self._is_series(comparison_data):
+            comparison_data = self._to_numeric(comparison_data, errors="coerce")
+        results = self._where_less_than(target_column, comparison_data)
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def less_than_or_equal_to(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        target_column = self._to_numeric(self.value[target], errors="coerce")
+        if self._is_series(comparison_data):
+            comparison_data = self._to_numeric(comparison_data, errors="coerce")
+        results = self._where_less_than_or_equal_to(target_column, comparison_data)
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def greater_than_or_equal_to(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        target_column = self._to_numeric(self.value[target], errors="coerce")
+        if self._is_series(comparison_data):
+            comparison_data = self._to_numeric(comparison_data, errors="coerce")
+        results = self._where_greater_than_or_equal_to(target_column, comparison_data)
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def greater_than(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        target_column = self._to_numeric(self.value[target], errors="coerce")
+        if self._is_series(comparison_data):
+            comparison_data = self._to_numeric(comparison_data, errors="coerce")
+        results = self._where_greater_than(target_column, comparison_data)
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def contains(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        if self.is_column_of_iterables(self.value[target]) or isinstance(
+            comparison_data, str
+        ):
+            results = vectorized_is_in(comparison_data, self.value[target])
+        elif self._is_series(comparison_data):
+            results = self._series_is_in(self.value[target], comparison_data)
+        else:
+            # Handles numeric case. This case should never occur
+            results = np.where(self.value[target] == comparison_data, True, False)
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_contain(self, other_value):
+        return ~self.contains(other_value)
+
+    def _series_is_in(self, target, comparison_data):
+        return np.where(comparison_data.isin(target), True, False)
+
+    @type_operator(FIELD_DATAFRAME)
+    def contains_case_insensitive(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = (
+            self.replace_prefix(other_value.get("comparator"))
+            if not value_is_literal
+            else other_value.get("comparator")
+        )
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        comparison_data = self.convert_string_data_to_lower(comparison_data)
+        if self.is_column_of_iterables(self.value[target]):
+            results = vectorized_case_insensitive_is_in(
+                comparison_data, self.value[target]
+            )
+        elif self._is_series(comparison_data):
+            results = self._series_is_in(
+                self.convert_string_data_to_lower(self.value[target]),
+                self.convert_string_data_to_lower(comparison_data),
+            )
+        else:
+            results = vectorized_case_insensitive_is_in(
+                comparison_data.lower(), self.value[target]
+            )
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_contain_case_insensitive(self, other_value):
+        return ~self.contains_case_insensitive(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_contained_by(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = other_value.get("comparator")
+        if isinstance(comparator, str) and not value_is_literal:
+            # column name provided
+            comparator = self.replace_prefix(comparator)
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        if self.is_column_of_iterables(comparison_data):
+            results = vectorized_is_in(self.value[target], comparison_data)
+        else:
+            results = self.value[target].isin(comparison_data)
+        return pd.Series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_contained_by(self, other_value):
+        return ~self.is_contained_by(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_contained_by_case_insensitive(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator", [])
+        value_is_literal = other_value.get("value_is_literal", False)
+        if isinstance(comparator, list):
+            comparator = [val.lower() for val in comparator]
+        elif isinstance(comparator, str) and not value_is_literal:
+            # column name provided
+            comparator = self.replace_prefix(comparator)
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        if self.is_column_of_iterables(comparison_data):
+            results = vectorized_case_insensitive_is_in(
+                self.value[target].str.lower(), comparison_data
+            )
+            return self._convert_to_series(results)
+        elif self._is_series(comparison_data):
+            results = self.value[target].str.lower().isin(comparison_data.str.lower())
+        else:
+            results = self.value[target].str.lower().isin(comparison_data)
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_contained_by_case_insensitive(self, other_value):
+        return ~self.is_contained_by_case_insensitive(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def prefix_matches_regex(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        prefix = other_value.get("prefix")
+        results = self.value[target].map(
+            lambda x: re.search(comparator, x[:prefix]) is not None
+        )
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_prefix_matches_regex(self, other_value):
+        return ~self.prefix_matches_regex(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def suffix_matches_regex(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        suffix = other_value.get("suffix")
+        results = self.value[target].apply(
+            lambda x: re.search(comparator, x[-suffix:]) is not None
+        )
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_suffix_matches_regex(self, other_value):
+        return ~self.suffix_matches_regex(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def matches_regex(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        results = self.value[target].str.match(comparator)
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_matches_regex(self, other_value):
+        return ~self.matches_regex(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def equals_string_part(self, other_value):
+        """
+        Checks that the values in the target column
+        equal the result of parsing the value in the comparison
+        column with a regex
+        """
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        regex = other_value.get("regex")
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparison_data: Union[str, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        if isinstance(comparison_data, str):
+            parsed_data = apply_regex(regex, comparison_data)
+        else:
+            parsed_data = comparison_data.str.findall(regex).str[0]
+        parsed_id = str(uuid4())
+        self.value[parsed_id] = parsed_data
+        return self.value.apply(
+            lambda row: self._check_equality(row, target, parsed_id, value_is_literal),
+            axis=1,
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_equal_string_part(self, other_value):
+        return ~self.equals_string_part(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def starts_with(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparison_data: Union[str, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        if self._is_series(comparison_data):
+            # need to convert series to tuple to make startswith operator work correctly
+            comparison_data: Tuple[str] = tuple(comparison_data)
+        results = self.value[target].str.startswith(comparison_data)
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def ends_with(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparison_data: Union[str, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        if self._is_series(comparison_data):
+            # need to convert series to tuple to make endswith operator work correctly
+            comparison_data: Tuple[str] = tuple(comparison_data)
+        results = self.value[target].str.endswith(comparison_data)
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def has_equal_length(self, other_value: dict):
+        """
+        Checks that the target length is the same as comparator.
+        If comparing two columns (value_is_literal is False), the operator
+        compares lengths of values in these columns.
+        """
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparison_data: Union[int, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        if self._is_series(comparison_data):
+            if is_integer_dtype(comparison_data):
+                results = self.value[target].str.len().eq(comparison_data)
+            else:
+                results = self.value[target].str.len().eq(comparison_data.str.len())
+        else:
+            results = self.value[target].str.len().eq(comparator)
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def has_not_equal_length(self, other_value: dict):
+        return ~self.has_equal_length(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def longer_than(self, other_value: dict):
+        """
+        Checks if the target is longer than the comparator.
+        If comparing two columns (value_is_literal is False), the operator
+        compares lengths of values in these columns.
+        """
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparison_data: Union[int, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        if self._is_series(comparison_data):
+            if is_integer_dtype(comparison_data):
+                results = self.value[target].str.len().gt(comparison_data)
+            else:
+                results = self.value[target].str.len().gt(comparison_data.str.len())
+        else:
+            results = self.value[target].str.len().gt(comparison_data)
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def longer_than_or_equal_to(self, other_value: dict):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparison_data: Union[int, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        if self._is_series(comparison_data):
+            if is_integer_dtype(comparison_data):
+                results = self.value[target].str.len().ge(comparison_data)
+            else:
+                results = self.value[target].str.len().ge(comparison_data.str.len())
+        else:
+            results = self.value[target].str.len().ge(comparator)
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def shorter_than(self, other_value: dict):
+        return ~self.longer_than_or_equal_to(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def shorter_than_or_equal_to(self, other_value: dict):
+        return ~self.longer_than(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def empty(self, other_value: dict):
+        target = self.replace_prefix(other_value.get("target"))
+        results = np.where(self.value[target].isin(["", None]), True, False)
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def empty_within_except_last_row(self, other_value: dict):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        # group all targets by comparator
+        grouped_target = self.value.groupby(comparator)[target]
+        # validate all targets except the last one
+        results = grouped_target.apply(lambda x: x[:-1]).apply(
+            lambda x: x in ["", None]
+        )
+        # extract values with corresponding indexes from results
+        self.value[f"result_{uuid4()}"] = results.reset_index(level=0, drop=True)
+        return True in results.values
+
+    @type_operator(FIELD_DATAFRAME)
+    def non_empty(self, other_value: dict):
+        return ~self.empty(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def non_empty_within_except_last_row(self, other_value: dict):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        # group all targets by comparator
+        grouped_target = self.value.groupby(comparator)[target]
+        # validate all targets except the last one
+        results = ~grouped_target.apply(lambda x: x[:-1]).apply(
+            lambda x: x in ["", None]
+        )
+        # extract values with corresponding indexes from results
+        self.value[f"result_{uuid4()}"] = results.reset_index(level=0, drop=True)
+        return not (False in results.values)
+
+    @type_operator(FIELD_DATAFRAME)
+    def contains_all(self, other_value: dict):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        if isinstance(comparator, list):
+            # get column as array of values
+            values = flatten_list(self.value, comparator)
+        else:
+            comparator = self.replace_prefix(comparator)
+            values = self.value[comparator].unique()
+        return set(values).issubset(set(self.value[target].unique()))
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_contains_all(self, other_value: dict):
+        return not self.contains_all(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def invalid_date(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        results = ~vectorized_is_valid(self.value[target])
+        return self._convert_to_series(results)
+
+    def date_comparison(self, other_value, operator):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
+        value_is_literal: bool = other_value.get("value_is_literal", False)
+        comparison_data: Union[str, pd.Series] = self.get_comparator_data(
+            comparator, value_is_literal
+        )
+        component = other_value.get("date_component")
+        results = np.where(
+            vectorized_compare_dates(
+                component, self.value[target], comparison_data, operator
+            ),
+            True,
+            False,
+        )
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def date_equal_to(self, other_value):
+        return self.date_comparison(other_value, operator.eq)
+
+    @type_operator(FIELD_DATAFRAME)
+    def date_not_equal_to(self, other_value):
+        return self.date_comparison(other_value, operator.ne)
+
+    @type_operator(FIELD_DATAFRAME)
+    def date_less_than(self, other_value):
+        return self.date_comparison(other_value, operator.lt)
+
+    @type_operator(FIELD_DATAFRAME)
+    def date_less_than_or_equal_to(self, other_value):
+        return self.date_comparison(other_value, operator.le)
+
+    @type_operator(FIELD_DATAFRAME)
+    def date_greater_than_or_equal_to(self, other_value):
+        return self.date_comparison(other_value, operator.ge)
+
+    @type_operator(FIELD_DATAFRAME)
+    def date_greater_than(self, other_value):
+        return self.date_comparison(other_value, operator.gt)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_incomplete_date(self, other_value):
+        return ~self.is_complete_date(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_complete_date(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        results = vectorized_is_complete_date(self.value[target])
+        return pd.Series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_unique_set(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        values = [target, comparator]
+        target_data = flatten_list(self.value, values)
+        target_names = []
+        for target_name in target_data:
+            target_name = self.replace_prefix(target_name)
+            if target_name in self.value.columns:
+                target_names.append(target_name)
+        target_names = list(set(target_names))
+        counts = (
+            self.value[target_names].groupby(target_names)[target].transform("size")
+        )
+        results = np.where(counts <= 1, True, False)
+        return self._convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_unique_relationship(self, other_value) -> pd.Series:
+        """
+        Validates one-to-one relationship between
+        two columns (target and comparator) against a dataset.
+        One-to-one means that a pair of columns can be duplicated
+        but its integrity must not be violated:
+        one value of target always corresponds to
+        one value of comparator.
+        Examples:
+
+        Valid dataset:
+        STUDYID  STUDYDESC
+        1        A
+        2        B
+        3        C
+        1        A
+        2        B
+
+        Invalid dataset:
+        STUDYID  STUDYDESC
+        1        A
+        2        A
+        3        C
+        """
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        if isinstance(comparator, list):
+            comparator = self.replace_all_prefixes(comparator)
+        else:
+            comparator = self.replace_prefix(comparator)
+        # remove repeating rows
+        df_without_duplicates: pd.DataFrame = self.value[
+            [target, comparator]
+        ].drop_duplicates()
+        # we need to check if ANY of the columns (target or comparator) is duplicated
+        duplicated_comparator: pd.Series = df_without_duplicates[comparator].duplicated(
+            keep=False
+        )
+        duplicated_target: pd.Series = df_without_duplicates[target].duplicated(
+            keep=False
+        )
+        result = pd.Series([False] * len(self.value))
+        if duplicated_comparator.any():
+            duplicated_comparator_values = set(
+                df_without_duplicates[duplicated_comparator][comparator]
+            )
+            result += self.value[comparator].isin(duplicated_comparator_values)
+        if duplicated_target.any():
+            duplicated_target_values = set(
+                df_without_duplicates[duplicated_target][target]
+            )
+            result += self.value[target].isin(duplicated_target_values)
+        return result
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_unique_relationship(self, other_value) -> pd.Series:
+        return ~self.is_not_unique_relationship(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_unique_set(self, other_value):
+        return ~self.is_unique_set(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_ordered_set(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value = other_value.get("comparator")
+        if not isinstance(value, str):
+            raise Exception("Comparator must be a single String value")
+
+        return not (
+            False
+            in self.value.groupby(value)
+            .agg(lambda x: list(x))[target]
+            .map(lambda x: sorted(x) == x)
+            .tolist()
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_ordered_set(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value = other_value.get("comparator")
+        if not isinstance(value, str):
+            raise Exception("Comparator must be a single String value")
+
+        return (
+            False
+            in self.value.groupby(value)
+            .agg(lambda x: list(x))[target]
+            .map(lambda x: sorted(x) == x)
+            .tolist()
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_valid_reference(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        context = self.replace_prefix(other_value.get("context"))
+        if context:
+            results = self.value.apply(
+                lambda row: row[target] in self.relationship_data.get(row[context], {}),
+                axis=1,
+            )
+        else:
+            results = self.value[target].isin(self.relationship_data)
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_valid_reference(self, other_value):
+        return ~self.is_valid_reference(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_valid_relationship(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_column = self.replace_prefix(other_value.get("comparator"))
+        context = self.replace_prefix(other_value.get("context"))
+        results = self.value.apply(
+            lambda row: self.detect_reference(row, value_column, target, context),
+            axis=1,
+        )
+        return results
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_valid_relationship(self, other_value):
+        return ~self.is_valid_relationship(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def non_conformant_value_data_type(self, other_value):
+        results = False
+        for vlm in self.value_level_metadata:
+            results |= self.value.apply(
+                lambda row: vlm["filter"](row) and not vlm["type_check"](row), axis=1
+            )
+        return pd.Series(results.values)
+
+    @type_operator(FIELD_DATAFRAME)
+    def non_conformant_value_length(self, other_value):
+        results = False
+        for vlm in self.value_level_metadata:
+            results |= self.value.apply(
+                lambda row: vlm["filter"](row) and not vlm["length_check"](row), axis=1
+            )
+        return pd.Series(results.values)
+
+    @type_operator(FIELD_DATAFRAME)
+    def conformant_value_data_type(self, other_value):
+        results = False
+        for vlm in self.value_level_metadata:
+            results |= self.value.apply(
+                lambda row: vlm["filter"](row) and vlm["type_check"](row), axis=1
+            )
+        return pd.Series(results.values)
+
+    @type_operator(FIELD_DATAFRAME)
+    def conformant_value_length(self, other_value):
+        results = False
+        for vlm in self.value_level_metadata:
+            results |= self.value.apply(
+                lambda row: vlm["filter"](row) and vlm["length_check"](row), axis=1
+            )
+        return pd.Series(results.values)
+
+    @type_operator(FIELD_DATAFRAME)
+    def has_next_corresponding_record(self, other_value: dict):
+        """
+        The operator ensures that value of target in current row
+        is the same as value of comparator in the next row.
+        In order to achieve this, we just remove last row from target
+        and first row from comparator and compare the resulting contents.
+        The result is reported for target.
+        """
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
+        group_by_column: str = self.replace_prefix(other_value.get("within"))
+        order_by_column: str = self.replace_prefix(other_value.get("ordering"))
+        ordered_df = self.value.sort_values(by=[order_by_column])
+        grouped_df = ordered_df.groupby(group_by_column)
+        results = grouped_df.apply(
+            lambda x: self.compare_target_with_comparator_next_row(
+                x, target, comparator
+            )
+        )
+        return self._convert_to_series(results.explode().tolist())
+
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_have_next_corresponding_record(self, other_value: dict):
+        return ~self.has_next_corresponding_record(other_value)
+
+    def compare_target_with_comparator_next_row(
+        self, df: pd.DataFrame, target: str, comparator: str
+    ):
+        """
+        Compares current row of a target with the next row of comparator.
+        We can't compare last row of target with the next row of comparator
+        because there is no row after the last one.
+        """
+        target_without_last_row = df[target].drop(df[target].tail(1).index)
+        comparator_without_first_row = df[comparator].drop(df[comparator].head(1).index)
+        results = np.where(
+            target_without_last_row.values == comparator_without_first_row.values,
+            True,
+            False,
+        )
+        # appending NA here to make the length of results list the same as length of df
+        return [
+            *results,
+            pd.NA,
+        ]
+
+    @type_operator(FIELD_DATAFRAME)
+    def present_on_multiple_rows_within(self, other_value: dict):
+        """
+        The operator ensures that the target is present on multiple rows
+        within a group_by column. The dataframe is grouped by a certain column
+        and the check is applied to each group.
+        """
+        target = self.replace_prefix(other_value.get("target"))
+        min_count: int = other_value.get("comparator") or 1
+        group_by_column = self.replace_prefix(other_value.get("within"))
+        grouped = self.value.groupby(group_by_column)
+        results = grouped.apply(
+            lambda x: self.validate_series_length(x, target, min_count)
+        )
+        return self._convert_to_series(results.sort_index(level=1).tolist())
+
+    def validate_series_length(self, data: pd.DataFrame, target: str, min_length: int):
+        value_counts = data[target].value_counts().to_dict()
+        return data[target].apply(lambda x: value_counts.get(x, 0) > min_length)
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_present_on_multiple_rows_within(self, other_value: dict):
+        return ~self.present_on_multiple_rows_within(other_value)
+
+    def detect_reference(self, row, value_column, target_column, context=None):
+        if context:
+            target_data = self.relationship_data.get(row[context], {}).get(
+                row[target_column], pd.Series([]).values
+            )
+        else:
+            target_data = self.relationship_data.get(
+                row[target_column], pd.Series([]).values
+            )
+        value = row[value_column]
+        return (
+            (value in target_data)
+            or (value in target_data.astype(int).astype(str))
+            or (value in target_data.astype(str))
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def additional_columns_empty(self, other_value: dict):
+        """
+        The dataframe column might have some additional columns.
+        If the next additional column exists,
+        the previous one cannot be empty.
+        Example:
+            column - TSVAL
+            additional columns - TSVAL1, TSVAL2, ...
+            If TSVAL2 exists -> TSVAL1 cannot be empty.
+            Original column (TSVAL) can be empty.
+
+        The operator extracts these
+        additional columns from the DF
+        and ensures they are not empty.
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        # starting from target,
+        # ending with integers and nothing is between them
+        regex: str = rf"^{target}\d+$"
+        df: pd.DataFrame = self.value.filter(regex=regex)
+        # applying a function to each row
+        result: pd.Series = df.apply(
+            lambda row: self.next_column_exists_and_previous_is_null(row), axis=1
+        )
+        return result
+
+    @type_operator(FIELD_DATAFRAME)
+    def additional_columns_not_empty(self, other_value: dict):
+        return ~self.additional_columns_empty(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def references_correct_codelist(self, other_value: dict):
+        target: str = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
+        result: pd.Series = self.value.apply(
+            lambda row: self.valid_codelist_reference(row[target], row[comparator]),
+            axis=1,
+        )
+        return result
+
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_reference_correct_codelist(self, other_value: dict):
+        return ~self.references_correct_codelist(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def uses_valid_codelist_terms(self, other_value: dict):
+        target: str = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
+        result: pd.Series = self.value.apply(
+            lambda row: self.valid_terms(row[target], row[comparator]), axis=1
+        )
+        return result
+
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_use_valid_codelist_terms(self, other_value: dict):
+        return ~self.uses_valid_codelist_terms(other_value)
+
+    def next_column_exists_and_previous_is_null(self, row: pd.Series) -> bool:
+        row.reset_index(drop=True, inplace=True)
+        for index in row[
+            row.isin([[], {}, "", None])
+        ].index:  # leaving null values only
+            next_position: int = index + 1
+            if next_position < len(row) and row[next_position] is not None:
+                return True
+        return False
+
+    def valid_codelist_reference(self, column_name, codelist):
+        if column_name in self.column_codelist_map:
+            return codelist in self.column_codelist_map[column_name]
+        elif self.column_prefix_map:
+            # Check for generic versions of variables (i.e --DECOD)
+            for key in self.column_prefix_map:
+                if column_name.startswith(self.column_prefix_map[key]):
+                    generic_column_name = column_name.replace(
+                        self.column_prefix_map[key], key, 1
+                    )
+                    if generic_column_name in self.column_codelist_map:
+                        return codelist in self.column_codelist_map.get(
+                            generic_column_name
+                        )
+        return True
+
+    def valid_terms(self, codelist, terms_list):
+        if not codelist:
+            return True
+        valid_term = False
+        for codelist_term_map in self.codelist_term_maps:
+            if codelist in codelist_term_map:
+                valid_term = valid_term or (
+                    codelist_term_map[codelist].get("extensible")
+                    or set(terms_list).issubset(
+                        codelist_term_map[codelist].get("allowed_terms", [])
+                    )
+                )
+        return valid_term
+
+    @type_operator(FIELD_DATAFRAME)
+    def has_different_values(self, other_value: dict):
+        """
+        The operator ensures that the target column has different values.
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        is_valid: bool = len(self.value[target].unique()) > 1
+        return self._convert_to_series([is_valid] * len(self.value[target]))
+
+    @type_operator(FIELD_DATAFRAME)
+    def has_same_values(self, other_value: dict):
+        return ~self.has_different_values(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_ordered_by(self, other_value: dict) -> pd.Series:
+        """
+        Checking validity based on target order.
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        sort_order: str = other_value.get("order", "asc")
+        if sort_order not in ["asc", "dsc"]:
+            raise ValueError("invalid sorting order")
+        sort_order_bool: bool = sort_order == "asc"
+        return self.value[target].eq(
+            self.value[target].sort_values(ascending=sort_order_bool, ignore_index=True)
+        )
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_ordered_by(self, other_value: dict) -> pd.Series:
+        return ~self.is_ordered_by(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def value_has_multiple_references(self, other_value: dict) -> pd.Series:
+        """
+        Requires a target column and a reference count column whose values
+        are a dictionary containing the number of times that value appears.
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        reference_count_column: str = self.replace_prefix(other_value.get("comparator"))
+        result = np.where(
+            vectorized_get_dict_key(
+                self.value[reference_count_column], self.value[target]
+            )
+            > 1,
+            True,
+            False,
+        )
+        return pd.Series(result)
+
+    @type_operator(FIELD_DATAFRAME)
+    def value_does_not_have_multiple_references(self, other_value: dict) -> pd.Series:
+        return ~self.value_has_multiple_references(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def target_is_sorted_by(self, other_value: dict) -> pd.Series:
+        """
+        Checking the sort order based on  comparators
+        """
+        target: str = self.replace_prefix(other_value.get("target"))
+        within: str = self.replace_prefix(other_value.get("within"))
+        columns = other_value["comparator"]
+        for col in columns:
+            comparator: str = self.replace_prefix(col["name"])
+            ascending: str = col["sort_order"] != "DESC"
+            na_pos: str = col["null_position"]
+
+            grouped_df: pd.Series = (
+                self.value.sort_values(by=[within, comparator], na_position=na_pos)
+                .groupby([within])
+                .apply(lambda x: x)
+            )
+            temp_target: pd.Series = (
+                grouped_df.groupby(within).cumcount().apply(lambda x: x + 1)
+            )
+            if not ascending:
+                grouped_df = grouped_df.reset_index(drop=True)
+                temp_target = temp_target[::-1].reset_index(drop=True)
+        return temp_target.eq(grouped_df[target]).sort_index(axis=0)
+
+    @type_operator(FIELD_DATAFRAME)
+    def target_is_not_sorted_by(self, other_value: dict) -> pd.Series:
+        return ~self.target_is_sorted_by(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def variable_metadata_equal_to(self, other_value: dict) -> pd.Series:
+        """
+        Validates the metadata for variables,
+        provided in the metadata column, is equal to
+        the comparator.
+        Ex.
+        target: STUDYID
+        comparator: "Exp"
+        metadata_column: {"STUDYID": "Req", "DOMAIN": "Req"}
+        result: False
+        """
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get(
+            "comparator"
+        )  # Assumes the comparator is a value not a column
+        metadata_column = self.replace_prefix(other_value.get("metadata"))
+        result = np.where(
+            vectorized_get_dict_key(self.value[metadata_column], target) == comparator,
+            True,
+            False,
+        )
+        return pd.Series(result)
+
+    @type_operator(FIELD_DATAFRAME)
+    def variable_metadata_not_equal_to(self, other_value: dict) -> pd.Series:
+        return ~self.variable_metadata_equal_to(other_value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ xport==3.6.1
 cachetools==5.3.1
 Pympler==1.0.1
 psutil==5.9.5
-dask[dataframe]==2023.9.1
-dask[array]==2023.9.1
+dask[dataframe]==2023.8.0
+dask[array]==2023.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ cachetools==5.3.1
 Pympler==1.0.1
 psutil==5.9.5
 dask[dataframe]==2023.9.1
+dask[array]==2023.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ xport==3.6.1
 cachetools==5.3.1
 Pympler==1.0.1
 psutil==5.9.5
+dask[dataframe]==2023.9.1

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_containment_checks.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_containment_checks.py
@@ -1,0 +1,128 @@
+from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
+import dask as dd
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "btt", "lll"]},
+            "VAR2",
+            [True, False, False],
+        ),
+        (
+            {"target": [["A", "B", "C"], ["A", "B", "L"], ["L", "Q", "R"]]},
+            "L",
+            [False, True, True],
+        ),
+    ],
+)
+def test_contains(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.contains({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["a", "btt", "lll"]},
+            "VAR2",
+            [True, True, False],
+        ),
+        (
+            {"target": [["A", "B", "C"], ["A", "B", "L"], ["L", "Q", "R"]]},
+            "l",
+            [False, True, True],
+        ),
+    ],
+)
+def test_contains_case_insensitive(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.contains_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "btt", "lll"]},
+            "VAR2",
+            [False, True, True],
+        ),
+        (
+            {"target": [["A", "B", "C"], ["A", "B", "L"], ["L", "Q", "R"]]},
+            "L",
+            [True, False, False],
+        ),
+    ],
+)
+def test_does_not_contain(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.does_not_contain(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["a", "btt", "lll"]},
+            "VAR2",
+            [False, False, True],
+        ),
+        (
+            {"target": [["A", "B", "C"], ["A", "B", "L"], ["L", "Q", "R"]]},
+            "l",
+            [True, False, False],
+        ),
+    ],
+)
+def test_does_not_contain_case_insensitive(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.does_not_contain_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "Btt", "A"]}, "VAR2", True),
+        ({"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "Btt", "D"]}, "VAR2", False),
+    ],
+)
+def test_contains_all(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.contains_all({"target": "target", "comparator": comparator})
+    assert result is expected_result
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "Btt", "A"]}, "VAR2", False),
+        ({"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "Btt", "D"]}, "VAR2", True),
+    ],
+)
+def test_not_contains_all(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.not_contains_all(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result is expected_result

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_containment_checks.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_containment_checks.py
@@ -1,5 +1,5 @@
 from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
-import dask as dd
+import dask.dataframe as dd
 import pandas as pd
 import pytest
 
@@ -20,7 +20,7 @@ import pytest
     ],
 )
 def test_contains(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.contains({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -42,7 +42,7 @@ def test_contains(data, comparator, expected_result):
     ],
 )
 def test_contains_case_insensitive(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.contains_case_insensitive(
         {"target": "target", "comparator": comparator}
@@ -66,7 +66,7 @@ def test_contains_case_insensitive(data, comparator, expected_result):
     ],
 )
 def test_does_not_contain(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.does_not_contain(
         {"target": "target", "comparator": comparator}
@@ -90,7 +90,7 @@ def test_does_not_contain(data, comparator, expected_result):
     ],
 )
 def test_does_not_contain_case_insensitive(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.does_not_contain_case_insensitive(
         {"target": "target", "comparator": comparator}
@@ -106,7 +106,7 @@ def test_does_not_contain_case_insensitive(data, comparator, expected_result):
     ],
 )
 def test_contains_all(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.contains_all({"target": "target", "comparator": comparator})
     assert result is expected_result
@@ -120,7 +120,7 @@ def test_contains_all(data, comparator, expected_result):
     ],
 )
 def test_not_contains_all(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.not_contains_all(
         {"target": "target", "comparator": comparator}

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_date_comparison.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_date_comparison.py
@@ -1,0 +1,670 @@
+from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
+import dask as dd
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,expected_result",
+    [
+        ({"target": ["2021", "2099", "2022", "2023"]}, [False, False, False, False]),
+        ({"target": ["90999", "20999", "2022", "2023"]}, [True, True, False, False]),
+        (
+            {
+                "target": [
+                    "2022-03-11T092030",
+                    "2022-03-11T09,20,30",
+                    "2022-03-11T09@20@30",
+                    "2022-03-11T09!20:30",
+                ]
+            },
+            [True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "2022-05-08T13:44:66",
+                ]
+            },
+            [False, False, False, True],
+        ),
+    ],
+)
+def test_invalid_date(data, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.invalid_date({"target": "target"})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [True, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [True, False, False, False, False],
+        ),
+    ],
+)
+def test_date_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [True, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [True, True, False, False, True],
+        ),
+    ],
+)
+def test_date_equal_to_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_equal_to(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [False, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [False, False, False, False, False],
+        ),
+    ],
+)
+def test_date_less_than(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_less_than(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [False, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [False, False, True, False, False],
+        ),
+    ],
+)
+def test_date_less_than_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_less_than(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [True, False, False, False, False],
+        ),
+    ],
+)
+def test_date_less_than_or_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_less_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [True, True, True, False, True],
+        ),
+    ],
+)
+def test_date_less_than_or_equal_to_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_less_than_or_equal_to(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [False, True, True, True, True],
+        ),
+    ],
+)
+def test_date_greater_than(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_greater_than(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [False, False, False, True, False],
+        ),
+    ],
+)
+def test_date_greater_than_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_greater_than(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [True, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [True, True, True, True, True],
+        ),
+    ],
+)
+def test_date_greater_than_or_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_greater_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [True, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [True, True, False, True, True],
+        ),
+    ],
+)
+def test_date_greater_than_or_equal_to_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.date_greater_than_or_equal_to(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.compute().equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_date_comparison.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_date_comparison.py
@@ -1,5 +1,5 @@
 from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
-import dask as dd
+import dask.dataframe as dd
 import pandas as pd
 import pytest
 
@@ -34,7 +34,7 @@ import pytest
     ],
 )
 def test_invalid_date(data, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.invalid_date({"target": "target"})
     assert result.compute().equals(pd.Series(expected_result))
@@ -79,7 +79,7 @@ def test_invalid_date(data, expected_result):
     ],
 )
 def test_date_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_equal_to(
         {"target": "target", "comparator": comparator}
@@ -158,7 +158,7 @@ def test_date_equal_to(data, comparator, expected_result):
 def test_date_equal_to_date_components(
     data, comparator, date_component, expected_result
 ):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_equal_to(
         {"target": "target", "comparator": comparator, "date_component": date_component}
@@ -205,7 +205,7 @@ def test_date_equal_to_date_components(
     ],
 )
 def test_date_less_than(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_less_than(
         {"target": "target", "comparator": comparator}
@@ -284,7 +284,7 @@ def test_date_less_than(data, comparator, expected_result):
 def test_date_less_than_date_components(
     data, comparator, date_component, expected_result
 ):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_less_than(
         {"target": "target", "comparator": comparator, "date_component": date_component}
@@ -331,7 +331,7 @@ def test_date_less_than_date_components(
     ],
 )
 def test_date_less_than_or_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_less_than_or_equal_to(
         {"target": "target", "comparator": comparator}
@@ -410,7 +410,7 @@ def test_date_less_than_or_equal_to(data, comparator, expected_result):
 def test_date_less_than_or_equal_to_date_components(
     data, comparator, date_component, expected_result
 ):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_less_than_or_equal_to(
         {"target": "target", "comparator": comparator, "date_component": date_component}
@@ -457,7 +457,7 @@ def test_date_less_than_or_equal_to_date_components(
     ],
 )
 def test_date_greater_than(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_greater_than(
         {"target": "target", "comparator": comparator}
@@ -536,7 +536,7 @@ def test_date_greater_than(data, comparator, expected_result):
 def test_date_greater_than_date_components(
     data, comparator, date_component, expected_result
 ):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_greater_than(
         {"target": "target", "comparator": comparator, "date_component": date_component}
@@ -583,7 +583,7 @@ def test_date_greater_than_date_components(
     ],
 )
 def test_date_greater_than_or_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_greater_than_or_equal_to(
         {"target": "target", "comparator": comparator}
@@ -662,7 +662,7 @@ def test_date_greater_than_or_equal_to(data, comparator, expected_result):
 def test_date_greater_than_or_equal_to_date_components(
     data, comparator, date_component, expected_result
 ):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.date_greater_than_or_equal_to(
         {"target": "target", "comparator": comparator, "date_component": date_component}

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_equality_checks.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_equality_checks.py
@@ -1,5 +1,5 @@
 from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
-import dask as dd
+import dask.dataframe as dd
 import pandas as pd
 import pytest
 
@@ -20,7 +20,7 @@ import pytest
     ],
 )
 def test_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.equal_to({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -42,7 +42,7 @@ def test_equal_to(data, comparator, expected_result):
     ],
 )
 def test_equal_to_null_strings(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.equal_to({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -64,7 +64,7 @@ def test_equal_to_null_strings(data, comparator, expected_result):
     ],
 )
 def test_not_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.not_equal_to({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -86,7 +86,7 @@ def test_not_equal_to(data, comparator, expected_result):
     ],
 )
 def test_equal_to_case_insensitive(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.equal_to_case_insensitive(
         {"target": "target", "comparator": comparator}
@@ -110,7 +110,7 @@ def test_equal_to_case_insensitive(data, comparator, expected_result):
     ],
 )
 def test_not_equal_to_case_insensitive(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.not_equal_to_case_insensitive(
         {"target": "target", "comparator": comparator}

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_equality_checks.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_equality_checks.py
@@ -1,0 +1,118 @@
+from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
+import dask as dd
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "VAR2",
+            [True, True, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            [False, True, False],
+        ),
+    ],
+)
+def test_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.equal_to({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", ""], "VAR2": ["", "", ""]},
+            "VAR2",
+            [False, False, False],
+        ),
+        (
+            {"target": ["A", "B", None], "VAR2": ["A", "B", "C"]},
+            "",
+            [False, False, False],
+        ),
+    ],
+)
+def test_equal_to_null_strings(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.equal_to({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "VAR2",
+            [False, False, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            [True, False, True],
+        ),
+    ],
+)
+def test_not_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.not_equal_to({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["a", "b", "c"]},
+            "VAR2",
+            [True, True, True],
+        ),
+        (
+            {"target": ["A", "b", "B"], "VAR2": ["A", "B", "C"]},
+            "B",
+            [False, True, True],
+        ),
+    ],
+)
+def test_equal_to_case_insensitive(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.equal_to_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["a", "b", "c"]},
+            "VAR2",
+            [False, False, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "b",
+            [True, False, True],
+        ),
+    ],
+)
+def test_not_equal_to_case_insensitive(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.not_equal_to_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_numeric_comparison.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_numeric_comparison.py
@@ -1,0 +1,84 @@
+from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
+import dask as dd
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, "VAR2", [True, True, False]),
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, 2, [True, False, False]),
+        (
+            {"target": ["1", "2", "3"], "VAR2": ["3", "3", "3"]},
+            "VAR2",
+            [True, True, False],
+        ),
+    ],
+)
+def test_less_than(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.less_than({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, "VAR2", [True, True, True]),
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, 2, [True, True, False]),
+        (
+            {"target": ["1", "2", "3"], "VAR2": ["3", "3", "3"]},
+            "VAR2",
+            [True, True, True],
+        ),
+    ],
+)
+def test_less_than_or_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.less_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": [1, 2, 4], "VAR2": [3, 3, 3]}, "VAR2", [False, False, True]),
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, 2, [False, False, True]),
+        (
+            {"target": ["1", "2", "3"], "VAR2": ["3", "3", "3"]},
+            "VAR2",
+            [False, False, False],
+        ),
+    ],
+)
+def test_greater_than(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.greater_than({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, "VAR2", [False, False, True]),
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, 2, [False, True, True]),
+        (
+            {"target": ["1", "2", "3"], "VAR2": ["3", "3", "3"]},
+            "VAR2",
+            [False, False, True],
+        ),
+    ],
+)
+def test_greater_than_or_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.greater_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_numeric_comparison.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_numeric_comparison.py
@@ -1,5 +1,5 @@
 from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
-import dask as dd
+import dask.dataframe as dd
 import pandas as pd
 import pytest
 
@@ -17,7 +17,7 @@ import pytest
     ],
 )
 def test_less_than(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.less_than({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -36,7 +36,7 @@ def test_less_than(data, comparator, expected_result):
     ],
 )
 def test_less_than_or_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.less_than_or_equal_to(
         {"target": "target", "comparator": comparator}
@@ -57,7 +57,7 @@ def test_less_than_or_equal_to(data, comparator, expected_result):
     ],
 )
 def test_greater_than(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.greater_than({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -76,7 +76,7 @@ def test_greater_than(data, comparator, expected_result):
     ],
 )
 def test_greater_than_or_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.greater_than_or_equal_to(
         {"target": "target", "comparator": comparator}

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_prefix_suffix_equality.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_prefix_suffix_equality.py
@@ -1,0 +1,108 @@
+from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
+import dask as dd
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,suffix,expected_result",
+    [
+        (
+            {"target": ["Atest", "B", "Ctest"], "VAR2": ["test", "test", "test"]},
+            "VAR2",
+            4,
+            [True, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            1,
+            [False, True, False],
+        ),
+    ],
+)
+def test_suffix_equal_to(data, comparator, suffix, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.suffix_equal_to(
+        {"target": "target", "comparator": comparator, "suffix": suffix}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,suffix,expected_result",
+    [
+        (
+            {"target": ["Atest", "B", "Ctest"], "VAR2": ["test", "test", "test"]},
+            "VAR2",
+            4,
+            [False, True, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            1,
+            [True, False, True],
+        ),
+    ],
+)
+def test_suffix_not_equal_to(data, comparator, suffix, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.suffix_not_equal_to(
+        {"target": "target", "comparator": comparator, "suffix": suffix}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,prefix,expected_result",
+    [
+        (
+            {"target": ["testA", "B", "testC"], "VAR2": ["test", "test", "test"]},
+            "VAR2",
+            4,
+            [True, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            1,
+            [False, True, False],
+        ),
+    ],
+)
+def test_prefix_equal_to(data, comparator, prefix, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.prefix_equal_to(
+        {"target": "target", "comparator": comparator, "prefix": prefix}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,prefix,expected_result",
+    [
+        (
+            {"target": ["testA", "B", "testC"], "VAR2": ["test", "test", "test"]},
+            "VAR2",
+            4,
+            [False, True, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            1,
+            [True, False, True],
+        ),
+    ],
+)
+def test_prefix_not_equal_to(data, comparator, prefix, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.prefix_not_equal_to(
+        {"target": "target", "comparator": comparator, "prefix": prefix}
+    )
+    assert result.compute().equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_prefix_suffix_equality.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_prefix_suffix_equality.py
@@ -1,5 +1,5 @@
 from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
-import dask as dd
+import dask.dataframe as dd
 import pandas as pd
 import pytest
 
@@ -22,7 +22,7 @@ import pytest
     ],
 )
 def test_suffix_equal_to(data, comparator, suffix, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.suffix_equal_to(
         {"target": "target", "comparator": comparator, "suffix": suffix}
@@ -48,7 +48,7 @@ def test_suffix_equal_to(data, comparator, suffix, expected_result):
     ],
 )
 def test_suffix_not_equal_to(data, comparator, suffix, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.suffix_not_equal_to(
         {"target": "target", "comparator": comparator, "suffix": suffix}
@@ -74,7 +74,7 @@ def test_suffix_not_equal_to(data, comparator, suffix, expected_result):
     ],
 )
 def test_prefix_equal_to(data, comparator, prefix, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.prefix_equal_to(
         {"target": "target", "comparator": comparator, "prefix": prefix}
@@ -100,7 +100,7 @@ def test_prefix_equal_to(data, comparator, prefix, expected_result):
     ],
 )
 def test_prefix_not_equal_to(data, comparator, prefix, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.prefix_not_equal_to(
         {"target": "target", "comparator": comparator, "prefix": prefix}

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_relationship_integrity_checks.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_relationship_integrity_checks.py
@@ -1,0 +1,341 @@
+from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
+import dask as dd
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,within,expected_result",
+    [
+        (
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                ],
+                "SEQ": [1, 2, 3, 4, 5, 6],
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP3",
+                    "AEHOSP2",
+                    "AEHOSP2",
+                ],
+            },
+            1,
+            "USUBJID",
+            [True, True, True, False, True, True],
+        ),
+    ],
+)
+def test_present_on_multiple_rows_within(data, comparator, within, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.present_on_multiple_rows_within(
+        {"target": "target", "comparator": comparator, "within": within}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data, expected_result",
+    [
+        (
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                ],
+                "SEQ": [1, 2, 3, 4, 5, 6],
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP3",
+                    "AEHOSP2",
+                    "AEHOSP2",
+                ],
+            },
+            [True, True, True, True, True, True],
+        ),
+    ],
+)
+def test_has_different_values(data, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.has_different_values({"target": "target"})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data, expected_result",
+    [
+        (
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                ],
+                "SEQ": [1, 2, 3, 4, 5, 6],
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP3",
+                    "AEHOSP2",
+                    "AEHOSP2",
+                ],
+            },
+            [False, False, False, False, False, False],
+        ),
+        (
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                ],
+                "SEQ": [1, 2, 3, 4, 5, 6],
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                ],
+            },
+            [True, True, True, True, True, True],
+        ),
+    ],
+)
+def test_has_same_values(data, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.has_same_values({"target": "target"})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "STUDYID": [
+                    "TEST",
+                    "TEST-1",
+                    "TEST-2",
+                    "TEST-3",
+                ],
+                "VISITNUM": [1, 2, 1, 3],
+                "target": [
+                    "Consulting",
+                    "Surgery",
+                    "Consulting",
+                    "Treatment",
+                ],
+            },
+            "VISITNUM",
+            [False, False, False, False],
+        ),
+        (
+            {
+                "STUDYID": [
+                    "TEST",
+                    "TEST-1",
+                    "TEST-2",
+                    "TEST-3",
+                ],
+                "VISITNUM": [1, 2, 1, 3],
+                "target": [
+                    "Consulting",
+                    "Surgery",
+                    "Surgery",
+                    "Treatment",
+                ],
+            },
+            "VISITNUM",
+            [True, True, True, True],
+        ),
+    ],
+)
+def test_is_not_unique_relationship(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.is_not_unique_relationship(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,context,expected_result",
+    [
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+                "IDVARVAL1": [4, 1, 31],
+                "IDVARVAL2": [5, 1, 35],
+            },
+            "IDVARVAL1",
+            "RDOMAIN",
+            [True, True, True],
+        ),
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+                "IDVARVAL1": [4, 1, 31],
+                "IDVARVAL2": [5, 1, 35],
+            },
+            "IDVARVAL2",
+            "RDOMAIN",
+            [True, True, False],
+        ),
+    ],
+)
+def test_valid_relationship(data, comparator, context, expected_result):
+    reference_data = {
+        "LB": {
+            "TEST": dd.dataframe.from_array(dd.array.from_array([4, 5, 6])),
+            "DATA": dd.dataframe.from_array(dd.array.from_array([1, 2, 3])),
+        },
+        "AE": {"AETERM": dd.dataframe.from_array(dd.array.from_array([31, 323, 33]))},
+    }
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType(
+        {"value": df, "relationship_data": reference_data}
+    )
+    result = dataframe_type.is_valid_relationship(
+        {"target": "target", "comparator": comparator, "context": context}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,context,expected_result",
+    [
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+                "IDVARVAL1": [4, 1, 31],
+                "IDVARVAL2": [5, 1, 35],
+            },
+            "IDVARVAL1",
+            "RDOMAIN",
+            [False, False, False],
+        ),
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+                "IDVARVAL1": [4, 1, 31],
+                "IDVARVAL2": [5, 1, 35],
+            },
+            "IDVARVAL2",
+            "RDOMAIN",
+            [False, False, True],
+        ),
+    ],
+)
+def test_is_not_valid_relationship(data, comparator, context, expected_result):
+    reference_data = {
+        "LB": {
+            "TEST": dd.dataframe.from_array(dd.array.from_array([4, 5, 6])),
+            "DATA": dd.dataframe.from_array(dd.array.from_array([1, 2, 3])),
+        },
+        "AE": {"AETERM": dd.dataframe.from_array(dd.array.from_array([31, 323, 33]))},
+    }
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType(
+        {"value": df, "relationship_data": reference_data}
+    )
+    result = dataframe_type.is_not_valid_relationship(
+        {"target": "target", "comparator": comparator, "context": context}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,context,expected_result",
+    [
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+            },
+            "RDOMAIN",
+            [True, True, True],
+        ),
+        (
+            {"RDOMAIN": ["LB", "LB", "AE"], "target": ["TEST", "AETERM", "AETERM"]},
+            "RDOMAIN",
+            [True, False, True],
+        ),
+    ],
+)
+def test_is_valid_reference(data, context, expected_result):
+    reference_data = {
+        "LB": {"TEST": [], "DATA": [1, 2, 3]},
+        "AE": {"AETERM": [1, 2, 3]},
+    }
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType(
+        {"value": df, "relationship_data": reference_data}
+    )
+    result = dataframe_type.is_valid_reference({"target": "target", "context": context})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,context,expected_result",
+    [
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+            },
+            "RDOMAIN",
+            [False, False, False],
+        ),
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "AETERM", "AETERM"],
+            },
+            "RDOMAIN",
+            [False, True, False],
+        ),
+    ],
+)
+def test_is_not_valid_reference(data, context, expected_result):
+    reference_data = {
+        "LB": {"TEST": [], "DATA": [1, 2, 3]},
+        "AE": {"AETERM": [1, 2, 3]},
+    }
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType(
+        {"value": df, "relationship_data": reference_data}
+    )
+    result = dataframe_type.is_not_valid_reference(
+        {"target": "target", "context": context}
+    )
+    assert result.compute().equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_relationship_integrity_checks.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_relationship_integrity_checks.py
@@ -1,5 +1,6 @@
 from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
-import dask as dd
+import dask.dataframe as dd
+import dask.array as da
 import pandas as pd
 import pytest
 
@@ -34,7 +35,7 @@ import pytest
     ],
 )
 def test_present_on_multiple_rows_within(data, comparator, within, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.present_on_multiple_rows_within(
         {"target": "target", "comparator": comparator, "within": within}
@@ -70,7 +71,7 @@ def test_present_on_multiple_rows_within(data, comparator, within, expected_resu
     ],
 )
 def test_has_different_values(data, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.has_different_values({"target": "target"})
     assert result.compute().equals(pd.Series(expected_result))
@@ -126,7 +127,7 @@ def test_has_different_values(data, expected_result):
     ],
 )
 def test_has_same_values(data, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.has_same_values({"target": "target"})
     assert result.compute().equals(pd.Series(expected_result))
@@ -176,7 +177,7 @@ def test_has_same_values(data, expected_result):
     ],
 )
 def test_is_not_unique_relationship(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.is_not_unique_relationship(
         {"target": "target", "comparator": comparator}
@@ -214,12 +215,12 @@ def test_is_not_unique_relationship(data, comparator, expected_result):
 def test_valid_relationship(data, comparator, context, expected_result):
     reference_data = {
         "LB": {
-            "TEST": dd.dataframe.from_array(dd.array.from_array([4, 5, 6])),
-            "DATA": dd.dataframe.from_array(dd.array.from_array([1, 2, 3])),
+            "TEST": dd.from_array(da.from_array([4, 5, 6])),
+            "DATA": dd.from_array(da.from_array([1, 2, 3])),
         },
-        "AE": {"AETERM": dd.dataframe.from_array(dd.array.from_array([31, 323, 33]))},
+        "AE": {"AETERM": dd.from_array(da.from_array([31, 323, 33]))},
     }
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType(
         {"value": df, "relationship_data": reference_data}
     )
@@ -259,12 +260,12 @@ def test_valid_relationship(data, comparator, context, expected_result):
 def test_is_not_valid_relationship(data, comparator, context, expected_result):
     reference_data = {
         "LB": {
-            "TEST": dd.dataframe.from_array(dd.array.from_array([4, 5, 6])),
-            "DATA": dd.dataframe.from_array(dd.array.from_array([1, 2, 3])),
+            "TEST": dd.from_array(da.from_array([4, 5, 6])),
+            "DATA": dd.from_array(da.from_array([1, 2, 3])),
         },
-        "AE": {"AETERM": dd.dataframe.from_array(dd.array.from_array([31, 323, 33]))},
+        "AE": {"AETERM": dd.from_array(da.from_array([31, 323, 33]))},
     }
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType(
         {"value": df, "relationship_data": reference_data}
     )
@@ -297,7 +298,7 @@ def test_is_valid_reference(data, context, expected_result):
         "LB": {"TEST": [], "DATA": [1, 2, 3]},
         "AE": {"AETERM": [1, 2, 3]},
     }
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType(
         {"value": df, "relationship_data": reference_data}
     )
@@ -331,7 +332,7 @@ def test_is_not_valid_reference(data, context, expected_result):
         "LB": {"TEST": [], "DATA": [1, 2, 3]},
         "AE": {"AETERM": [1, 2, 3]},
     }
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType(
         {"value": df, "relationship_data": reference_data}
     )

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_string_comparison.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_string_comparison.py
@@ -1,0 +1,374 @@
+from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
+import dask as dd
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,regex,expected_result",
+    [
+        (
+            {"VAR2": ["blaAtt", "yyyBtt", "aaaCtt"], "target": ["A", "B", "D"]},
+            "VAR2",
+            ".{3}(.).*",
+            [True, True, False],
+        ),
+    ],
+)
+def test_equals_string_part(data, comparator, regex, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.equals_string_part(
+        {"target": "target", "comparator": comparator, "regex": regex}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "B", "D"]},
+            "VAR2",
+            [True, True, False],
+        ),
+    ],
+)
+def test_starts_with(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.starts_with({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["tt", "B", "D"]},
+            "VAR2",
+            [True, True, True],
+        ),
+    ],
+)
+def test_ends_with(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.ends_with({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            "VAR2",
+            [False, False, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [True, True, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [False, True, False],
+        ),
+    ],
+)
+def test_has_equal_length(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.has_equal_length(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            "VAR2",
+            [True, True, False],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [False, False, False],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [True, False, True],
+        ),
+    ],
+)
+def test_has_not_equal_length(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.has_not_equal_length(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            "VAR2",
+            [True, True, False],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctta"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [False, False, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [True, False, True],
+        ),
+    ],
+)
+def test_longer_than(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.longer_than({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["AiAa", "Bd", "lll"]},
+            "VAR2",
+            [False, True, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [True, True, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [True, True, True],
+        ),
+    ],
+)
+def test_longer_than_or_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.longer_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            "VAR2",
+            [False, False, False],
+        ),
+        (
+            {"target": ["At", "Btt", "Ctta"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [True, False, False],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 5, 2]},
+            "VAR2",
+            [False, True, False],
+        ),
+    ],
+)
+def test_shorter_than(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.shorter_than({"target": "target", "comparator": comparator})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["AiAa", "Bd", "lll"]},
+            "VAR2",
+            [True, False, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [True, True, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [False, True, False],
+        ),
+    ],
+)
+def test_shorter_than_or_equal_to(data, comparator, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.shorter_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,expected_result",
+    [
+        ({"target": ["Att", "", None]}, [False, True, True]),
+    ],
+)
+def test_empty(data, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.empty({"target": "target"})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,expected_result",
+    [
+        ({"target": ["Att", "", None]}, [True, False, False]),
+    ],
+)
+def test_non_empty(data, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.non_empty({"target": "target"})
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,prefix,expected_result",
+    [
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "w.*",
+            2,
+            [True, False],
+        ),
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "[0-9].*",
+            2,
+            [False, False],
+        ),
+    ],
+)
+def test_prefix_matches_regex(data, comparator, prefix, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.prefix_matches_regex(
+        {"target": "target", "comparator": comparator, "prefix": prefix}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,suffix,expected_result",
+    [
+        (
+            {
+                "target": ["WORD", "test"],
+            },
+            "es.*",
+            3,
+            [False, True],
+        ),
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "[0-9].*",
+            3,
+            [False, False],
+        ),
+    ],
+)
+def test_suffix_matches_regex(data, comparator, suffix, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.suffix_matches_regex(
+        {"target": "target", "comparator": comparator, "suffix": suffix}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,suffix,expected_result",
+    [
+        (
+            {
+                "target": ["WORD", "test"],
+            },
+            ".*",
+            3,
+            [False, False],
+        ),
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "[0-9].*",
+            3,
+            [True, True],
+        ),
+    ],
+)
+def test_not_suffix_matches_regex(data, comparator, suffix, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.not_suffix_matches_regex(
+        {"target": "target", "comparator": comparator, "suffix": suffix}
+    )
+    assert result.compute().equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,prefix,expected_result",
+    [
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            ".*",
+            2,
+            [False, False],
+        ),
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "[0-9].*",
+            2,
+            [True, True],
+        ),
+    ],
+)
+def test_not_prefix_matches_regex(data, comparator, prefix, expected_result):
+    df = dd.dataframe.from_dict(data, npartitions=1)
+    dataframe_type = DaskDataframeType({"value": df})
+    result = dataframe_type.not_prefix_matches_regex(
+        {"target": "target", "comparator": comparator, "prefix": prefix}
+    )
+    assert result.compute().equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_string_comparison.py
+++ b/tests/unit/test_rule_operators/test_dask_dataframe_operators/test_string_comparison.py
@@ -1,5 +1,5 @@
 from cdisc_rules_engine.rule_operators.dask_dataframe_operators import DaskDataframeType
-import dask as dd
+import dask.dataframe as dd
 import pandas as pd
 import pytest
 
@@ -16,7 +16,7 @@ import pytest
     ],
 )
 def test_equals_string_part(data, comparator, regex, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.equals_string_part(
         {"target": "target", "comparator": comparator, "regex": regex}
@@ -35,7 +35,7 @@ def test_equals_string_part(data, comparator, regex, expected_result):
     ],
 )
 def test_starts_with(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.starts_with({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -52,7 +52,7 @@ def test_starts_with(data, comparator, expected_result):
     ],
 )
 def test_ends_with(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.ends_with({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -79,7 +79,7 @@ def test_ends_with(data, comparator, expected_result):
     ],
 )
 def test_has_equal_length(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.has_equal_length(
         {"target": "target", "comparator": comparator}
@@ -108,7 +108,7 @@ def test_has_equal_length(data, comparator, expected_result):
     ],
 )
 def test_has_not_equal_length(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.has_not_equal_length(
         {"target": "target", "comparator": comparator}
@@ -137,7 +137,7 @@ def test_has_not_equal_length(data, comparator, expected_result):
     ],
 )
 def test_longer_than(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.longer_than({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -164,7 +164,7 @@ def test_longer_than(data, comparator, expected_result):
     ],
 )
 def test_longer_than_or_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.longer_than_or_equal_to(
         {"target": "target", "comparator": comparator}
@@ -193,7 +193,7 @@ def test_longer_than_or_equal_to(data, comparator, expected_result):
     ],
 )
 def test_shorter_than(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.shorter_than({"target": "target", "comparator": comparator})
     assert result.compute().equals(pd.Series(expected_result))
@@ -220,7 +220,7 @@ def test_shorter_than(data, comparator, expected_result):
     ],
 )
 def test_shorter_than_or_equal_to(data, comparator, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.shorter_than_or_equal_to(
         {"target": "target", "comparator": comparator}
@@ -235,7 +235,7 @@ def test_shorter_than_or_equal_to(data, comparator, expected_result):
     ],
 )
 def test_empty(data, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.empty({"target": "target"})
     assert result.compute().equals(pd.Series(expected_result))
@@ -248,7 +248,7 @@ def test_empty(data, expected_result):
     ],
 )
 def test_non_empty(data, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.non_empty({"target": "target"})
     assert result.compute().equals(pd.Series(expected_result))
@@ -276,7 +276,7 @@ def test_non_empty(data, expected_result):
     ],
 )
 def test_prefix_matches_regex(data, comparator, prefix, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.prefix_matches_regex(
         {"target": "target", "comparator": comparator, "prefix": prefix}
@@ -306,7 +306,7 @@ def test_prefix_matches_regex(data, comparator, prefix, expected_result):
     ],
 )
 def test_suffix_matches_regex(data, comparator, suffix, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.suffix_matches_regex(
         {"target": "target", "comparator": comparator, "suffix": suffix}
@@ -336,7 +336,7 @@ def test_suffix_matches_regex(data, comparator, suffix, expected_result):
     ],
 )
 def test_not_suffix_matches_regex(data, comparator, suffix, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.not_suffix_matches_regex(
         {"target": "target", "comparator": comparator, "suffix": suffix}
@@ -366,7 +366,7 @@ def test_not_suffix_matches_regex(data, comparator, suffix, expected_result):
     ],
 )
 def test_not_prefix_matches_regex(data, comparator, prefix, expected_result):
-    df = dd.dataframe.from_dict(data, npartitions=1)
+    df = dd.from_dict(data, npartitions=1)
     dataframe_type = DaskDataframeType({"value": df})
     result = dataframe_type.not_prefix_matches_regex(
         {"target": "target", "comparator": comparator, "prefix": prefix}

--- a/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_containment_checks_pandas.py
+++ b/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_containment_checks_pandas.py
@@ -1,0 +1,127 @@
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "btt", "lll"]},
+            "VAR2",
+            [True, False, False],
+        ),
+        (
+            {"target": [["A", "B", "C"], ["A", "B", "L"], ["L", "Q", "R"]]},
+            "L",
+            [False, True, True],
+        ),
+    ],
+)
+def test_contains(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.contains({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["a", "btt", "lll"]},
+            "VAR2",
+            [True, True, False],
+        ),
+        (
+            {"target": [["A", "B", "C"], ["A", "B", "L"], ["L", "Q", "R"]]},
+            "l",
+            [False, True, True],
+        ),
+    ],
+)
+def test_contains_case_insensitive(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.contains_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "btt", "lll"]},
+            "VAR2",
+            [False, True, True],
+        ),
+        (
+            {"target": [["A", "B", "C"], ["A", "B", "L"], ["L", "Q", "R"]]},
+            "L",
+            [True, False, False],
+        ),
+    ],
+)
+def test_does_not_contain(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.does_not_contain(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["a", "btt", "lll"]},
+            "VAR2",
+            [False, False, True],
+        ),
+        (
+            {"target": [["A", "B", "C"], ["A", "B", "L"], ["L", "Q", "R"]]},
+            "l",
+            [True, False, False],
+        ),
+    ],
+)
+def test_does_not_contain_case_insensitive(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.does_not_contain_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "Btt", "A"]}, "VAR2", True),
+        ({"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "Btt", "D"]}, "VAR2", False),
+    ],
+)
+def test_contains_all(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.contains_all({"target": "target", "comparator": comparator})
+    assert result is expected_result
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "Btt", "A"]}, "VAR2", False),
+        ({"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "Btt", "D"]}, "VAR2", True),
+    ],
+)
+def test_not_contains_all(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.not_contains_all(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result is expected_result

--- a/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_date_comparison_pandas.py
+++ b/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_date_comparison_pandas.py
@@ -1,0 +1,669 @@
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,expected_result",
+    [
+        ({"target": ["2021", "2099", "2022", "2023"]}, [False, False, False, False]),
+        ({"target": ["90999", "20999", "2022", "2023"]}, [True, True, False, False]),
+        (
+            {
+                "target": [
+                    "2022-03-11T092030",
+                    "2022-03-11T09,20,30",
+                    "2022-03-11T09@20@30",
+                    "2022-03-11T09!20:30",
+                ]
+            },
+            [True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "2022-05-08T13:44:66",
+                ]
+            },
+            [False, False, False, True],
+        ),
+    ],
+)
+def test_invalid_date(data, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.invalid_date({"target": "target"})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [True, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [True, False, False, False, False],
+        ),
+    ],
+)
+def test_date_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [True, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [True, True, False, False, True],
+        ),
+    ],
+)
+def test_date_equal_to_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_equal_to(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [False, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [False, False, False, False, False],
+        ),
+    ],
+)
+def test_date_less_than(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_less_than(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [False, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [False, False, True, False, False],
+        ),
+    ],
+)
+def test_date_less_than_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_less_than(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [True, False, False, False, False],
+        ),
+    ],
+)
+def test_date_less_than_or_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_less_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [True, True, True, False, True],
+        ),
+    ],
+)
+def test_date_less_than_or_equal_to_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_less_than_or_equal_to(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [False, True, True, True, True],
+        ),
+    ],
+)
+def test_date_greater_than(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_greater_than(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [False, False, False, True, False],
+        ),
+    ],
+)
+def test_date_greater_than_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_greater_than(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            [True, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ]
+            },
+            "1997-07",
+            [True, True, True, True, True],
+        ),
+    ],
+)
+def test_date_greater_than_or_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_greater_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,date_component,expected_result",
+    [
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "hour",
+            [True, True, True, True, True],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:20:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:20:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "month",
+            [True, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "1997-07",
+                    "1997-07-16",
+                    "1997-07-16T19:20:30.45+01:00",
+                    "1997-07-16T19:22:30+01:00",
+                    "1997-07-16T19:20+01:00",
+                ],
+                "comparator": [
+                    "1997-07",
+                    "1997-08-16",
+                    "1997-08-16T19:21:30.45+01:00",
+                    "1997-08-16T19:20:30+01:00",
+                    "1997-08-16T19:20+01:00",
+                ],
+            },
+            "comparator",
+            "minute",
+            [True, True, False, True, True],
+        ),
+    ],
+)
+def test_date_greater_than_or_equal_to_date_components(
+    data, comparator, date_component, expected_result
+):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.date_greater_than_or_equal_to(
+        {"target": "target", "comparator": comparator, "date_component": date_component}
+    )
+    assert result.equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_equality_checks_pandas.py
+++ b/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_equality_checks_pandas.py
@@ -1,0 +1,117 @@
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "VAR2",
+            [True, True, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            [False, True, False],
+        ),
+    ],
+)
+def test_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.equal_to({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", ""], "VAR2": ["", "", ""]},
+            "VAR2",
+            [False, False, False],
+        ),
+        (
+            {"target": ["A", "B", None], "VAR2": ["A", "B", "C"]},
+            "",
+            [False, False, False],
+        ),
+    ],
+)
+def test_equal_to_null_strings(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.equal_to({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "VAR2",
+            [False, False, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            [True, False, True],
+        ),
+    ],
+)
+def test_not_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.not_equal_to({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["a", "b", "c"]},
+            "VAR2",
+            [True, True, True],
+        ),
+        (
+            {"target": ["A", "b", "B"], "VAR2": ["A", "B", "C"]},
+            "B",
+            [False, True, True],
+        ),
+    ],
+)
+def test_equal_to_case_insensitive(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.equal_to_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["a", "b", "c"]},
+            "VAR2",
+            [False, False, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "b",
+            [True, False, True],
+        ),
+    ],
+)
+def test_not_equal_to_case_insensitive(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.not_equal_to_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_numeric_comparison_pandas.py
+++ b/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_numeric_comparison_pandas.py
@@ -1,0 +1,83 @@
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, "VAR2", [True, True, False]),
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, 2, [True, False, False]),
+        (
+            {"target": ["1", "2", "3"], "VAR2": ["3", "3", "3"]},
+            "VAR2",
+            [True, True, False],
+        ),
+    ],
+)
+def test_less_than(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.less_than({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, "VAR2", [True, True, True]),
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, 2, [True, True, False]),
+        (
+            {"target": ["1", "2", "3"], "VAR2": ["3", "3", "3"]},
+            "VAR2",
+            [True, True, True],
+        ),
+    ],
+)
+def test_less_than_or_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.less_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": [1, 2, 4], "VAR2": [3, 3, 3]}, "VAR2", [False, False, True]),
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, 2, [False, False, True]),
+        (
+            {"target": ["1", "2", "3"], "VAR2": ["3", "3", "3"]},
+            "VAR2",
+            [False, False, False],
+        ),
+    ],
+)
+def test_greater_than(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.greater_than({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, "VAR2", [False, False, True]),
+        ({"target": [1, 2, 3], "VAR2": [3, 3, 3]}, 2, [False, True, True]),
+        (
+            {"target": ["1", "2", "3"], "VAR2": ["3", "3", "3"]},
+            "VAR2",
+            [False, False, True],
+        ),
+    ],
+)
+def test_greater_than_or_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.greater_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_prefix_suffix_equality_pandas.py
+++ b/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_prefix_suffix_equality_pandas.py
@@ -1,0 +1,107 @@
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,suffix,expected_result",
+    [
+        (
+            {"target": ["Atest", "B", "Ctest"], "VAR2": ["test", "test", "test"]},
+            "VAR2",
+            4,
+            [True, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            1,
+            [False, True, False],
+        ),
+    ],
+)
+def test_suffix_equal_to(data, comparator, suffix, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.suffix_equal_to(
+        {"target": "target", "comparator": comparator, "suffix": suffix}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,suffix,expected_result",
+    [
+        (
+            {"target": ["Atest", "B", "Ctest"], "VAR2": ["test", "test", "test"]},
+            "VAR2",
+            4,
+            [False, True, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            1,
+            [True, False, True],
+        ),
+    ],
+)
+def test_suffix_not_equal_to(data, comparator, suffix, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.suffix_not_equal_to(
+        {"target": "target", "comparator": comparator, "suffix": suffix}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,prefix,expected_result",
+    [
+        (
+            {"target": ["testA", "B", "testC"], "VAR2": ["test", "test", "test"]},
+            "VAR2",
+            4,
+            [True, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            1,
+            [False, True, False],
+        ),
+    ],
+)
+def test_prefix_equal_to(data, comparator, prefix, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.prefix_equal_to(
+        {"target": "target", "comparator": comparator, "prefix": prefix}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,prefix,expected_result",
+    [
+        (
+            {"target": ["testA", "B", "testC"], "VAR2": ["test", "test", "test"]},
+            "VAR2",
+            4,
+            [False, True, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": ["A", "B", "C"]},
+            "B",
+            1,
+            [True, False, True],
+        ),
+    ],
+)
+def test_prefix_not_equal_to(data, comparator, prefix, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.prefix_not_equal_to(
+        {"target": "target", "comparator": comparator, "prefix": prefix}
+    )
+    assert result.equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_relationship_integrity_checks_pandas.py
+++ b/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_relationship_integrity_checks_pandas.py
@@ -1,0 +1,332 @@
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,within,expected_result",
+    [
+        (
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                ],
+                "SEQ": [1, 2, 3, 4, 5, 6],
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP3",
+                    "AEHOSP2",
+                    "AEHOSP2",
+                ],
+            },
+            1,
+            "USUBJID",
+            [True, True, True, False, True, True],
+        ),
+    ],
+)
+def test_present_on_multiple_rows_within(data, comparator, within, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.present_on_multiple_rows_within(
+        {"target": "target", "comparator": comparator, "within": within}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data, expected_result",
+    [
+        (
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                ],
+                "SEQ": [1, 2, 3, 4, 5, 6],
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP3",
+                    "AEHOSP2",
+                    "AEHOSP2",
+                ],
+            },
+            [True, True, True, True, True, True],
+        ),
+    ],
+)
+def test_has_different_values(data, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.has_different_values({"target": "target"})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data, expected_result",
+    [
+        (
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                ],
+                "SEQ": [1, 2, 3, 4, 5, 6],
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP3",
+                    "AEHOSP2",
+                    "AEHOSP2",
+                ],
+            },
+            [False, False, False, False, False, False],
+        ),
+        (
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                ],
+                "SEQ": [1, 2, 3, 4, 5, 6],
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                ],
+            },
+            [True, True, True, True, True, True],
+        ),
+    ],
+)
+def test_has_same_values(data, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.has_same_values({"target": "target"})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {
+                "STUDYID": [
+                    "TEST",
+                    "TEST-1",
+                    "TEST-2",
+                    "TEST-3",
+                ],
+                "VISITNUM": [1, 2, 1, 3],
+                "target": [
+                    "Consulting",
+                    "Surgery",
+                    "Consulting",
+                    "Treatment",
+                ],
+            },
+            "VISITNUM",
+            [False, False, False, False],
+        ),
+        (
+            {
+                "STUDYID": [
+                    "TEST",
+                    "TEST-1",
+                    "TEST-2",
+                    "TEST-3",
+                ],
+                "VISITNUM": [1, 2, 1, 3],
+                "target": [
+                    "Consulting",
+                    "Surgery",
+                    "Surgery",
+                    "Treatment",
+                ],
+            },
+            "VISITNUM",
+            [True, True, True, False],
+        ),
+    ],
+)
+def test_is_not_unique_relationship(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.is_not_unique_relationship(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,context,expected_result",
+    [
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+                "IDVARVAL1": [4, 1, 31],
+                "IDVARVAL2": [5, 1, 35],
+            },
+            "IDVARVAL1",
+            "RDOMAIN",
+            [True, True, True],
+        ),
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+                "IDVARVAL1": [4, 1, 31],
+                "IDVARVAL2": [5, 1, 35],
+            },
+            "IDVARVAL2",
+            "RDOMAIN",
+            [True, True, False],
+        ),
+    ],
+)
+def test_valid_relationship(data, comparator, context, expected_result):
+    reference_data = {
+        "LB": {
+            "TEST": pd.Series([4, 5, 6]).values,
+            "DATA": pd.Series([1, 2, 3]).values,
+        },
+        "AE": {"AETERM": pd.Series([31, 323, 33]).values},
+    }
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df, "relationship_data": reference_data})
+    result = dataframe_type.is_valid_relationship(
+        {"target": "target", "comparator": comparator, "context": context}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,context,expected_result",
+    [
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+                "IDVARVAL1": [4, 1, 31],
+                "IDVARVAL2": [5, 1, 35],
+            },
+            "IDVARVAL1",
+            "RDOMAIN",
+            [False, False, False],
+        ),
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+                "IDVARVAL1": [4, 1, 31],
+                "IDVARVAL2": [5, 1, 35],
+            },
+            "IDVARVAL2",
+            "RDOMAIN",
+            [False, False, True],
+        ),
+    ],
+)
+def test_is_not_valid_relationship(data, comparator, context, expected_result):
+    reference_data = {
+        "LB": {
+            "TEST": pd.Series([4, 5, 6]).values,
+            "DATA": pd.Series([1, 2, 3]).values,
+        },
+        "AE": {"AETERM": pd.Series([31, 323, 33]).values},
+    }
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df, "relationship_data": reference_data})
+    result = dataframe_type.is_not_valid_relationship(
+        {"target": "target", "comparator": comparator, "context": context}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,context,expected_result",
+    [
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+            },
+            "RDOMAIN",
+            [True, True, True],
+        ),
+        (
+            {"RDOMAIN": ["LB", "LB", "AE"], "target": ["TEST", "AETERM", "AETERM"]},
+            "RDOMAIN",
+            [True, False, True],
+        ),
+    ],
+)
+def test_is_valid_reference(data, context, expected_result):
+    reference_data = {
+        "LB": {"TEST": [], "DATA": [1, 2, 3]},
+        "AE": {"AETERM": [1, 2, 3]},
+    }
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df, "relationship_data": reference_data})
+    result = dataframe_type.is_valid_reference({"target": "target", "context": context})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,context,expected_result",
+    [
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "DATA", "AETERM"],
+            },
+            "RDOMAIN",
+            [False, False, False],
+        ),
+        (
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "target": ["TEST", "AETERM", "AETERM"],
+            },
+            "RDOMAIN",
+            [False, True, False],
+        ),
+    ],
+)
+def test_is_not_valid_reference(data, context, expected_result):
+    reference_data = {
+        "LB": {"TEST": [], "DATA": [1, 2, 3]},
+        "AE": {"AETERM": [1, 2, 3]},
+    }
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df, "relationship_data": reference_data})
+    result = dataframe_type.is_not_valid_reference(
+        {"target": "target", "context": context}
+    )
+    assert result.equals(pd.Series(expected_result))

--- a/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_string_comparison_pandas.py
+++ b/tests/unit/test_rule_operators/test_pandas_dataframe_operators/test_string_comparison_pandas.py
@@ -1,0 +1,373 @@
+from cdisc_rules_engine.rule_operators.dataframe_operators import DataframeType
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "data,comparator,regex,expected_result",
+    [
+        (
+            {"VAR2": ["blaAtt", "yyyBtt", "aaaCtt"], "target": ["A", "B", "D"]},
+            "VAR2",
+            ".{3}(.).*",
+            [True, True, False],
+        ),
+    ],
+)
+def test_equals_string_part(data, comparator, regex, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.equals_string_part(
+        {"target": "target", "comparator": comparator, "regex": regex}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "B", "D"]},
+            "VAR2",
+            [True, True, False],
+        ),
+    ],
+)
+def test_starts_with(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.starts_with({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["tt", "B", "D"]},
+            "VAR2",
+            [True, True, True],
+        ),
+    ],
+)
+def test_ends_with(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.ends_with({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            "VAR2",
+            [False, False, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [True, True, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [False, True, False],
+        ),
+    ],
+)
+def test_has_equal_length(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.has_equal_length(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            "VAR2",
+            [True, True, False],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [False, False, False],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [True, False, True],
+        ),
+    ],
+)
+def test_has_not_equal_length(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.has_not_equal_length(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            "VAR2",
+            [True, True, False],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctta"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [False, False, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [True, False, True],
+        ),
+    ],
+)
+def test_longer_than(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.longer_than({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["AiAa", "Bd", "lll"]},
+            "VAR2",
+            [False, True, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [True, True, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [True, True, True],
+        ),
+    ],
+)
+def test_longer_than_or_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.longer_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            "VAR2",
+            [False, False, False],
+        ),
+        (
+            {"target": ["At", "Btt", "Ctta"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [True, False, False],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 5, 2]},
+            "VAR2",
+            [False, True, False],
+        ),
+    ],
+)
+def test_shorter_than(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.shorter_than({"target": "target", "comparator": comparator})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["AiAa", "Bd", "lll"]},
+            "VAR2",
+            [True, False, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": ["A", "Bd", "lll"]},
+            3,
+            [True, True, True],
+        ),
+        (
+            {"target": ["Att", "Btt", "Ctt"], "VAR2": [2, 3, 2]},
+            "VAR2",
+            [False, True, False],
+        ),
+    ],
+)
+def test_shorter_than_or_equal_to(data, comparator, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.shorter_than_or_equal_to(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,expected_result",
+    [
+        ({"target": ["Att", "", None]}, [False, True, True]),
+    ],
+)
+def test_empty(data, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.empty({"target": "target"})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,expected_result",
+    [
+        ({"target": ["Att", "", None]}, [True, False, False]),
+    ],
+)
+def test_non_empty(data, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.non_empty({"target": "target"})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,prefix,expected_result",
+    [
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "w.*",
+            2,
+            [True, False],
+        ),
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "[0-9].*",
+            2,
+            [False, False],
+        ),
+    ],
+)
+def test_prefix_matches_regex(data, comparator, prefix, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.prefix_matches_regex(
+        {"target": "target", "comparator": comparator, "prefix": prefix}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,suffix,expected_result",
+    [
+        (
+            {
+                "target": ["WORD", "test"],
+            },
+            "es.*",
+            3,
+            [False, True],
+        ),
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "[0-9].*",
+            3,
+            [False, False],
+        ),
+    ],
+)
+def test_suffix_matches_regex(data, comparator, suffix, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.suffix_matches_regex(
+        {"target": "target", "comparator": comparator, "suffix": suffix}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,suffix,expected_result",
+    [
+        (
+            {
+                "target": ["WORD", "test"],
+            },
+            ".*",
+            3,
+            [False, False],
+        ),
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "[0-9].*",
+            3,
+            [True, True],
+        ),
+    ],
+)
+def test_not_suffix_matches_regex(data, comparator, suffix, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.not_suffix_matches_regex(
+        {"target": "target", "comparator": comparator, "suffix": suffix}
+    )
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,prefix,expected_result",
+    [
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            ".*",
+            2,
+            [False, False],
+        ),
+        (
+            {
+                "target": ["word", "TEST"],
+            },
+            "[0-9].*",
+            2,
+            [True, True],
+        ),
+    ],
+)
+def test_not_prefix_matches_regex(data, comparator, prefix, expected_result):
+    df = pd.DataFrame.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.not_prefix_matches_regex(
+        {"target": "target", "comparator": comparator, "prefix": prefix}
+    )
+    assert result.equals(pd.Series(expected_result))


### PR DESCRIPTION
This PR:

* Moves rule operators implementation from business rules to the engine. This should allow for easier updates
* Creates a new type DaskDataframeType which utilizes much of the same functionality as the dataframe type.
* Adds tests for both dask and the pandas dataframe types.

Steps to test:
1. Regression test validation functionality both full validation and test validation