### PR TITLE
Relrec merging

### DIFF
--- a/cdisc_rules_engine/models/rule.py
+++ b/cdisc_rules_engine/models/rule.py
@@ -163,7 +163,8 @@ class Rule:
         for data in match_key_data:
             join_data = {
                 "domain_name": data.get("Name"),
-                "match_key": data.get("Keys"),
+                "match_key": data.get("Keys", []),
+                "wildcard": data.get("Wildcard", "**"),
             }
             if data.get("Is_Relationship", False):
                 join_data["relationship_columns"] = relationship_columns

--- a/cdisc_rules_engine/services/data_services/local_data_service.py
+++ b/cdisc_rules_engine/services/data_services/local_data_service.py
@@ -84,7 +84,8 @@ class LocalDataService(BaseDataService):
         )
         return DatasetMetadata(
             name=contents_metadata["dataset_name"],
-            domain_name=contents_metadata["domain_name"],
+            domain_name=contents_metadata["domain_name"]
+            or contents_metadata["dataset_name"],
             label=contents_metadata["dataset_label"],
             modification_date=contents_metadata["dataset_modification_date"],
             filename=file_metadata["name"],

--- a/cdisc_rules_engine/utilities/dataset_preprocessor.py
+++ b/cdisc_rules_engine/utilities/dataset_preprocessor.py
@@ -84,6 +84,7 @@ class DatasetPreprocessor:
                 left_dataset_domain_name=self._dataset_domain,
                 right_dataset=other_dataset,
                 right_dataset_domain_details=domain_details,
+                datasets=datasets,
             )
         logger.info(f"Dataset after preprocessing = {result}")
         return result
@@ -102,6 +103,7 @@ class DatasetPreprocessor:
         left_dataset_domain_name: str,
         right_dataset: pd.DataFrame,
         right_dataset_domain_details: dict,
+        datasets: List[dict],
     ) -> pd.DataFrame:
         """
         Merges datasets on their match keys.
@@ -118,7 +120,16 @@ class DatasetPreprocessor:
         )
 
         # merge datasets based on their type
-        if self._rule_processor.is_relationship_dataset(right_dataset_domain_name):
+        if right_dataset_domain_name == "RELREC":
+            result: pd.DataFrame = DataProcessor.merge_relrec_datasets(
+                left_dataset=left_dataset,
+                left_dataset_domain_name=left_dataset_domain_name,
+                relrec_dataset=right_dataset,
+                datasets=datasets,
+                dataset_preprocessor=self,
+                wildcard=right_dataset_domain_details.get("wildcard"),
+            )
+        elif self._rule_processor.is_relationship_dataset(right_dataset_domain_name):
             result: pd.DataFrame = DataProcessor.merge_relationship_datasets(
                 left_dataset=left_dataset,
                 left_dataset_match_keys=left_dataset_match_keys,

--- a/cdisc_rules_engine/utilities/sdtm_utilities.py
+++ b/cdisc_rules_engine/utilities/sdtm_utilities.py
@@ -374,3 +374,25 @@ def get_model_domain_metadata(model_details: dict, domain_name: str) -> dict:
 
 def replace_variable_wildcards(variables_metadata, domain):
     return [var["name"].replace("--", domain) for var in variables_metadata]
+
+
+def get_all_model_wildcard_variables(model_details: dict):
+    return {
+        classVariable["name"]
+        for cls in model_details.get("classes", [])
+        for classVariable in cls.get("classVariables", [])
+        if classVariable["name"].startswith("--")
+    }
+
+
+def add_variable_wildcards(
+    model_details: dict, variables: list[str], domain: str, wildcard: str
+):
+    all_model_wildcard_variables = get_all_model_wildcard_variables(model_details)
+    return {
+        variable: variable.replace(domain, wildcard, 1)
+        if variable.startswith(domain)
+        and variable.replace(domain, "--", 1) in all_model_wildcard_variables
+        else variable
+        for variable in variables
+    }

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -164,6 +164,14 @@ def get_model_details_cache_key(standard: str, model_version: str) -> str:
     return f"models/{standard}/{model_version.replace('.', '-')}"
 
 
+def get_model_details_cache_key_from_ig(standard_metadata: dict) -> str:
+    model_link = standard_metadata.get("_links", {}).get("model", {}).get("href", "")
+    model_link_parts = model_link.split("/")
+    return get_model_details_cache_key(
+        standard=model_link_parts[2], model_version=model_link_parts[3]
+    )
+
+
 def replace_pattern_in_list_of_strings(
     list_of_strings: List[str], pattern: str, value: str
 ) -> List[str]:

--- a/resources/schema/CORE-base.json
+++ b/resources/schema/CORE-base.json
@@ -361,9 +361,12 @@
               "$ref": "#/$defs/VariableName"
             },
             "type": "array"
+          },
+          "Wildcard": {
+            "type": "string"
           }
         },
-        "required": ["Name", "Keys"],
+        "required": ["Name"],
         "type": "object"
       },
       "minItems": 1,

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -17,7 +17,7 @@ from cdisc_rules_engine.models.dictionaries.get_dictionary_terms import (
 from cdisc_rules_engine.utilities.utils import (
     get_rules_cache_key,
     get_standard_details_cache_key,
-    get_model_details_cache_key,
+    get_model_details_cache_key_from_ig,
     get_library_variables_metadata_cache_key,
     get_standard_codelist_cache_key,
 )
@@ -34,13 +34,9 @@ def get_library_metadata_from_cache(args) -> LibraryMetadataContainer:
     )
     with open(standards_file, "rb") as f:
         data = pickle.load(f)
-        standards_metadata = data.get(standard_details_cache_key, {})
+        standard_metadata = data.get(standard_details_cache_key, {})
 
-    model_link = standards_metadata.get("_links", {}).get("model", {}).get("href", "")
-    model_link_parts = model_link.split("/")
-    model_type = model_link_parts[1]
-    model_version = model_link_parts[-1]
-    model_cache_key = get_model_details_cache_key(model_type, model_version)
+    model_cache_key = get_model_details_cache_key_from_ig(standard_metadata)
     with open(models_file, "rb") as f:
         data = pickle.load(f)
         model_details = data.get(model_cache_key, {})
@@ -74,7 +70,7 @@ def get_library_metadata_from_cache(args) -> LibraryMetadataContainer:
                 ct_package_data[ct_version] = data
 
     return LibraryMetadataContainer(
-        standard_metadata=standards_metadata,
+        standard_metadata=standard_metadata,
         model_metadata=model_details,
         variable_codelist_map=variable_codelist_maps,
         variables_metadata=variables_metadata,

--- a/tests/unit/test_dataset_preprocessor.py
+++ b/tests/unit/test_dataset_preprocessor.py
@@ -487,14 +487,16 @@ def test_preprocess_relrec_dataset(mock_get_dataset: MagicMock):
 
     # save model metadata to cache
     cache = InMemoryCacheService.get_instance()
-    library_metadata = LibraryMetadataContainer(model_metadata={})
     sdtm_utilities.get_all_model_wildcard_variables = MagicMock(
         return_value=["--SEQ", "--STDY"]
     )
     # execute operation
     data_service = LocalDataService.get_instance(
-        cache_service=cache, config=ConfigService(), library_metadata=library_metadata
+        cache_service=cache,
+        config=ConfigService(),
     )
+    data_service.library_metadata = LibraryMetadataContainer()
+
     preprocessor = DatasetPreprocessor(
         ec_dataset,
         "EC",

--- a/tests/unit/test_dataset_preprocessor.py
+++ b/tests/unit/test_dataset_preprocessor.py
@@ -8,6 +8,13 @@ from cdisc_rules_engine.services.cache.in_memory_cache_service import (
 )
 from cdisc_rules_engine.services.data_services import LocalDataService
 from cdisc_rules_engine.utilities.dataset_preprocessor import DatasetPreprocessor
+from cdisc_rules_engine.constants.rule_constants import ALL_KEYWORD
+from cdisc_rules_engine.models.rule_conditions import ConditionCompositeFactory
+from cdisc_rules_engine.utilities import sdtm_utilities
+from cdisc_rules_engine.config import ConfigService
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 
 def test_preprocess_no_datasets_in_rule(dataset_rule_equal_to_error_objects: dict):
@@ -328,6 +335,193 @@ def test_preprocess_relationship_dataset(
             "IDVARVAL": [
                 4.0,
                 5.0,
+            ],
+        }
+    )
+    assert preprocessed_dataset.equals(expected_dataset)
+
+
+@patch("cdisc_rules_engine.services.data_services.LocalDataService.get_dataset")
+def test_preprocess_relrec_dataset(mock_get_dataset: MagicMock):
+    """
+    Unit test for preprocess method. Checks the case when
+    we are merging datasets using relrec.
+    """
+    # Rule
+    relrec_rule = {
+        "core_id": "MockRule",
+        "standards": [{"Name": "SDTMIG", "Version": "3.3"}],
+        "classes": {"Include": [ALL_KEYWORD]},
+        "domains": {"Include": ["EC"]},
+        "datasets": [{"domain_name": "RELREC", "wildcard": "__", "match_key": []}],
+        "conditions": ConditionCompositeFactory.get_condition_composite(
+            {
+                "all": [
+                    {
+                        "name": "get_dataset",
+                        "operator": "equal_to",
+                        "value": {
+                            "target": "ECSTDY",
+                            "comparator": "RELREC.__STDY",
+                        },
+                    }
+                ]
+            }
+        ),
+        "actions": [
+            {
+                "name": "generate_dataset_error_objects",
+                "params": {
+                    "message": "Value of ECSTDY is equal to AESTDY.",
+                },
+            }
+        ],
+        "output_variables": [
+            "ECSTDY",
+        ],
+    }
+    # create datasets
+    ec_dataset = pd.DataFrame.from_dict(
+        {
+            "ECSEQ": [
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+            ],
+            "ECSTDY": [
+                4,
+                5,
+                6,
+                7,
+                8,
+            ],
+            "STUDYID": [
+                "1",
+                "2",
+                "1",
+                "2",
+                "3",
+            ],
+            "USUBJID": [
+                "CDISC001",
+                "CDISC001",
+                "CDISC002",
+                "CDISC002",
+                "CDISC003",
+            ],
+        }
+    )
+    ae_dataset = pd.DataFrame.from_dict(
+        {
+            "AESEQ": [
+                "1",
+                "2",
+                "3",
+                "4",
+            ],
+            "AESTDY": [
+                4,
+                5,
+                16,
+                17,
+            ],
+            "STUDYID": [
+                "1",
+                "2",
+                "1",
+                "2",
+            ],
+            "USUBJID": [
+                "CDISC001",
+                "CDISC001",
+                "CDISC002",
+                "CDISC002",
+            ],
+        }
+    )
+    relrec_dataset = pd.DataFrame.from_dict(
+        {
+            "RDOMAIN": [
+                "EC",
+                "AE",
+            ],
+            "IDVAR": [
+                "ECSEQ",
+                "AESEQ",
+            ],
+            "IDVARVAL": [
+                "",
+                "",
+            ],
+            "RELID": [
+                "ECAE",
+                "ECAE",
+            ],
+            "STUDYID": [
+                "1",
+                "1",
+            ],
+            "USUBJID": [
+                "",
+                "",
+            ],
+        }
+    )
+
+    # mock blob storage call
+    path_to_dataset_map: dict = {
+        os.path.join("path", "ae.xpt"): ae_dataset,
+        os.path.join("path", "relrec.xpt"): relrec_dataset,
+    }
+    mock_get_dataset.side_effect = lambda dataset_name: path_to_dataset_map[
+        dataset_name
+    ]
+
+    # call preprocessor
+    datasets: List[dict] = [
+        {"domain": "AE", "filename": "ae.xpt"},
+        {"domain": "RELREC", "filename": "relrec.xpt"},
+    ]
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    library_metadata = LibraryMetadataContainer(model_metadata={})
+    sdtm_utilities.get_all_model_wildcard_variables = MagicMock(
+        return_value=["--SEQ", "--STDY"]
+    )
+    # execute operation
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService(), library_metadata=library_metadata
+    )
+    preprocessor = DatasetPreprocessor(
+        ec_dataset,
+        "EC",
+        os.path.join("path", "ec.xpt"),
+        data_service,
+        InMemoryCacheService(),
+    )
+    preprocessed_dataset: pd.DataFrame = preprocessor.preprocess(relrec_rule, datasets)
+    expected_dataset = pd.DataFrame.from_dict(
+        {
+            "ECSEQ": ["1", "2", "3", "4"],
+            "ECSTDY": [4, 5, 6, 7],
+            "STUDYID": ["1", "2", "1", "2"],
+            "USUBJID": [
+                "CDISC001",
+                "CDISC001",
+                "CDISC002",
+                "CDISC002",
+            ],
+            "RELREC.__SEQ": ["1", "2", "3", "4"],
+            "RELREC.__STDY": [4, 5, 16, 17],
+            "RELREC.STUDYID": ["1", "2", "1", "2"],
+            "RELREC.USUBJID": [
+                "CDISC001",
+                "CDISC001",
+                "CDISC002",
+                "CDISC002",
             ],
         }
     )

--- a/tests/unit/test_rule.py
+++ b/tests/unit/test_rule.py
@@ -83,7 +83,7 @@ def test_valid_parse_actions():
     [
         (
             [{"Name": "AA", "Keys": ["USUBJID"]}],
-            [{"domain_name": "AA", "match_key": ["USUBJID"]}],
+            [{"domain_name": "AA", "match_key": ["USUBJID"], "wildcard": "**"}],
         ),
         (
             [{"Name": "SUPPEC", "Keys": ["USUBJID"], "Is_Relationship": True}],
@@ -95,6 +95,7 @@ def test_valid_parse_actions():
                         "column_with_names": "IDVAR",
                         "column_with_values": "IDVARVAL",
                     },
+                    "wildcard": "**",
                 }
             ],
         ),


### PR DESCRIPTION
Allows Match Datasets to use match information provided in a relrec.

Example given in test data and in attached data. In attached data, you can see a sample rule, test data, and result (with one negative result).
[CG0174.zip](https://github.com/cdisc-org/cdisc-rules-engine/files/12610341/CG0174.zip)

- Library model meta is required in order to find variables that should have wildcards.
- This update includes 2 bugfixes for library and caching
  1. The testrule endpoint dataservice was being created without the library metadata object
  2. The model metadata cache key was being extracted from the ig incorrectly (wrong indices)

```yaml
# Variable: FAOBJ
# Condition: Related record present in parent domain dataset
# Rule: FAOBJ in (--TERM, --TRT, --DECOD)
Check:
  all:
    - name: FAOBJ
      operator: not_equal_to
      value: RELREC.__TERM
    - name: FAOBJ
      operator: not_equal_to
      value: RELREC.__TRT
    - name: FAOBJ
      operator: not_equal_to
      value: RELREC.__DECOD
Match Datasets:
  - Name: RELREC
    Wildcard: __
```