### PR TITLE
Update operators to use dataset abstraction

### DIFF
--- a/cdisc_rules_engine/models/dataset/dask_dataset.py
+++ b/cdisc_rules_engine/models/dataset/dask_dataset.py
@@ -1,16 +1,83 @@
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+from typing import List
 
 
 class DaskDataset(PandasDataset):
-    def __init__(self, data):
+    def __init__(self, data=dd.from_pandas(pd.DataFrame(), npartitions=1)):
         self._data = data
 
     @property
     def data(self):
         return self._data
 
+    @data.setter
+    def data(self, data):
+        self._data = data
+
+    def __getitem__(self, item):
+        return self._data[item].compute()
+
+    def __setitem__(self, key, value):
+        if isinstance(value, list):
+            self._data[key] = dd.from_pandas(pd.Series(value), npartitions=1)
+        else:
+            self._data[key] = value
+
     @classmethod
-    def from_dict(cls, data: dict):
-        dataframe = dd.from_dict(data, npartitions=1)
+    def from_dict(cls, data: dict, **kwargs):
+        dataframe = dd.from_dict(data, npartitions=1, **kwargs)
         return cls(dataframe)
+
+    @classmethod
+    def from_records(cls, data: List[dict], **kwargs):
+        data = pd.DataFrame.from_records(data)
+        dataframe = dd.from_pandas(data, npartitions=1)
+        return cls(dataframe)
+
+    def get(self, column: str, default=None):
+        if column in self._data:
+            return self._data[column].compute()
+        return default
+
+    def __concat_columns(self, current, other):
+        for column in other.columns:
+            current[column] = other[column]
+        return current
+
+    def concat(self, other, **kwargs):
+        if kwargs.get("axis", 0) == 1:
+            if isinstance(other, list):
+                new_data = self._data.copy()
+                for dataset in other:
+                    new_data = self.__concat_columns(new_data, dataset)
+            else:
+                new_data = self.__concat_columns(self._data.copy(), other)
+        else:
+            if isinstance(other, list):
+                datasets = [dataset.data for dataset in other]
+                new_data = dd.concat([self._data] + datasets, **kwargs)
+            else:
+                new_data = dd.concat([self._data.copy(), other.data], **kwargs)
+
+        return self.__class__(new_data)
+
+    def groupby(self, by: List[str], **kwargs):
+        invalid_kwargs = ["as_index"]
+        for arg in invalid_kwargs:
+            del kwargs[arg]
+        return self._data.groupby(by, **kwargs)
+
+    def is_series(self, data) -> bool:
+        return isinstance(data, dd.Series)
+
+    def convert_to_series(self, result):
+        if self.is_series(result):
+            return result
+        elif isinstance(result, np.ndarray):
+            return dd.from_array(result)
+        elif isinstance(result, pd.Series):
+            return dd.from_pandas(result, npartitions=1)
+        return pd.Series(result)

--- a/cdisc_rules_engine/models/dataset/dataset_interface.py
+++ b/cdisc_rules_engine/models/dataset/dataset_interface.py
@@ -108,3 +108,9 @@ class DatasetInterface(ABC):
         """
         Create a series of a single value
         """
+
+    @abstractmethod
+    def len(self) -> int:
+        """
+        Return the length of the dataset
+        """

--- a/cdisc_rules_engine/models/dataset/dataset_interface.py
+++ b/cdisc_rules_engine/models/dataset/dataset_interface.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import List
 
 
 class DatasetInterface(ABC):
@@ -9,9 +10,101 @@ class DatasetInterface(ABC):
         Stores the underlying data for the dataset
         """
 
+    @property
+    @abstractmethod
+    def columns(self):
+        """
+        Stores the columns of the underlying dataset
+        """
+
     @classmethod
     @abstractmethod
-    def from_dict(self, data):
+    def from_dict(self, data: dict, **kwargs):
         """
         Create the underlying dataset from provided dictionary data
+        """
+
+    @classmethod
+    @abstractmethod
+    def from_records(self, data: List[dict], **kwargs):
+        """
+        Create the underlying dataset from provided list of records
+        """
+
+    @abstractmethod
+    def __getitem__(self, item: str):
+        """
+        Access dataset column by name
+        """
+
+    @abstractmethod
+    def __setitem__(self, key: str, data):
+        """
+        Set value of a dataset column
+        """
+
+    @abstractmethod
+    def __len__(self):
+        """
+        Get length of dataset
+        """
+
+    @abstractmethod
+    def __contains__(self, item: str) -> bool:
+        """
+        Return true if item is in dataset
+        """
+
+    @abstractmethod
+    def get(self, column: str, default=None):
+        """
+        Return column if column is in dataset, else return default
+        """
+
+    @abstractmethod
+    def groupby(self, by: List[str], **kwargs):
+        """
+        Group dataframe by list of columns.
+        """
+
+    @abstractmethod
+    def concat(self, other: "DatasetInterface", **kwargs):
+        """
+        Concat two datasets
+        """
+
+    @abstractmethod
+    def merge(self, other: "DatasetInterface", **kwargs):
+        """
+        merge two datasets
+        """
+
+    @abstractmethod
+    def apply(self, func, **kwargs):
+        """
+        Apply a function to a dataset
+        """
+
+    @abstractmethod
+    def iterrows(self):
+        """
+        Return iterator over all dataset rows
+        """
+
+    @abstractmethod
+    def is_series(self, data) -> bool:
+        """
+        Return true if the data is a series compatible with the underlying dataset
+        """
+
+    @abstractmethod
+    def convert_to_series(self, data):
+        """
+        Converts list like data to a series corresponding with the underlying dataset
+        """
+
+    @abstractmethod
+    def get_series_from_value(self, value):
+        """
+        Create a series of a single value
         """

--- a/cdisc_rules_engine/models/dataset/pandas_dataset.py
+++ b/cdisc_rules_engine/models/dataset/pandas_dataset.py
@@ -49,7 +49,7 @@ class PandasDataset(DatasetInterface):
         return default
 
     def groupby(self, by: List[str], **kwargs):
-        return self._data.groupby(by, **kwargs)
+        return self.__class__(self._data.groupby(by, **kwargs))
 
     def concat(self, other: Union[DatasetInterface, List[DatasetInterface]], **kwargs):
         if isinstance(other, list):
@@ -65,7 +65,7 @@ class PandasDataset(DatasetInterface):
         return self.__class__(new_data)
 
     def apply(self, func, **kwargs):
-        return self._data.apply(func, **kwargs)
+        return self._data.apply(func, **self._remove_invalid_kwargs(["meta"], kwargs))
 
     def iterrows(self):
         return self._data.iterrows()
@@ -82,3 +82,13 @@ class PandasDataset(DatasetInterface):
         if hasattr(result, "__iter__"):
             return pd.Series([result] * len(self._data), index=self._data.index)
         return pd.Series(result, index=self._data.index)
+
+    def _remove_invalid_kwargs(self, invalid_args, kwargs) -> dict:
+        for arg in invalid_args:
+            if arg in kwargs:
+                del kwargs[arg]
+
+        return kwargs
+
+    def len(self) -> int:
+        return self._data.shape[0]

--- a/cdisc_rules_engine/models/dataset/pandas_dataset.py
+++ b/cdisc_rules_engine/models/dataset/pandas_dataset.py
@@ -1,16 +1,84 @@
 from cdisc_rules_engine.models.dataset.dataset_interface import DatasetInterface
 import pandas as pd
+from typing import Union, List
 
 
 class PandasDataset(DatasetInterface):
-    def __init__(self, data: pd.DataFrame):
+    def __init__(self, data: pd.DataFrame = pd.DataFrame()):
         self._data = data
 
     @property
     def data(self):
         return self._data
 
+    @data.setter
+    def data(self, data):
+        self._data = data
+
+    @property
+    def columns(self):
+        return self._data.columns
+
     @classmethod
-    def from_dict(cls, data: dict):
-        dataframe = pd.DataFrame.from_dict(data)
+    def from_dict(cls, data: dict, **kwargs):
+        dataframe = pd.DataFrame.from_dict(data, **kwargs)
         return cls(dataframe)
+
+    @classmethod
+    def from_records(cls, data: List[dict], **kwargs):
+        dataframe = pd.DataFrame.from_records(data, **kwargs)
+        return cls(dataframe)
+
+    def __getitem__(
+        self, item: Union[str, List[str]]
+    ) -> Union[pd.Series, pd.DataFrame]:
+        return self._data[item]
+
+    def __setitem__(self, key, value: pd.Series):
+        self._data[key] = value
+
+    def __len__(self):
+        return len(self._data)
+
+    def __contains__(self, item: str) -> bool:
+        return item in self._data
+
+    def get(self, column: str, default=None):
+        if column in self._data:
+            return self._data[column]
+        return default
+
+    def groupby(self, by: List[str], **kwargs):
+        return self._data.groupby(by, **kwargs)
+
+    def concat(self, other: Union[DatasetInterface, List[DatasetInterface]], **kwargs):
+        if isinstance(other, list):
+            new_data = self._data.copy()
+            for dataset in other:
+                new_data = pd.concat([new_data, dataset.data], **kwargs)
+        else:
+            new_data = pd.concat([self._data, other.data], **kwargs)
+        return self.__class__(new_data)
+
+    def merge(self, other: DatasetInterface, **kwargs):
+        new_data = self._data.merge(other, **kwargs)
+        return self.__class__(new_data)
+
+    def apply(self, func, **kwargs):
+        return self._data.apply(func, **kwargs)
+
+    def iterrows(self):
+        return self._data.iterrows()
+
+    def is_series(self, data) -> bool:
+        return isinstance(data, pd.Series)
+
+    def convert_to_series(self, result):
+        if self.is_series(result):
+            return result
+        return pd.Series(result)
+
+    def get_series_from_value(self, result):
+        if hasattr(result, "__iter__"):
+            return pd.Series([result] * len(self._data), index=self._data.index)
+        return pd.Series(result, index=self._data.index)

--- a/cdisc_rules_engine/operations/day_data_validator.py
+++ b/cdisc_rules_engine/operations/day_data_validator.py
@@ -32,7 +32,7 @@ class DayDataValidator(BaseOperation):
         delta = (dtc_value - new_dataset[rfstdtc_value].map(self.parse_timestamp)).map(
             self.get_day_difference
         )
-        return delta.replace(np.nan, "")
+        return self.evaluation_dataset.convert_to_series(delta.replace(np.nan, ""))
 
     def parse_timestamp(self, timestamp: str) -> datetime:
         try:

--- a/cdisc_rules_engine/operations/distinct.py
+++ b/cdisc_rules_engine/operations/distinct.py
@@ -11,9 +11,18 @@ class Distinct(BaseOperation):
             result = set(data)
         else:
             grouped = self.params.dataframe.groupby(
-                self.params.grouping, as_index=False
+                self.params.grouping, as_index=False, group_keys=False
             )
-            result = grouped[self.params.target].agg(
-                lambda x: pd.Series([set(x.unique())])
-            )
+            if isinstance(self.params.dataframe.data, pd.DataFrame):
+                result = grouped[self.params.target].agg(self._unique_values_for_column)
+            else:
+                result = (
+                    grouped[self.params.target]
+                    .unique()
+                    .rename({self.params.target: self.params.operation_id})
+                )
+                result = result.apply(set).to_frame().reset_index()
         return result
+
+    def _unique_values_for_column(self, column):
+        return pd.Series({self.params.operation_id: set(column.unique())})

--- a/cdisc_rules_engine/operations/distinct.py
+++ b/cdisc_rules_engine/operations/distinct.py
@@ -12,7 +12,7 @@ class Distinct(BaseOperation):
         else:
             grouped = self.params.dataframe.groupby(
                 self.params.grouping, as_index=False, group_keys=False
-            )
+            ).data
             if isinstance(self.params.dataframe.data, pd.DataFrame):
                 result = grouped[self.params.target].agg(self._unique_values_for_column)
             else:

--- a/cdisc_rules_engine/operations/get_codelist_attributes.py
+++ b/cdisc_rules_engine/operations/get_codelist_attributes.py
@@ -59,7 +59,7 @@ class CodeListAttributes(BaseOperation):
         # -------------------------------------------------------------------
         cc_key = ct_data[ct_name].to_list()
         ct_list = ct_cache[(ct_cache[ct_name].isin(cc_key))]
-        ds_len = self.params.dataframe.data.shape[0]  # dataset length
+        ds_len = self.params.dataframe.len()
         result = pd.Series([ct_list[ct_attribute].values[0] for _ in range(ds_len)])
         return result
 

--- a/cdisc_rules_engine/operations/get_codelist_attributes.py
+++ b/cdisc_rules_engine/operations/get_codelist_attributes.py
@@ -59,7 +59,7 @@ class CodeListAttributes(BaseOperation):
         # -------------------------------------------------------------------
         cc_key = ct_data[ct_name].to_list()
         ct_list = ct_cache[(ct_cache[ct_name].isin(cc_key))]
-        ds_len = self.params.dataframe.shape[0]  # dataset length
+        ds_len = self.params.dataframe.data.shape[0]  # dataset length
         result = pd.Series([ct_list[ct_attribute].values[0] for _ in range(ds_len)])
         return result
 
@@ -140,7 +140,7 @@ class CodeListAttributes(BaseOperation):
         df = self.params.dataframe
 
         # add CT_PACKAGE column
-        df[ct_key] = df.apply(
+        df[ct_key] = df.data.apply(
             lambda row: "sdtmct-" + row[ct_version]
             if row[ct_target] is not None and row[ct_target] in ("CDISC", "CDISC CT")
             else row[ct_target] + "-" + row[ct_version],

--- a/cdisc_rules_engine/operations/label_referenced_variable_metadata.py
+++ b/cdisc_rules_engine/operations/label_referenced_variable_metadata.py
@@ -1,5 +1,4 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
-import pandas as pd
 
 
 class LabelReferencedVariableMetadata(BaseOperation):
@@ -10,14 +9,14 @@ class LabelReferencedVariableMetadata(BaseOperation):
         found in the column provided in self.params.target.
         """
         variables_metadata = self._get_variables_metadata_from_standard()
-        df = pd.DataFrame(variables_metadata).add_prefix(f"{self.params.operation_id}_")
-        return (
+        df = self.evaluation_dataset.__class__.from_records(variables_metadata)
+        df.data = df.data.add_prefix(f"{self.params.operation_id}_")
+        target_columns = df.columns
+        return self.evaluation_dataset.__class__(
             df.merge(
-                self.evaluation_dataset,
+                self.evaluation_dataset.data,
                 left_on=f"{self.params.operation_id}_label",
                 right_on=self.params.target,
                 how="right",
-            )
-            .filter(like=self.params.operation_id, axis=1)
-            .fillna("")
+            ).data.fillna("")[target_columns]
         )

--- a/cdisc_rules_engine/operations/max_date.py
+++ b/cdisc_rules_engine/operations/max_date.py
@@ -14,5 +14,5 @@ class MaxDate(BaseOperation):
         else:
             result = self.params.dataframe.groupby(
                 self.params.grouping, as_index=False
-            ).max()
+            ).data.max()
         return result

--- a/cdisc_rules_engine/operations/maximum.py
+++ b/cdisc_rules_engine/operations/maximum.py
@@ -8,5 +8,5 @@ class Maximum(BaseOperation):
         else:
             result = self.params.dataframe.groupby(
                 self.params.grouping, as_index=False
-            ).max()
+            ).data.max()
         return result

--- a/cdisc_rules_engine/operations/mean.py
+++ b/cdisc_rules_engine/operations/mean.py
@@ -8,5 +8,5 @@ class Mean(BaseOperation):
         else:
             result = self.params.dataframe.groupby(
                 self.params.grouping, as_index=False
-            ).mean()
+            ).data.mean()
         return result

--- a/cdisc_rules_engine/operations/meddra_code_references_validator.py
+++ b/cdisc_rules_engine/operations/meddra_code_references_validator.py
@@ -32,4 +32,4 @@ class MedDRACodeReferencesValidator(BaseOperation):
             "/".join, axis=1
         )
         result = self.params.dataframe[column].isin(valid_code_hierarchies)
-        return result
+        return self.evaluation_dataset.convert_to_series(result)

--- a/cdisc_rules_engine/operations/meddra_code_term_pairs_validator.py
+++ b/cdisc_rules_engine/operations/meddra_code_term_pairs_validator.py
@@ -29,7 +29,7 @@ class MedDRACodeTermPairsValidator(BaseOperation):
             )
         )
         result = self.params.dataframe[column].isin(valid_code_term_pairs[term_type])
-        return result
+        return self.evaluation_dataset.convert_to_series(result)
 
     def _get_columns_by_meddra_variable_name(
         self,

--- a/cdisc_rules_engine/operations/meddra_term_references_validator.py
+++ b/cdisc_rules_engine/operations/meddra_term_references_validator.py
@@ -32,4 +32,4 @@ class MedDRATermReferencesValidator(BaseOperation):
             "/".join, axis=1
         )
         result = self.params.dataframe[column].isin(valid_term_hierarchies)
-        return result
+        return self.evaluation_dataset.convert_to_series(result)

--- a/cdisc_rules_engine/operations/minimum.py
+++ b/cdisc_rules_engine/operations/minimum.py
@@ -8,5 +8,5 @@ class Minimum(BaseOperation):
         else:
             result = self.params.dataframe.groupby(
                 self.params.grouping, as_index=False
-            ).min()
+            ).data.min()
         return result

--- a/cdisc_rules_engine/operations/name_referenced_variable_metadata.py
+++ b/cdisc_rules_engine/operations/name_referenced_variable_metadata.py
@@ -1,5 +1,4 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
-import pandas as pd
 
 
 class NameReferencedVariableMetadata(BaseOperation):
@@ -10,14 +9,14 @@ class NameReferencedVariableMetadata(BaseOperation):
         found in the column provided in self.params.target.
         """
         variables_metadata = self._get_variables_metadata_from_standard()
-        df = pd.DataFrame(variables_metadata).add_prefix(f"{self.params.operation_id}_")
-        return (
+        df = self.evaluation_dataset.__class__.from_records(variables_metadata)
+        df.data = df.data.add_prefix(f"{self.params.operation_id}_")
+        target_columns = df.columns
+        return self.evaluation_dataset.__class__(
             df.merge(
-                self.evaluation_dataset,
+                self.evaluation_dataset.data,
                 left_on=f"{self.params.operation_id}_name",
                 right_on=self.params.target,
                 how="right",
-            )
-            .filter(like=self.params.operation_id, axis=1)
-            .fillna("")
+            ).data.fillna("")[target_columns]
         )

--- a/cdisc_rules_engine/operations/parent_library_model_column_order.py
+++ b/cdisc_rules_engine/operations/parent_library_model_column_order.py
@@ -21,13 +21,15 @@ class ParentLibraryModelColumnOrder(LibraryModelColumnOrder):
         """
         domain_to_datasets = self._get_domain_to_datasets()
         rdomain_names_list = {}
-        return Series(
-            rdomain_names_list.setdefault(
-                rdomain,
-                self._get_parent_variable_names_list(domain_to_datasets, rdomain),
-            )
-            for rdomain in self.params.dataframe.get(
-                "RDOMAIN", [None] * len(self.params.dataframe)
+        return self.evaluation_dataset.convert_to_series(
+            Series(
+                rdomain_names_list.setdefault(
+                    rdomain,
+                    self._get_parent_variable_names_list(domain_to_datasets, rdomain),
+                )
+                for rdomain in self.params.dataframe.get(
+                    "RDOMAIN", [None] * len(self.params.dataframe)
+                )
             )
         )
 

--- a/cdisc_rules_engine/operations/whodrug_hierarchy_validator.py
+++ b/cdisc_rules_engine/operations/whodrug_hierarchy_validator.py
@@ -30,7 +30,7 @@ class WhodrugHierarchyValidator(BaseOperation):
             "/".join, axis=1
         )
         result = self.params.dataframe[column].isin(valid_code_hierarchies)
-        return result
+        return self.evaluation_dataset.convert_to_series(result)
 
     def get_code_hierarchies(self, term_map: dict) -> Set[str]:
         valid_codes = set()

--- a/cdisc_rules_engine/operations/whodrug_references_validator.py
+++ b/cdisc_rules_engine/operations/whodrug_references_validator.py
@@ -20,4 +20,4 @@ class WhodrugReferencesValidator(BaseOperation):
             term.code for term in terms[WhodrugRecordTypes.ATC_TEXT.value].values()
         )
         result = self.params.dataframe[self.params.target].isin(valid_codes)
-        return result
+        return self.evaluation_dataset.convert_to_series(result)

--- a/tests/unit/test_operations/test_dataset_column_order.py
+++ b/tests/unit/test_operations/test_dataset_column_order.py
@@ -1,16 +1,20 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 
 from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.dataset_column_order import DatasetColumnOrder
+import pytest
 
 
-def test_get_column_order_from_dataset(operation_params: OperationParams):
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_get_column_order_from_dataset(operation_params: OperationParams, dataset_type):
     """
     Unit test for DataProcessor.get_column_order_from_dataset.
     """
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "CDISC01",

--- a/tests/unit/test_operations/test_day_data_validtor.py
+++ b/tests/unit/test_operations/test_day_data_validtor.py
@@ -1,8 +1,9 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.operations.day_data_validator import DayDataValidator
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
 import pytest
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 
@@ -11,20 +12,18 @@ from cdisc_rules_engine.services.cache.cache_service_factory import CacheService
     "data, expected",
     [
         (
-            pd.DataFrame.from_dict(
-                {
-                    "values": [
-                        "1997-07-19T19:20:30",
-                        "1997-08-16T19:20:30",
-                        "1997-07-16T19:20",
-                        "2022-05-20T13:44",
-                        "2022-05-20T13:44",
-                        None,
-                        "2022-05-19T13:44",
-                    ],
-                    "USUBJID": [1, 2, 3, 4, 5, 6, 7],
-                }
-            ),
+            {
+                "values": [
+                    "1997-07-19T19:20:30",
+                    "1997-08-16T19:20:30",
+                    "1997-07-16T19:20",
+                    "2022-05-20T13:44",
+                    "2022-05-20T13:44",
+                    None,
+                    "2022-05-19T13:44",
+                ],
+                "USUBJID": [1, 2, 3, 4, 5, 6, 7],
+            },
             [4, 32, 1, 13, "", "", -1],
         ),
     ],
@@ -35,7 +34,7 @@ def test_day_data_calculation(
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     datasets_map = {
-        "dm.xpt": pd.DataFrame.from_dict(
+        "dm.xpt": PandasDataset.from_dict(
             {
                 "RFSTDTC": [
                     "1997-07-16T19:20:30",
@@ -57,10 +56,68 @@ def test_day_data_calculation(
         name.split("/")[-1]
     )
     operation_params.datasets = datasets
-    operation_params.dataframe = data
+    operation_params.dataframe = PandasDataset.from_dict(data)
     operation_params.target = "values"
     result = DayDataValidator(
-        operation_params, data, cache, mock_data_service
+        operation_params, PandasDataset.from_dict(data), cache, mock_data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    for i, val in enumerate(result[operation_params.operation_id]):
+        assert val == expected[i]
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            {
+                "values": [
+                    "1997-07-19T19:20:30",
+                    "1997-08-16T19:20:30",
+                    "1997-07-16T19:20",
+                    "2022-05-20T13:44",
+                    "2022-05-20T13:44",
+                    None,
+                    "2022-05-19T13:44",
+                ],
+                "USUBJID": [1, 2, 3, 4, 5, 6, 7],
+            },
+            [4, 32, 1, 13, "", "", -1],
+        ),
+    ],
+)
+def test_day_data_calculation_dask(
+    data, expected, mock_data_service, operation_params: OperationParams
+):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    datasets_map = {
+        "dm.xpt": DaskDataset.from_dict(
+            {
+                "RFSTDTC": [
+                    "1997-07-16T19:20:30",
+                    "1997-07-16T19:20:30",
+                    "1997-07-16T19:20",
+                    "2022-05-08T13:44",
+                    "TEST",
+                    "2022-05-20T13:44",
+                    "2022-05-20T13:44",
+                ],
+                "USUBJID": [1, 2, 3, 4, 5, 6, 7],
+            }
+        )
+    }
+    datasets = [
+        {"domain": "DM", "filename": "dm.xpt"},
+    ]
+    mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
+        name.split("/")[-1]
+    )
+    operation_params.datasets = datasets
+    operation_params.dataframe = DaskDataset.from_dict(data)
+    operation_params.target = "values"
+    result = DayDataValidator(
+        operation_params, DaskDataset.from_dict(data), cache, mock_data_service
     ).execute()
     assert operation_params.operation_id in result
     for i, val in enumerate(result[operation_params.operation_id]):

--- a/tests/unit/test_operations/test_define_variable_metadata.py
+++ b/tests/unit/test_operations/test_define_variable_metadata.py
@@ -11,9 +11,12 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
 )
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+import pytest
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_get_define_variable_metadata_variable_in_domain(
+    dataset_type,
     operation_params: OperationParams,
 ):
     config = ConfigService()
@@ -25,14 +28,16 @@ def test_get_define_variable_metadata_variable_in_domain(
     operation_params.target = "--SER"
     operation_params.attribute_name = "define_variable_ccode"
     result = DefineVariableMetadata(
-        operation_params, PandasDataset.from_dict({"A": [1, 2, 3]}), cache, data_service
+        operation_params, dataset_type.from_dict({"A": [1, 2, 3]}), cache, data_service
     ).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:
         val == "C49487"
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_get_define_variable_metadata_variable_not_in_domain(
+    dataset_type,
     operation_params: OperationParams,
 ):
     config = ConfigService()
@@ -44,45 +49,7 @@ def test_get_define_variable_metadata_variable_not_in_domain(
     operation_params.target = "VERYFAKEVARIABLE"
     operation_params.attribute_name = "define_variable_ccode"
     result = DefineVariableMetadata(
-        operation_params, PandasDataset.from_dict({"A": [1, 2, 3]}), cache, data_service
-    ).execute()
-    assert operation_params.operation_id in result
-    for val in result[operation_params.operation_id]:
-        val == ""
-
-
-def test_get_define_variable_metadata_dask_variable_in_domain(
-    operation_params: OperationParams,
-):
-    config = ConfigService()
-    cache = CacheServiceFactory(config).get_cache_service()
-    data_service = DataServiceFactory(config, cache).get_data_service()
-    resources_path: Path = Path(__file__).parent.parent.parent.joinpath("resources")
-    operation_params.directory_path = str(resources_path)
-    operation_params.domain = "AE"
-    operation_params.target = "--SER"
-    operation_params.attribute_name = "define_variable_ccode"
-    result = DefineVariableMetadata(
-        operation_params, DaskDataset.from_dict({"A": [1, 2, 3]}), cache, data_service
-    ).execute()
-    assert operation_params.operation_id in result
-    for val in result[operation_params.operation_id]:
-        val == "C49487"
-
-
-def test_get_define_variable_metadata_dask_variable_not_in_domain(
-    operation_params: OperationParams,
-):
-    config = ConfigService()
-    cache = CacheServiceFactory(config).get_cache_service()
-    data_service = DataServiceFactory(config, cache).get_data_service()
-    resources_path: Path = Path(__file__).parent.parent.parent.joinpath("resources")
-    operation_params.directory_path = str(resources_path)
-    operation_params.domain = "AE"
-    operation_params.target = "VERYFAKEVARIABLE"
-    operation_params.attribute_name = "define_variable_ccode"
-    result = DefineVariableMetadata(
-        operation_params, DaskDataset.from_dict({"A": [1, 2, 3]}), cache, data_service
+        operation_params, dataset_type.from_dict({"A": [1, 2, 3]}), cache, data_service
     ).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:

--- a/tests/unit/test_operations/test_define_variable_metadata.py
+++ b/tests/unit/test_operations/test_define_variable_metadata.py
@@ -1,6 +1,6 @@
-import pandas as pd
 from cdisc_rules_engine.config.config import ConfigService
 from pathlib import Path
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.operations.define_variable_metadata import (
     DefineVariableMetadata,
 )
@@ -10,6 +10,7 @@ from cdisc_rules_engine.services.cache.cache_service_factory import CacheService
 from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
 )
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 
 
 def test_get_define_variable_metadata_variable_in_domain(
@@ -24,7 +25,7 @@ def test_get_define_variable_metadata_variable_in_domain(
     operation_params.target = "--SER"
     operation_params.attribute_name = "define_variable_ccode"
     result = DefineVariableMetadata(
-        operation_params, pd.DataFrame.from_dict({"A": [1, 2, 3]}), cache, data_service
+        operation_params, PandasDataset.from_dict({"A": [1, 2, 3]}), cache, data_service
     ).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:
@@ -43,7 +44,45 @@ def test_get_define_variable_metadata_variable_not_in_domain(
     operation_params.target = "VERYFAKEVARIABLE"
     operation_params.attribute_name = "define_variable_ccode"
     result = DefineVariableMetadata(
-        operation_params, pd.DataFrame.from_dict({"A": [1, 2, 3]}), cache, data_service
+        operation_params, PandasDataset.from_dict({"A": [1, 2, 3]}), cache, data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        val == ""
+
+
+def test_get_define_variable_metadata_dask_variable_in_domain(
+    operation_params: OperationParams,
+):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    resources_path: Path = Path(__file__).parent.parent.parent.joinpath("resources")
+    operation_params.directory_path = str(resources_path)
+    operation_params.domain = "AE"
+    operation_params.target = "--SER"
+    operation_params.attribute_name = "define_variable_ccode"
+    result = DefineVariableMetadata(
+        operation_params, DaskDataset.from_dict({"A": [1, 2, 3]}), cache, data_service
+    ).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        val == "C49487"
+
+
+def test_get_define_variable_metadata_dask_variable_not_in_domain(
+    operation_params: OperationParams,
+):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    resources_path: Path = Path(__file__).parent.parent.parent.joinpath("resources")
+    operation_params.directory_path = str(resources_path)
+    operation_params.domain = "AE"
+    operation_params.target = "VERYFAKEVARIABLE"
+    operation_params.attribute_name = "define_variable_ccode"
+    result = DefineVariableMetadata(
+        operation_params, DaskDataset.from_dict({"A": [1, 2, 3]}), cache, data_service
     ).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:

--- a/tests/unit/test_operations/test_distinct.py
+++ b/tests/unit/test_operations/test_distinct.py
@@ -1,9 +1,10 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.distinct import Distinct
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
-import pytest
 
+import pytest
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
@@ -14,7 +15,11 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
     "data, expected",
     [
         (
-            pd.DataFrame.from_dict({"values": [11, 12, 12, 5, 18, 9]}),
+            PandasDataset.from_dict({"values": [11, 12, 12, 5, 18, 9]}),
+            {5, 9, 11, 12, 18},
+        ),
+        (
+            DaskDataset.from_dict({"values": [11, 12, 12, 5, 18, 9]}),
             {5, 9, 11, 12, 18},
         ),
     ],
@@ -36,7 +41,13 @@ def test_distinct(data, expected, operation_params: OperationParams):
     "data, expected",
     [
         (
-            pd.DataFrame.from_dict(
+            PandasDataset.from_dict(
+                {"values": [11, 12, 12, 5, 18, 9], "patient": [1, 2, 2, 1, 2, 1]}
+            ),
+            {1: {5, 9, 11}, 2: {12, 18}},
+        ),
+        (
+            DaskDataset.from_dict(
                 {"values": [11, 12, 12, 5, 18, 9], "patient": [1, 2, 2, 1, 2, 1]}
             ),
             {1: {5, 9, 11}, 2: {12, 18}},

--- a/tests/unit/test_operations/test_domain_is_custom.py
+++ b/tests/unit/test_operations/test_domain_is_custom.py
@@ -1,10 +1,11 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.dataset_interface import DatasetInterface
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
 import pytest
-import pandas as pd
-
 from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.domain_is_custom import DomainIsCustom
 from cdisc_rules_engine.services.cache import InMemoryCacheService
@@ -15,7 +16,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
     "dataframe, domain, standard, standard_version, expected",
     [
         (
-            pd.DataFrame.from_dict(
+            PandasDataset.from_dict(
                 {
                     "STUDYID": [
                         "TEST_STUDY",
@@ -35,7 +36,27 @@ from cdisc_rules_engine.services.data_services import LocalDataService
             False,
         ),
         (
-            pd.DataFrame.from_dict(
+            DaskDataset.from_dict(
+                {
+                    "STUDYID": [
+                        "TEST_STUDY",
+                        "TEST_STUDY",
+                        "TEST_STUDY",
+                    ],
+                    "AETERM": [
+                        "test",
+                        "test",
+                        "test",
+                    ],
+                }
+            ),
+            "AE",
+            "sdtmig",
+            "3-4",
+            False,
+        ),
+        (
+            PandasDataset.from_dict(
                 {
                     "STUDYID": [
                         "TEST_STUDY",
@@ -58,7 +79,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
 )
 def test_domain_is_custom(
     operation_params: OperationParams,
-    dataframe: pd.DataFrame,
+    dataframe: DatasetInterface,
     domain: str,
     standard: str,
     standard_version: str,
@@ -85,7 +106,7 @@ def test_domain_is_custom(
         data_service,
         library_metadata,
     )
-    result: pd.DataFrame = operation.execute()
+    result = operation.execute()
     assert result[operation_params.operation_id].equals(
-        pd.Series([expected, expected, expected])
+        dataframe.convert_to_series([expected, expected, expected])
     )

--- a/tests/unit/test_operations/test_domain_label.py
+++ b/tests/unit/test_operations/test_domain_label.py
@@ -9,9 +9,11 @@ from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.domain_label import DomainLabel
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
+import pytest
 
 
-def test_get_domain_label_from_library(operation_params: OperationParams):
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_get_domain_label_from_library(dataset_type, operation_params: OperationParams):
     standard_metadata = {
         "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
         "classes": [
@@ -30,7 +32,7 @@ def test_get_domain_label_from_library(operation_params: OperationParams):
             }
         ],
     }
-    operation_params.dataframe = PandasDataset.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -73,7 +75,9 @@ def test_get_domain_label_from_library(operation_params: OperationParams):
     assert result[operation_params.operation_id].equals(expected)
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_get_domain_label_from_library_domain_not_found(
+    dataset_type,
     operation_params: OperationParams,
 ):
     standard_metadata = {
@@ -94,7 +98,7 @@ def test_get_domain_label_from_library_domain_not_found(
             }
         ],
     }
-    operation_params.dataframe = PandasDataset.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -138,7 +142,9 @@ def test_get_domain_label_from_library_domain_not_found(
     assert result[operation_params.operation_id].equals(expected)
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_get_domain_label_from_library_domain_missing_label(
+    dataset_type,
     operation_params: OperationParams,
 ):
     standard_metadata = {
@@ -158,198 +164,7 @@ def test_get_domain_label_from_library_domain_missing_label(
             }
         ],
     }
-    operation_params.dataframe = PandasDataset.from_dict(
-        {
-            "STUDYID": [
-                "TEST_STUDY",
-                "TEST_STUDY",
-                "TEST_STUDY",
-            ],
-            "AETERM": [
-                "test",
-                "test",
-                "test",
-            ],
-        }
-    )
-    operation_params.domain = "AE"
-    operation_params.standard = "sdtmig"
-    operation_params.standard_version = "3-4"
-
-    # save model metadata to cache
-    cache = InMemoryCacheService.get_instance()
-    # execute operation
-    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
-    # execute operation
-    data_service = LocalDataService.get_instance(
-        cache_service=cache, config=ConfigService()
-    )
-    operation = DomainLabel(
-        operation_params,
-        operation_params.dataframe,
-        cache,
-        data_service,
-        library_metadata,
-    )
-    result = operation.execute()
-    expected: pd.Series = pd.Series(
-        [
-            "",
-            "",
-            "",
-        ]
-    )
-    assert result[operation_params.operation_id].equals(expected)
-
-
-def test_get_domain_label_from_library_dask(operation_params: OperationParams):
-    standard_metadata = {
-        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
-        "classes": [
-            {
-                "name": "Events",
-                "datasets": [
-                    {
-                        "name": "AE",
-                        "label": "Adverse Events",
-                        "datasetVariables": [
-                            {"name": "AETEST", "ordinal": 1},
-                            {"name": "AENEW", "ordinal": 2},
-                        ],
-                    }
-                ],
-            }
-        ],
-    }
-    operation_params.dataframe = DaskDataset.from_dict(
-        {
-            "STUDYID": [
-                "TEST_STUDY",
-                "TEST_STUDY",
-                "TEST_STUDY",
-            ],
-            "AETERM": [
-                "test",
-                "test",
-                "test",
-            ],
-        }
-    )
-    operation_params.domain = "AE"
-    operation_params.standard = "sdtmig"
-    operation_params.standard_version = "3-4"
-
-    # save model metadata to cache
-    cache = InMemoryCacheService.get_instance()
-    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
-    # execute operation
-    data_service = LocalDataService.get_instance(
-        cache_service=cache, config=ConfigService()
-    )
-    operation = DomainLabel(
-        operation_params,
-        operation_params.dataframe,
-        cache,
-        data_service,
-        library_metadata,
-    )
-    result = operation.execute()
-    expected: pd.Series = pd.Series(
-        [
-            "Adverse Events",
-            "Adverse Events",
-            "Adverse Events",
-        ]
-    )
-    assert result[operation_params.operation_id].equals(expected)
-
-
-def test_get_domain_label_from_library_domain_not_found_dask(
-    operation_params: OperationParams,
-):
-    standard_metadata = {
-        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
-        "classes": [
-            {
-                "name": "Events",
-                "datasets": [
-                    {
-                        "name": "AE",
-                        "label": "Adverse Events",
-                        "datasetVariables": [
-                            {"name": "AETEST", "ordinal": 1},
-                            {"name": "AENEW", "ordinal": 2},
-                        ],
-                    }
-                ],
-            }
-        ],
-    }
-    operation_params.dataframe = DaskDataset.from_dict(
-        {
-            "STUDYID": [
-                "TEST_STUDY",
-                "TEST_STUDY",
-                "TEST_STUDY",
-            ],
-            "AETERM": [
-                "test",
-                "test",
-                "test",
-            ],
-        }
-    )
-    operation_params.domain = "VS"
-    operation_params.standard = "sdtmig"
-    operation_params.standard_version = "3-4"
-
-    # save model metadata to cache
-    cache = InMemoryCacheService.get_instance()
-    # execute operation
-    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
-    # execute operation
-    data_service = LocalDataService.get_instance(
-        cache_service=cache, config=ConfigService()
-    )
-    operation = DomainLabel(
-        operation_params,
-        operation_params.dataframe,
-        cache,
-        data_service,
-        library_metadata,
-    )
-    result = operation.execute()
-    expected: pd.Series = pd.Series(
-        [
-            "",
-            "",
-            "",
-        ]
-    )
-    assert result[operation_params.operation_id].equals(expected)
-
-
-def test_get_domain_label_from_library_domain_missing_label_dask(
-    operation_params: OperationParams,
-):
-    standard_metadata = {
-        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
-        "classes": [
-            {
-                "name": "Events",
-                "datasets": [
-                    {
-                        "name": "AE",
-                        "datasetVariables": [
-                            {"name": "AETEST", "ordinal": 1},
-                            {"name": "AENEW", "ordinal": 2},
-                        ],
-                    }
-                ],
-            }
-        ],
-    }
-    operation_params.dataframe = DaskDataset.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_domain_label.py
+++ b/tests/unit/test_operations/test_domain_label.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
@@ -28,7 +30,7 @@ def test_get_domain_label_from_library(operation_params: OperationParams):
             }
         ],
     }
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = PandasDataset.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -60,7 +62,7 @@ def test_get_domain_label_from_library(operation_params: OperationParams):
         data_service,
         library_metadata,
     )
-    result: pd.DataFrame = operation.execute()
+    result = operation.execute()
     expected: pd.Series = pd.Series(
         [
             "Adverse Events",
@@ -92,7 +94,7 @@ def test_get_domain_label_from_library_domain_not_found(
             }
         ],
     }
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = PandasDataset.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -125,7 +127,7 @@ def test_get_domain_label_from_library_domain_not_found(
         data_service,
         library_metadata,
     )
-    result: pd.DataFrame = operation.execute()
+    result = operation.execute()
     expected: pd.Series = pd.Series(
         [
             "",
@@ -156,7 +158,7 @@ def test_get_domain_label_from_library_domain_missing_label(
             }
         ],
     }
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = PandasDataset.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -189,7 +191,198 @@ def test_get_domain_label_from_library_domain_missing_label(
         data_service,
         library_metadata,
     )
-    result: pd.DataFrame = operation.execute()
+    result = operation.execute()
+    expected: pd.Series = pd.Series(
+        [
+            "",
+            "",
+            "",
+        ]
+    )
+    assert result[operation_params.operation_id].equals(expected)
+
+
+def test_get_domain_label_from_library_dask(operation_params: OperationParams):
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1},
+                            {"name": "AENEW", "ordinal": 2},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    operation_params.dataframe = DaskDataset.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.domain = "AE"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
+    # execute operation
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
+    operation = DomainLabel(
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
+    )
+    result = operation.execute()
+    expected: pd.Series = pd.Series(
+        [
+            "Adverse Events",
+            "Adverse Events",
+            "Adverse Events",
+        ]
+    )
+    assert result[operation_params.operation_id].equals(expected)
+
+
+def test_get_domain_label_from_library_domain_not_found_dask(
+    operation_params: OperationParams,
+):
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1},
+                            {"name": "AENEW", "ordinal": 2},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    operation_params.dataframe = DaskDataset.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.domain = "VS"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    # execute operation
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
+    # execute operation
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
+    operation = DomainLabel(
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
+    )
+    result = operation.execute()
+    expected: pd.Series = pd.Series(
+        [
+            "",
+            "",
+            "",
+        ]
+    )
+    assert result[operation_params.operation_id].equals(expected)
+
+
+def test_get_domain_label_from_library_domain_missing_label_dask(
+    operation_params: OperationParams,
+):
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1},
+                            {"name": "AENEW", "ordinal": 2},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    operation_params.dataframe = DaskDataset.from_dict(
+        {
+            "STUDYID": [
+                "TEST_STUDY",
+                "TEST_STUDY",
+                "TEST_STUDY",
+            ],
+            "AETERM": [
+                "test",
+                "test",
+                "test",
+            ],
+        }
+    )
+    operation_params.domain = "AE"
+    operation_params.standard = "sdtmig"
+    operation_params.standard_version = "3-4"
+
+    # save model metadata to cache
+    cache = InMemoryCacheService.get_instance()
+    # execute operation
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata)
+    # execute operation
+    data_service = LocalDataService.get_instance(
+        cache_service=cache, config=ConfigService()
+    )
+    operation = DomainLabel(
+        operation_params,
+        operation_params.dataframe,
+        cache,
+        data_service,
+        library_metadata,
+    )
+    result = operation.execute()
     expected: pd.Series = pd.Series(
         [
             "",

--- a/tests/unit/test_operations/test_expected_variables.py
+++ b/tests/unit/test_operations/test_expected_variables.py
@@ -1,5 +1,6 @@
 from typing import List
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
@@ -14,86 +15,80 @@ from cdisc_rules_engine.operations.expected_variables import ExpectedVariables
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
 
-
-@pytest.mark.parametrize(
-    "model_metadata, standard_metadata",
-    [
-        (
-            {
-                "datasets": [
-                    {
-                        "name": "AE",
-                        "datasetVariables": [
-                            {
-                                "name": "AETERM",
-                                "ordinal": 4,
-                            },
-                            {
-                                "name": "AESEQ",
-                                "ordinal": 3,
-                            },
-                        ],
-                    }
-                ],
-                "classes": [
-                    {
-                        "name": "Events",
-                        "classVariables": [
-                            {"name": "--TERM", "ordinal": 1},
-                            {"name": "--SEQ", "ordinal": 2},
-                        ],
-                    },
-                    {
-                        "name": GENERAL_OBSERVATIONS_CLASS,
-                        "classVariables": [
-                            {
-                                "name": "DOMAIN",
-                                "role": VariableRoles.IDENTIFIER.value,
-                                "ordinal": 2,
-                            },
-                            {
-                                "name": "STUDYID",
-                                "role": VariableRoles.IDENTIFIER.value,
-                                "ordinal": 1,
-                            },
-                            {
-                                "name": "TIMING_VAR",
-                                "role": VariableRoles.TIMING.value,
-                                "ordinal": 33,
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
-                "classes": [
-                    {
-                        "name": "Events",
-                        "datasets": [
-                            {
-                                "name": "AE",
-                                "label": "Adverse Events",
-                                "datasetVariables": [
-                                    {"name": "AETEST", "ordinal": 1, "core": "Req"},
-                                    {"name": "AENEW", "ordinal": 2, "core": "Exp"},
-                                ],
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
+model_metadata = {
+    "datasets": [
+        {
+            "name": "AE",
+            "datasetVariables": [
+                {
+                    "name": "AETERM",
+                    "ordinal": 4,
+                },
+                {
+                    "name": "AESEQ",
+                    "ordinal": 3,
+                },
+            ],
+        }
     ],
-)
-def test_get_expected_variables(
-    operation_params: OperationParams, model_metadata: dict, standard_metadata: dict
-):
+    "classes": [
+        {
+            "name": "Events",
+            "classVariables": [
+                {"name": "--TERM", "ordinal": 1},
+                {"name": "--SEQ", "ordinal": 2},
+            ],
+        },
+        {
+            "name": GENERAL_OBSERVATIONS_CLASS,
+            "classVariables": [
+                {
+                    "name": "DOMAIN",
+                    "role": VariableRoles.IDENTIFIER.value,
+                    "ordinal": 2,
+                },
+                {
+                    "name": "STUDYID",
+                    "role": VariableRoles.IDENTIFIER.value,
+                    "ordinal": 1,
+                },
+                {
+                    "name": "TIMING_VAR",
+                    "role": VariableRoles.TIMING.value,
+                    "ordinal": 33,
+                },
+            ],
+        },
+    ],
+}
+
+standard_metadata = {
+    "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+    "classes": [
+        {
+            "name": "Events",
+            "datasets": [
+                {
+                    "name": "AE",
+                    "label": "Adverse Events",
+                    "datasetVariables": [
+                        {"name": "AETEST", "ordinal": 1, "core": "Req"},
+                        {"name": "AENEW", "ordinal": 2, "core": "Exp"},
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_get_expected_variables(operation_params: OperationParams, dataset_type):
     """
     Unit test for DataProcessor.get_column_order_from_library.
     Mocks cache call to return metadata.
     """
-    operation_params.dataframe = PandasDataset.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_expected_variables.py
+++ b/tests/unit/test_operations/test_expected_variables.py
@@ -1,9 +1,9 @@
 from typing import List
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
-
 import pandas as pd
 import pytest
 
@@ -93,7 +93,7 @@ def test_get_expected_variables(
     Unit test for DataProcessor.get_column_order_from_library.
     Mocks cache call to return metadata.
     """
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = PandasDataset.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -127,7 +127,7 @@ def test_get_expected_variables(
         data_service,
         library_metadata,
     )
-    result: pd.DataFrame = operation.execute()
+    result = operation.execute()
     variables: List[str] = ["AENEW"]
     expected: pd.Series = pd.Series(
         [

--- a/tests/unit/test_operations/test_extract_metadata.py
+++ b/tests/unit/test_operations/test_extract_metadata.py
@@ -1,17 +1,23 @@
 import pandas as pd
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.extract_metadata import ExtractMetadata
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
 from unittest.mock import Mock
+import pytest
 
 
-def test_extract_metadata_get_dataset_name(operation_params: OperationParams):
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_extract_metadata_get_dataset_name(
+    operation_params: OperationParams, dataset_type
+):
     mock_data_service = Mock(LocalDataService)
     mock_data_service.get_dataset_metadata.return_value = pd.DataFrame.from_dict(
         {"dataset_name": ["AE"]}
     )
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_get_codelist_attributes.py
+++ b/tests/unit/test_operations/test_get_codelist_attributes.py
@@ -1,4 +1,5 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
@@ -40,6 +41,7 @@ test_set1 = (
             "C141663": {"extensible": False, "allowed_terms": []},
         },
     ],
+    PandasDataset,
     {"C141663", "C25473", "C49487"},
 )
 
@@ -73,18 +75,20 @@ test_set2 = (
             "C141663": {"extensible": False, "allowed_terms": []},
         },
     ],
+    DaskDataset,
     {"C141656", "C141663", "C141657"},
 )
 
 
 @pytest.mark.parametrize(
-    "ct_packages, ts_data, ct_data, ct_list", [test_set1, test_set2]
+    "ct_packages, ts_data, ct_data, dataset_type, ct_list", [test_set1, test_set2]
 )
 def test_get_codelist_attributes(
     operation_params: OperationParams,
     ct_packages,
     ts_data: dict,
     ct_data: list,
+    dataset_type,
     ct_list,
 ):
     """
@@ -92,7 +96,7 @@ def test_get_codelist_attributes(
     Mocks cache call to return metadata.
     """
     # 1.0 set parameters
-    operation_params.dataframe = PandasDataset.from_dict(ts_data)
+    operation_params.dataframe = dataset_type.from_dict(ts_data)
     operation_params.domain = "TS"
     operation_params.standard = "sdtmig"
     operation_params.standard_version = "3-4"

--- a/tests/unit/test_operations/test_get_codelist_attributes.py
+++ b/tests/unit/test_operations/test_get_codelist_attributes.py
@@ -1,10 +1,10 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
 import pandas as pd
 import pytest
-
 from typing import List
 
 from cdisc_rules_engine.models.operation_params import OperationParams
@@ -92,7 +92,7 @@ def test_get_codelist_attributes(
     Mocks cache call to return metadata.
     """
     # 1.0 set parameters
-    operation_params.dataframe = pd.DataFrame.from_dict(ts_data)
+    operation_params.dataframe = PandasDataset.from_dict(ts_data)
     operation_params.domain = "TS"
     operation_params.standard = "sdtmig"
     operation_params.standard_version = "3-4"

--- a/tests/unit/test_operations/test_get_model_filtered_variables.py
+++ b/tests/unit/test_operations/test_get_model_filtered_variables.py
@@ -1,11 +1,9 @@
-# python -m pytest -s tests/unit/test_operations/test_get_model_filtered_variables.py
-
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
-import pandas as pd
 import pytest
-
+import pandas as pd
 from typing import List
 
 from cdisc_rules_engine.constants.classes import (
@@ -525,7 +523,7 @@ def test_get_model_filtered_variables(
     """
     if key_val is None:
         key_val = "Timing"
-    operation_params.dataframe = pd.DataFrame.from_dict(study_data)
+    operation_params.dataframe = PandasDataset.from_dict(study_data)
     operation_params.domain = "AE"
     operation_params.standard = "sdtmig"
     operation_params.standard_version = "3-4"
@@ -550,10 +548,10 @@ def test_get_model_filtered_variables(
         library_metadata,
     )
 
-    result: pd.DataFrame = operation.execute()
+    result = operation.execute()
 
     variables: List[str] = var_list
-    expected: pd.Series = pd.Series(
+    expected = pd.Series(
         [
             variables,
             variables,

--- a/tests/unit/test_operations/test_label_referenced_variable_metadata.py
+++ b/tests/unit/test_operations/test_label_referenced_variable_metadata.py
@@ -1,4 +1,5 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
@@ -11,9 +12,14 @@ from cdisc_rules_engine.operations.label_referenced_variable_metadata import (
 )
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+import pytest
 
 
-def test_get_label_referenced_variable_metadata(operation_params: OperationParams):
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_get_label_referenced_variable_metadata(
+    operation_params: OperationParams, dataset_type
+):
     model_metadata = {
         "datasets": [
             {
@@ -78,7 +84,7 @@ def test_get_label_referenced_variable_metadata(operation_params: OperationParam
             }
         ],
     }
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_library_model_column_order.py
+++ b/tests/unit/test_operations/test_library_model_column_order.py
@@ -1,5 +1,6 @@
 from typing import List
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
@@ -21,89 +22,83 @@ from cdisc_rules_engine.operations.library_model_column_order import (
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
 
-
-@pytest.mark.parametrize(
-    "model_metadata, standard_metadata",
-    [
-        (
-            {
-                "datasets": [
-                    {
-                        "_links": {"parentClass": {"title": "Events"}},
-                        "name": "AE",
-                        "datasetVariables": [
-                            {
-                                "name": "AETERM",
-                                "ordinal": 4,
-                            },
-                            {
-                                "name": "AESEQ",
-                                "ordinal": 3,
-                            },
-                        ],
-                    }
-                ],
-                "classes": [
-                    {
-                        "name": "Events",
-                        "label": "Events",
-                        "classVariables": [
-                            {"name": "--TERM", "ordinal": 1},
-                            {"name": "--SEQ", "ordinal": 2},
-                        ],
-                    },
-                    {
-                        "name": GENERAL_OBSERVATIONS_CLASS,
-                        "label": GENERAL_OBSERVATIONS_CLASS,
-                        "classVariables": [
-                            {
-                                "name": "DOMAIN",
-                                "role": VariableRoles.IDENTIFIER.value,
-                                "ordinal": 2,
-                            },
-                            {
-                                "name": "STUDYID",
-                                "role": VariableRoles.IDENTIFIER.value,
-                                "ordinal": 1,
-                            },
-                            {
-                                "name": "TIMING_VAR",
-                                "role": VariableRoles.TIMING.value,
-                                "ordinal": 33,
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
-                "classes": [
-                    {
-                        "name": "Events",
-                        "datasets": [
-                            {
-                                "name": "AE",
-                                "label": "Adverse Events",
-                                "datasetVariables": [
-                                    {"name": "AETEST", "ordinal": 1},
-                                    {"name": "AENEW", "ordinal": 2},
-                                ],
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
+model_metadata = {
+    "datasets": [
+        {
+            "_links": {"parentClass": {"title": "Events"}},
+            "name": "AE",
+            "datasetVariables": [
+                {
+                    "name": "AETERM",
+                    "ordinal": 4,
+                },
+                {
+                    "name": "AESEQ",
+                    "ordinal": 3,
+                },
+            ],
+        }
     ],
-)
-def test_get_column_order_from_library(
-    operation_params: OperationParams, model_metadata: dict, standard_metadata: dict
-):
+    "classes": [
+        {
+            "name": "Events",
+            "label": "Events",
+            "classVariables": [
+                {"name": "--TERM", "ordinal": 1},
+                {"name": "--SEQ", "ordinal": 2},
+            ],
+        },
+        {
+            "name": GENERAL_OBSERVATIONS_CLASS,
+            "label": GENERAL_OBSERVATIONS_CLASS,
+            "classVariables": [
+                {
+                    "name": "DOMAIN",
+                    "role": VariableRoles.IDENTIFIER.value,
+                    "ordinal": 2,
+                },
+                {
+                    "name": "STUDYID",
+                    "role": VariableRoles.IDENTIFIER.value,
+                    "ordinal": 1,
+                },
+                {
+                    "name": "TIMING_VAR",
+                    "role": VariableRoles.TIMING.value,
+                    "ordinal": 33,
+                },
+            ],
+        },
+    ],
+}
+
+standard_metadata = {
+    "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+    "classes": [
+        {
+            "name": "Events",
+            "datasets": [
+                {
+                    "name": "AE",
+                    "label": "Adverse Events",
+                    "datasetVariables": [
+                        {"name": "AETEST", "ordinal": 1},
+                        {"name": "AENEW", "ordinal": 2},
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_get_column_order_from_library(operation_params: OperationParams, dataset_type):
     """
     Unit test for DataProcessor.get_column_order_from_library.
     Mocks cache call to return metadata.
     """
-    operation_params.dataframe = PandasDataset.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_library_model_column_order.py
+++ b/tests/unit/test_operations/test_library_model_column_order.py
@@ -1,5 +1,6 @@
 from typing import List
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
@@ -102,7 +103,7 @@ def test_get_column_order_from_library(
     Unit test for DataProcessor.get_column_order_from_library.
     Mocks cache call to return metadata.
     """
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = PandasDataset.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -243,7 +244,7 @@ def test_get_findings_class_column_order_from_library(
     Unit test for DataProcessor.get_column_order_from_library.
     Mocks cache call to return metadata.
     """
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = PandasDataset.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_maximum.py
+++ b/tests/unit/test_operations/test_maximum.py
@@ -1,9 +1,9 @@
 from cdisc_rules_engine.config.config import ConfigService
 from cdisc_rules_engine.operations.maximum import Maximum
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
 import pytest
-
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
@@ -13,19 +13,36 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
 @pytest.mark.parametrize(
     "data, expected",
     [
-        (pd.DataFrame.from_dict({"values": [11, 12, 12, 5, 18, 9]}), 18),
-        (pd.DataFrame.from_dict({"values": [11, 12, 12, 5, 18, 29]}), 29),
+        ({"values": [11, 12, 12, 5, 18, 9]}, 18),
+        ({"values": [11, 12, 12, 5, 18, 29]}, 29),
     ],
 )
-def test_minimum(data, expected, operation_params: OperationParams):
+def test_maximum(data, expected, operation_params: OperationParams):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    operation_params.dataframe = data
+    dataset = PandasDataset.from_dict(data)
+    operation_params.dataframe = dataset
     operation_params.target = "values"
-    result = Maximum(
-        operation_params, pd.DataFrame.copy(data), cache, data_service
-    ).execute()
-    assert operation_params.operation_id in result
+    result = Maximum(operation_params, dataset, cache, data_service).execute()
+    for val in result[operation_params.operation_id]:
+        assert val == expected
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        ({"values": [11, 12, 12, 5, 18, 9]}, 18),
+        ({"values": [11, 12, 12, 5, 18, 29]}, 29),
+    ],
+)
+def test_maximum_dask(data, expected, operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    dataset = DaskDataset.from_dict(data)
+    operation_params.dataframe = dataset
+    operation_params.target = "values"
+    result = Maximum(operation_params, dataset, cache, data_service).execute()
     for val in result[operation_params.operation_id]:
         assert val == expected

--- a/tests/unit/test_operations/test_maximum.py
+++ b/tests/unit/test_operations/test_maximum.py
@@ -11,36 +11,17 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
 
 
 @pytest.mark.parametrize(
-    "data, expected",
+    "data, dataset_type, expected",
     [
-        ({"values": [11, 12, 12, 5, 18, 9]}, 18),
-        ({"values": [11, 12, 12, 5, 18, 29]}, 29),
+        ({"values": [11, 12, 12, 5, 18, 9]}, PandasDataset, 18),
+        ({"values": [11, 12, 12, 5, 18, 29]}, DaskDataset, 29),
     ],
 )
-def test_maximum(data, expected, operation_params: OperationParams):
+def test_maximum(data, dataset_type, expected, operation_params: OperationParams):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    dataset = PandasDataset.from_dict(data)
-    operation_params.dataframe = dataset
-    operation_params.target = "values"
-    result = Maximum(operation_params, dataset, cache, data_service).execute()
-    for val in result[operation_params.operation_id]:
-        assert val == expected
-
-
-@pytest.mark.parametrize(
-    "data, expected",
-    [
-        ({"values": [11, 12, 12, 5, 18, 9]}, 18),
-        ({"values": [11, 12, 12, 5, 18, 29]}, 29),
-    ],
-)
-def test_maximum_dask(data, expected, operation_params: OperationParams):
-    config = ConfigService()
-    cache = CacheServiceFactory(config).get_cache_service()
-    data_service = DataServiceFactory(config, cache).get_data_service()
-    dataset = DaskDataset.from_dict(data)
+    dataset = dataset_type.from_dict(data)
     operation_params.dataframe = dataset
     operation_params.target = "values"
     result = Maximum(operation_params, dataset, cache, data_service).execute()

--- a/tests/unit/test_operations/test_mean.py
+++ b/tests/unit/test_operations/test_mean.py
@@ -12,19 +12,25 @@ from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 
 
 @pytest.mark.parametrize(
-    "data, expected",
+    "data, dataset_type, expected",
     [
         (
             {"values": [11, 12, 12, 5, 18, 9]},
+            PandasDataset,
+            11.166666666666666,
+        ),
+        (
+            {"values": [11, 12, 12, 5, 18, 9]},
+            DaskDataset,
             11.166666666666666,
         ),
     ],
 )
-def test_mean(data, expected, operation_params: OperationParams):
+def test_mean(data, dataset_type, expected, operation_params: OperationParams):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    dataset = PandasDataset.from_dict(data)
+    dataset = dataset_type.from_dict(data)
     operation_params.dataframe = dataset
     operation_params.target = "values"
     result = Mean(operation_params, dataset, cache, data_service).execute()
@@ -34,64 +40,25 @@ def test_mean(data, expected, operation_params: OperationParams):
 
 
 @pytest.mark.parametrize(
-    "data, expected",
+    "data, dataset_type, expected",
     [
         (
             {"values": [11, 12, 12, 5, 18, 9], "patient": [1, 2, 2, 1, 2, 1]},
+            PandasDataset,
+            {1: 8.333333333333334, 2: 14.0},
+        ),
+        (
+            {"values": [11, 12, 12, 5, 18, 9], "patient": [1, 2, 2, 1, 2, 1]},
+            DaskDataset,
             {1: 8.333333333333334, 2: 14.0},
         ),
     ],
 )
-def test_grouped_mean(data, expected, operation_params: OperationParams):
+def test_grouped_mean(data, dataset_type, expected, operation_params: OperationParams):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    dataset = PandasDataset.from_dict(data)
-    operation_params.dataframe = dataset
-    operation_params.target = "values"
-    operation_params.grouping = ["patient"]
-    result = Mean(operation_params, dataset, cache, data_service).execute()
-    assert operation_params.operation_id in result
-    for _, val in result.iterrows():
-        assert val[operation_params.operation_id] == expected.get(val["patient"])
-
-
-@pytest.mark.parametrize(
-    "data, expected",
-    [
-        (
-            {"values": [11, 12, 12, 5, 18, 9]},
-            11.166666666666666,
-        ),
-    ],
-)
-def test_mean_dask(data, expected, operation_params: OperationParams):
-    config = ConfigService()
-    cache = CacheServiceFactory(config).get_cache_service()
-    data_service = DataServiceFactory(config, cache).get_data_service()
-    dataset = DaskDataset.from_dict(data)
-    operation_params.dataframe = dataset
-    operation_params.target = "values"
-    result = Mean(operation_params, dataset, cache, data_service).execute()
-    assert operation_params.operation_id in result
-    for val in result[operation_params.operation_id]:
-        assert val == expected
-
-
-@pytest.mark.parametrize(
-    "data, expected",
-    [
-        (
-            {"values": [11, 12, 12, 5, 18, 9], "patient": [1, 2, 2, 1, 2, 1]},
-            {1: 8.333333333333334, 2: 14.0},
-        ),
-    ],
-)
-def test_grouped_mean_dask(data, expected, operation_params: OperationParams):
-    config = ConfigService()
-    cache = CacheServiceFactory(config).get_cache_service()
-    data_service = DataServiceFactory(config, cache).get_data_service()
-    dataset = DaskDataset.from_dict(data)
+    dataset = dataset_type.from_dict(data)
     operation_params.dataframe = dataset
     operation_params.target = "values"
     operation_params.grouping = ["patient"]

--- a/tests/unit/test_operations/test_mean.py
+++ b/tests/unit/test_operations/test_mean.py
@@ -1,20 +1,21 @@
 from cdisc_rules_engine.config.config import ConfigService
 from cdisc_rules_engine.operations.mean import Mean
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
 import pytest
 
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
 )
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 
 
 @pytest.mark.parametrize(
     "data, expected",
     [
         (
-            pd.DataFrame.from_dict({"values": [11, 12, 12, 5, 18, 9]}),
+            {"values": [11, 12, 12, 5, 18, 9]},
             11.166666666666666,
         ),
     ],
@@ -23,9 +24,10 @@ def test_mean(data, expected, operation_params: OperationParams):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    operation_params.dataframe = data
+    dataset = PandasDataset.from_dict(data)
+    operation_params.dataframe = dataset
     operation_params.target = "values"
-    result = Mean(operation_params, data, cache, data_service).execute()
+    result = Mean(operation_params, dataset, cache, data_service).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:
         assert val == expected
@@ -35,9 +37,7 @@ def test_mean(data, expected, operation_params: OperationParams):
     "data, expected",
     [
         (
-            pd.DataFrame.from_dict(
-                {"values": [11, 12, 12, 5, 18, 9], "patient": [1, 2, 2, 1, 2, 1]}
-            ),
+            {"values": [11, 12, 12, 5, 18, 9], "patient": [1, 2, 2, 1, 2, 1]},
             {1: 8.333333333333334, 2: 14.0},
         ),
     ],
@@ -46,10 +46,56 @@ def test_grouped_mean(data, expected, operation_params: OperationParams):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    operation_params.dataframe = data
+    dataset = PandasDataset.from_dict(data)
+    operation_params.dataframe = dataset
     operation_params.target = "values"
     operation_params.grouping = ["patient"]
-    result = Mean(operation_params, data, cache, data_service).execute()
+    result = Mean(operation_params, dataset, cache, data_service).execute()
+    assert operation_params.operation_id in result
+    for _, val in result.iterrows():
+        assert val[operation_params.operation_id] == expected.get(val["patient"])
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            {"values": [11, 12, 12, 5, 18, 9]},
+            11.166666666666666,
+        ),
+    ],
+)
+def test_mean_dask(data, expected, operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    dataset = DaskDataset.from_dict(data)
+    operation_params.dataframe = dataset
+    operation_params.target = "values"
+    result = Mean(operation_params, dataset, cache, data_service).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        assert val == expected
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (
+            {"values": [11, 12, 12, 5, 18, 9], "patient": [1, 2, 2, 1, 2, 1]},
+            {1: 8.333333333333334, 2: 14.0},
+        ),
+    ],
+)
+def test_grouped_mean_dask(data, expected, operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    dataset = DaskDataset.from_dict(data)
+    operation_params.dataframe = dataset
+    operation_params.target = "values"
+    operation_params.grouping = ["patient"]
+    result = Mean(operation_params, dataset, cache, data_service).execute()
     assert operation_params.operation_id in result
     for _, val in result.iterrows():
         assert val[operation_params.operation_id] == expected.get(val["patient"])

--- a/tests/unit/test_operations/test_meddra_code_references_validator.py
+++ b/tests/unit/test_operations/test_meddra_code_references_validator.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.meddra_code_references_validator import (
     MedDRACodeReferencesValidator,
 )
@@ -8,10 +10,12 @@ import pandas as pd
 from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
 )
+import pytest
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_meddra_code_references_validator(
-    installed_meddra_dictionaries: dict, operation_params: OperationParams
+    installed_meddra_dictionaries: dict, operation_params: OperationParams, dataset_type
 ):
     """
     Unit test for valid_whodrug_references function.
@@ -20,7 +24,7 @@ def test_meddra_code_references_validator(
     cache = installed_meddra_dictionaries["cache_service"]
     data_service = DataServiceFactory(config, cache).get_data_service()
     # create a dataset where 2 rows reference invalid terms
-    invalid_df = pd.DataFrame.from_dict(
+    invalid_df = dataset_type.from_dict(
         {
             "AELLTCD": ["TEST1", "TEST2", "LLT3"],
             "AESOCCD": ["TEST1", "TEST2", "SOC3"],

--- a/tests/unit/test_operations/test_meddra_code_term_pairs_validator.py
+++ b/tests/unit/test_operations/test_meddra_code_term_pairs_validator.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.meddra_code_term_pairs_validator import (
     MedDRACodeTermPairsValidator,
 )
@@ -8,10 +10,12 @@ import pandas as pd
 from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
 )
+import pytest
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_meddra_code_term_pairs_validator(
-    installed_meddra_dictionaries: dict, operation_params: OperationParams
+    installed_meddra_dictionaries: dict, operation_params: OperationParams, dataset_type
 ):
     """
     Unit test for valid_whodrug_references function.
@@ -20,7 +24,7 @@ def test_meddra_code_term_pairs_validator(
     cache = installed_meddra_dictionaries["cache_service"]
     data_service = DataServiceFactory(config, cache).get_data_service()
     # create a dataset where 2 rows reference invalid terms
-    invalid_df = pd.DataFrame.from_dict(
+    invalid_df = dataset_type.from_dict(
         {"AELLTCD": ["TEST1", "TEST2", "LLT3"], "AELLT": ["TEST1", "TEST2", "TESTLLT3"]}
     )
 

--- a/tests/unit/test_operations/test_meddra_term_references_validator.py
+++ b/tests/unit/test_operations/test_meddra_term_references_validator.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.meddra_term_references_validator import (
     MedDRATermReferencesValidator,
 )
@@ -8,10 +10,12 @@ import pandas as pd
 from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
 )
+import pytest
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_meddra_term_references_validator(
-    installed_meddra_dictionaries: dict, operation_params: OperationParams
+    installed_meddra_dictionaries: dict, operation_params: OperationParams, dataset_type
 ):
     """
     Unit test for valid_whodrug_references function.
@@ -20,7 +24,7 @@ def test_meddra_term_references_validator(
     cache = installed_meddra_dictionaries["cache_service"]
     data_service = DataServiceFactory(config, cache).get_data_service()
     # create a dataset where 2 rows reference invalid terms
-    invalid_df = pd.DataFrame.from_dict(
+    invalid_df = dataset_type.from_dict(
         {
             "AELLT": ["TEST1", "TEST2", "TESTLLT3"],
             "AESOC": ["TEST1", "TEST2", "TESTSOC3"],

--- a/tests/unit/test_operations/test_min_date.py
+++ b/tests/unit/test_operations/test_min_date.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.min_date import MinDate
 from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
@@ -11,23 +13,30 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
 
 
 @pytest.mark.parametrize(
-    "data, expected",
+    "data, expected, dataset_type",
     [
         (
-            pd.DataFrame.from_dict({"dates": ["2001-01-01", "", "2022-01-01"]}),
+            {"dates": ["2001-01-01", "", "2022-01-01"]},
             pd.to_datetime("2001-01-01").isoformat(),
+            DaskDataset,
         ),
-        (pd.DataFrame.from_dict({"dates": [None, None]}), ""),
+        ({"dates": [None, None]}, "", DaskDataset),
+        (
+            {"dates": ["2001-01-01", "", "2022-01-01"]},
+            pd.to_datetime("2001-01-01").isoformat(),
+            PandasDataset,
+        ),
+        ({"dates": [None, None]}, "", PandasDataset),
     ],
 )
-def test_minimum(data, expected, operation_params: OperationParams):
+def test_minimum(data, expected, operation_params: OperationParams, dataset_type):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    operation_params.dataframe = data
+    operation_params.dataframe = dataset_type.from_dict(data)
     operation_params.target = "dates"
     result = MinDate(
-        operation_params, pd.DataFrame.copy(data), cache, data_service
+        operation_params, dataset_type.from_dict(data), cache, data_service
     ).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:

--- a/tests/unit/test_operations/test_minimum.py
+++ b/tests/unit/test_operations/test_minimum.py
@@ -1,7 +1,8 @@
 from cdisc_rules_engine.config.config import ConfigService
 from cdisc_rules_engine.operations.minimum import Minimum
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 import pytest
 
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
@@ -13,18 +14,36 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
 @pytest.mark.parametrize(
     "data, expected",
     [
-        (pd.DataFrame.from_dict({"values": [11, 12, 12, 5, 18, 9]}), 5),
+        ({"values": [11, 12, 12, 5, 18, 9]}, 5),
     ],
 )
 def test_minimum(data, expected, operation_params: OperationParams):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    operation_params.dataframe = data
+    dataset = PandasDataset.from_dict(data)
+    operation_params.dataframe = dataset
     operation_params.target = "values"
-    result = Minimum(
-        operation_params, pd.DataFrame.copy(data), cache, data_service
-    ).execute()
+    result = Minimum(operation_params, dataset, cache, data_service).execute()
+    assert operation_params.operation_id in result
+    for val in result[operation_params.operation_id]:
+        assert val == expected
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        ({"values": [11, 12, 12, 5, 18, 9]}, 5),
+    ],
+)
+def test_minimum_dask(data, expected, operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    dataset = DaskDataset.from_dict(data)
+    operation_params.dataframe = dataset
+    operation_params.target = "values"
+    result = Minimum(operation_params, dataset, cache, data_service).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:
         assert val == expected

--- a/tests/unit/test_operations/test_minimum.py
+++ b/tests/unit/test_operations/test_minimum.py
@@ -12,35 +12,17 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
 
 
 @pytest.mark.parametrize(
-    "data, expected",
+    "data, dataset_type, expected",
     [
-        ({"values": [11, 12, 12, 5, 18, 9]}, 5),
+        ({"values": [11, 12, 12, 5, 18, 9]}, PandasDataset, 5),
+        ({"values": [11, 12, 12, 5, 18, 9]}, DaskDataset, 5),
     ],
 )
-def test_minimum(data, expected, operation_params: OperationParams):
+def test_minimum(data, dataset_type, expected, operation_params: OperationParams):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
-    dataset = PandasDataset.from_dict(data)
-    operation_params.dataframe = dataset
-    operation_params.target = "values"
-    result = Minimum(operation_params, dataset, cache, data_service).execute()
-    assert operation_params.operation_id in result
-    for val in result[operation_params.operation_id]:
-        assert val == expected
-
-
-@pytest.mark.parametrize(
-    "data, expected",
-    [
-        ({"values": [11, 12, 12, 5, 18, 9]}, 5),
-    ],
-)
-def test_minimum_dask(data, expected, operation_params: OperationParams):
-    config = ConfigService()
-    cache = CacheServiceFactory(config).get_cache_service()
-    data_service = DataServiceFactory(config, cache).get_data_service()
-    dataset = DaskDataset.from_dict(data)
+    dataset = dataset_type.from_dict(data)
     operation_params.dataframe = dataset
     operation_params.target = "values"
     result = Minimum(operation_params, dataset, cache, data_service).execute()

--- a/tests/unit/test_operations/test_name_referenced_variable_metadata.py
+++ b/tests/unit/test_operations/test_name_referenced_variable_metadata.py
@@ -1,8 +1,9 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
-import pandas as pd
 from cdisc_rules_engine.constants.classes import GENERAL_OBSERVATIONS_CLASS
 from cdisc_rules_engine.enums.variable_roles import VariableRoles
 from cdisc_rules_engine.models.operation_params import OperationParams
@@ -11,9 +12,13 @@ from cdisc_rules_engine.operations.name_referenced_variable_metadata import (
 )
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
+import pytest
 
 
-def test_get_name_referenced_variable_metadata(operation_params: OperationParams):
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_get_name_referenced_variable_metadata(
+    operation_params: OperationParams, dataset_type
+):
     model_metadata = {
         "datasets": [
             {
@@ -78,7 +83,7 @@ def test_get_name_referenced_variable_metadata(operation_params: OperationParams
             }
         ],
     }
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -115,7 +120,7 @@ def test_get_name_referenced_variable_metadata(operation_params: OperationParams
         data_service,
         library_metadata,
     )
-    result: pd.DataFrame = operation.execute()
+    result = operation.execute()
     expected_columns = [
         "STUDYID",
         "AETERM",

--- a/tests/unit/test_operations/test_parent_library_model_column_order.py
+++ b/tests/unit/test_operations/test_parent_library_model_column_order.py
@@ -1,5 +1,7 @@
 from typing import List
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
@@ -27,7 +29,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
     "data, model_metadata, standard_metadata",
     [
         (
-            pd.DataFrame.from_dict(
+            PandasDataset.from_dict(
                 {
                     "RDOMAIN": ["AE", "AE", "AE", "AE"],
                     "IDVAR": ["AESEQ", "AESEQ", "AESEQ", "AESEQ"],
@@ -116,7 +118,7 @@ def test_get_parent_column_order_from_library(
             "filename": "ae.xpt",
         }
     ]
-    ae = pd.DataFrame.from_dict(
+    ae = PandasDataset.from_dict(
         {
             "AESTDY": [4, 5, 6],
             "STUDYID": [101, 201, 300],
@@ -173,7 +175,7 @@ def test_get_parent_column_order_from_library(
     "data, model_metadata, standard_metadata",
     [
         (
-            pd.DataFrame.from_dict(
+            DaskDataset.from_dict(
                 {
                     "RDOMAIN": ["AE", "AE", "AE", "AE"],
                     "IDVAR": ["AESEQ", "AESEQ", "AESEQ", "AESEQ"],
@@ -283,7 +285,7 @@ def test_get_parent_findings_class_column_order_from_library(
             "filename": "ec.xpt",
         },
     ]
-    ae = pd.DataFrame.from_dict(
+    ae = DaskDataset.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",
@@ -299,7 +301,7 @@ def test_get_parent_findings_class_column_order_from_library(
             "AETESTCD": ["test", "test", "test"],
         }
     )
-    ec = pd.DataFrame.from_dict(
+    ec = DaskDataset.from_dict(
         {
             "ECSTDY": [500, 4],
             "STUDYID": [201, 101],

--- a/tests/unit/test_operations/test_permissible_variables.py
+++ b/tests/unit/test_operations/test_permissible_variables.py
@@ -1,4 +1,6 @@
 from typing import List
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
@@ -15,7 +17,7 @@ from cdisc_rules_engine.services.data_services import LocalDataService
 
 
 @pytest.mark.parametrize(
-    "model_metadata, standard_metadata",
+    "model_metadata, standard_metadata, dataset_type",
     [
         (
             {
@@ -83,17 +85,85 @@ from cdisc_rules_engine.services.data_services import LocalDataService
                     }
                 ],
             },
-        )
+            PandasDataset,
+        ),
+        (
+            {
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "datasetVariables": [
+                            {
+                                "name": "AETERM",
+                                "ordinal": 4,
+                            },
+                            {
+                                "name": "AESEQ",
+                                "ordinal": 3,
+                            },
+                        ],
+                    }
+                ],
+                "classes": [
+                    {
+                        "name": "Events",
+                        "classVariables": [
+                            {"name": "--TERM", "ordinal": 1},
+                            {"name": "--SEQ", "ordinal": 2},
+                        ],
+                    },
+                    {
+                        "name": GENERAL_OBSERVATIONS_CLASS,
+                        "classVariables": [
+                            {
+                                "name": "DOMAIN",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 2,
+                            },
+                            {
+                                "name": "STUDYID",
+                                "role": VariableRoles.IDENTIFIER.value,
+                                "ordinal": 1,
+                            },
+                            {
+                                "name": "TIMING_VAR",
+                                "role": VariableRoles.TIMING.value,
+                                "ordinal": 33,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+                "classes": [
+                    {
+                        "name": "Events",
+                        "datasets": [
+                            {
+                                "name": "AE",
+                                "label": "Adverse Events",
+                                "datasetVariables": [
+                                    {"name": "AETEST", "ordinal": 1, "core": "Req"},
+                                    {"name": "AENEW", "ordinal": 2, "core": "Exp"},
+                                    {"name": "AEPERM", "ordinal": 2, "core": "Perm"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            DaskDataset,
+        ),
     ],
 )
 def test_get_permissible_variables(
-    operation_params: OperationParams, model_metadata: dict, standard_metadata: dict
+    operation_params: OperationParams,
+    model_metadata: dict,
+    standard_metadata: dict,
+    dataset_type,
 ):
-    """
-    Unit test for DataProcessor.get_column_order_from_library.
-    Mocks cache call to return metadata.
-    """
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_record_count.py
+++ b/tests/unit/test_operations/test_record_count.py
@@ -1,18 +1,22 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 
 from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.operations.record_count import RecordCount
+import pytest
 
 
-def test_record_count_operation(operation_params: OperationParams):
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_record_count_operation(operation_params: OperationParams, dataset_type):
     """
     Unit test for RecordCount operation.
     Creates a dataframe and checks that
     the operation returns correct number of records.
     """
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "CDISC01",

--- a/tests/unit/test_operations/test_required_variables.py
+++ b/tests/unit/test_operations/test_required_variables.py
@@ -1,4 +1,5 @@
 from typing import List
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
@@ -14,91 +15,84 @@ from cdisc_rules_engine.operations.required_variables import RequiredVariables
 from cdisc_rules_engine.services.cache import InMemoryCacheService
 from cdisc_rules_engine.services.data_services import LocalDataService
 
-
-@pytest.mark.parametrize(
-    "model_metadata, standard_metadata",
-    [
-        (
-            {
-                "datasets": [
-                    {
-                        "name": "AE",
-                        "datasetVariables": [
-                            {
-                                "name": "AETERM",
-                                "ordinal": 4,
-                            },
-                            {
-                                "name": "AESEQ",
-                                "ordinal": 3,
-                            },
-                        ],
-                    }
-                ],
-                "classes": [
-                    {
-                        "name": "Events",
-                        "classVariables": [
-                            {"name": "--TERM", "ordinal": 1},
-                            {"name": "--SEQ", "ordinal": 2},
-                        ],
-                    },
-                    {
-                        "name": GENERAL_OBSERVATIONS_CLASS,
-                        "classVariables": [
-                            {
-                                "name": "DOMAIN",
-                                "role": VariableRoles.IDENTIFIER.value,
-                                "ordinal": 2,
-                            },
-                            {
-                                "name": "STUDYID",
-                                "role": VariableRoles.IDENTIFIER.value,
-                                "ordinal": 1,
-                            },
-                            {
-                                "name": "--SEQ",
-                                "role": VariableRoles.IDENTIFIER.value,
-                                "ordinal": 12,
-                            },
-                            {
-                                "name": "TIMING_VAR",
-                                "role": VariableRoles.TIMING.value,
-                                "ordinal": 33,
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
-                "classes": [
-                    {
-                        "name": "Events",
-                        "datasets": [
-                            {
-                                "name": "AE",
-                                "label": "Adverse Events",
-                                "datasetVariables": [
-                                    {"name": "AETEST", "ordinal": 1, "core": "Req"},
-                                    {"name": "AENEW", "ordinal": 2, "core": "Exp"},
-                                ],
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
+model_metadata = {
+    "datasets": [
+        {
+            "name": "AE",
+            "datasetVariables": [
+                {
+                    "name": "AETERM",
+                    "ordinal": 4,
+                },
+                {
+                    "name": "AESEQ",
+                    "ordinal": 3,
+                },
+            ],
+        }
     ],
-)
-def test_get_required_variables(
-    operation_params: OperationParams, model_metadata: dict, standard_metadata: dict
-):
+    "classes": [
+        {
+            "name": "Events",
+            "classVariables": [
+                {"name": "--TERM", "ordinal": 1},
+                {"name": "--SEQ", "ordinal": 2},
+            ],
+        },
+        {
+            "name": GENERAL_OBSERVATIONS_CLASS,
+            "classVariables": [
+                {
+                    "name": "DOMAIN",
+                    "role": VariableRoles.IDENTIFIER.value,
+                    "ordinal": 2,
+                },
+                {
+                    "name": "STUDYID",
+                    "role": VariableRoles.IDENTIFIER.value,
+                    "ordinal": 1,
+                },
+                {
+                    "name": "--SEQ",
+                    "role": VariableRoles.IDENTIFIER.value,
+                    "ordinal": 12,
+                },
+                {
+                    "name": "TIMING_VAR",
+                    "role": VariableRoles.TIMING.value,
+                    "ordinal": 33,
+                },
+            ],
+        },
+    ],
+}
+standard_metadata = {
+    "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+    "classes": [
+        {
+            "name": "Events",
+            "datasets": [
+                {
+                    "name": "AE",
+                    "label": "Adverse Events",
+                    "datasetVariables": [
+                        {"name": "AETEST", "ordinal": 1, "core": "Req"},
+                        {"name": "AENEW", "ordinal": 2, "core": "Exp"},
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
+def test_get_required_variables(operation_params: OperationParams, dataset_type):
     """
     Unit test for DataProcessor.get_column_order_from_library.
     Mocks cache call to return metadata.
     """
-    operation_params.dataframe = PandasDataset.from_dict(
+    operation_params.dataframe = dataset_type.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_required_variables.py
+++ b/tests/unit/test_operations/test_required_variables.py
@@ -1,4 +1,5 @@
 from typing import List
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
@@ -97,7 +98,7 @@ def test_get_required_variables(
     Unit test for DataProcessor.get_column_order_from_library.
     Mocks cache call to return metadata.
     """
-    operation_params.dataframe = pd.DataFrame.from_dict(
+    operation_params.dataframe = PandasDataset.from_dict(
         {
             "STUDYID": [
                 "TEST_STUDY",

--- a/tests/unit/test_operations/test_valid_codelist_dates.py
+++ b/tests/unit/test_operations/test_valid_codelist_dates.py
@@ -1,10 +1,10 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
 from cdisc_rules_engine.operations.valid_codelist_dates import ValidCodelistDates
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 import pytest
 
@@ -37,7 +37,7 @@ def test_variable_count(
     operation_params.standard = standard
     result = ValidCodelistDates(
         operation_params,
-        pd.DataFrame.from_dict({"test": [1, 2, 33]}),
+        PandasDataset.from_dict({"test": [1, 2, 33]}),
         cache,
         mock_data_service,
         library_metadata,

--- a/tests/unit/test_operations/test_valid_external_dictionary_value.py
+++ b/tests/unit/test_operations/test_valid_external_dictionary_value.py
@@ -1,18 +1,20 @@
 from cdisc_rules_engine.config.config import ConfigService
 from cdisc_rules_engine.exceptions.custom_exceptions import UnsupportedDictionaryType
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.valid_external_dictionary_value import (
     ValidExternalDictionaryValue,
 )
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 from cdisc_rules_engine.models.dictionaries.meddra.terms.term_types import TermTypes
 from cdisc_rules_engine.models.dictionaries.meddra.terms.meddra_term import MedDRATerm
 import pytest
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_valid_external_dictionary_value_with_meddra(
-    mock_data_service, operation_params: OperationParams
+    mock_data_service, operation_params: OperationParams, dataset_type
 ):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
@@ -22,7 +24,7 @@ def test_valid_external_dictionary_value_with_meddra(
     operation_params.original_target = "--DECOD"
     operation_params.target = "AEDECOD"
 
-    data = pd.DataFrame.from_dict(
+    data = dataset_type.from_dict(
         {
             "AEDECOD": ["A", "B", "C"],
         }
@@ -46,8 +48,9 @@ def test_valid_external_dictionary_value_with_meddra(
     assert result[operation_params.operation_id].tolist() == [True, True, False]
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_valid_external_dictionary_value_with_invalid_external_dictionary_type(
-    mock_data_service, operation_params: OperationParams
+    mock_data_service, operation_params: OperationParams, dataset_type
 ):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
@@ -55,7 +58,7 @@ def test_valid_external_dictionary_value_with_invalid_external_dictionary_type(
     operation_params.original_target = "--DECOD"
     operation_params.target = "AEDECOD"
 
-    data = pd.DataFrame.from_dict(
+    data = dataset_type.from_dict(
         {
             "AEDECOD": ["A", "B", "C"],
         }

--- a/tests/unit/test_operations/test_variable_count.py
+++ b/tests/unit/test_operations/test_variable_count.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.variable_count import VariableCount
 from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
@@ -8,20 +10,24 @@ import os
 
 
 @pytest.mark.parametrize(
-    "target, expected",
-    [("DOMAIN", 2), ("--SEQ", 2), ("SPECIALVAR", 1)],
+    "target, expected, dataset_type",
+    [
+        ("DOMAIN", 2, PandasDataset),
+        ("--SEQ", 2, DaskDataset),
+        ("SPECIALVAR", 1, PandasDataset),
+    ],
 )
 def test_variable_count(
-    target, expected, mock_data_service, operation_params: OperationParams
+    target, expected, mock_data_service, operation_params: OperationParams, dataset_type
 ):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     dataset_path = os.path.join("study", "bundle", "blah")
     datasets_map = {
-        "AE": pd.DataFrame.from_dict(
+        "AE": dataset_type.from_dict(
             {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
         ),
-        "EX": pd.DataFrame.from_dict(
+        "EX": dataset_type.from_dict(
             {
                 "STUDYID": [4, 8, 12],
                 "EXSEQ": [1, 2, 3],
@@ -29,10 +35,10 @@ def test_variable_count(
                 "SPECIALVAR": ["A", "B", "C"],
             }
         ),
-        "AE2": pd.DataFrame.from_dict(
+        "AE2": dataset_type.from_dict(
             {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
         ),
-        "RELREC": pd.DataFrame.from_dict({"LNKGRP": ["DOMAIN", "EXSEQ", "AESEQ"]}),
+        "RELREC": dataset_type.from_dict({"LNKGRP": ["DOMAIN", "EXSEQ", "AESEQ"]}),
     }
 
     datasets = [

--- a/tests/unit/test_operations/test_variable_is_null.py
+++ b/tests/unit/test_operations/test_variable_is_null.py
@@ -1,7 +1,8 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.variable_is_null import VariableIsNull
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
 import pytest
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 
@@ -10,27 +11,27 @@ from cdisc_rules_engine.services.cache.cache_service_factory import CacheService
     "data, expected",
     [
         (
-            pd.DataFrame.from_dict({"AEVAR": ["A", "B", "C"]}),
+            PandasDataset.from_dict({"AEVAR": ["A", "B", "C"]}),
             False,
         ),
         (
-            pd.DataFrame.from_dict({"AEVAR": [1, 2, 3]}),
+            DaskDataset.from_dict({"AEVAR": [1, 2, 3]}),
             False,
         ),
         (
-            pd.DataFrame.from_dict({"AEVAR": ["", None, "C"]}),
+            DaskDataset.from_dict({"AEVAR": ["", None, "C"]}),
             False,
         ),
         (
-            pd.DataFrame.from_dict({"AEVAR": [None, None, 3]}),
+            PandasDataset.from_dict({"AEVAR": [None, None, 3]}),
             False,
         ),
         (
-            pd.DataFrame.from_dict({"AEVAR": ["", None]}),
+            PandasDataset.from_dict({"AEVAR": ["", None]}),
             True,
         ),
         (
-            pd.DataFrame.from_dict({"BCVAR": ["A", "B", "C"]}),
+            DaskDataset.from_dict({"BCVAR": ["A", "B", "C"]}),
             True,
         ),
     ],
@@ -44,29 +45,27 @@ def test_variable_is_null(
     operation_params.target = "--VAR"
     operation_params.domain = "AE"
     mock_data_service.get_dataset.return_value = data
-    result = VariableIsNull(
-        operation_params, pd.DataFrame.copy(data), cache, mock_data_service
-    ).execute()
+    result = VariableIsNull(operation_params, data, cache, mock_data_service).execute()
     assert operation_params.operation_id in result
     for val in result[operation_params.operation_id]:
         assert val == expected
 
 
 def test_define_crosscheck_variable_is_null(mock_data_service, operation_params):
-    define_metadata = pd.DataFrame.from_dict(
+    define_metadata = PandasDataset.from_dict(
         {
             "define_variable_name": ["AEHLT", "AETERM"],
             "define_variable_has_no_data": ["Yes", "No"],
         }
     )
-    dataset = pd.DataFrame.from_dict({"AEHLT": [None, None], "AETERM": [1, 2]})
+    dataset = PandasDataset.from_dict({"AEHLT": [None, None], "AETERM": [1, 2]})
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     operation_params.dataframe = define_metadata
     operation_params.target = "define_variable_name"
     mock_data_service.get_dataset.return_value = dataset
     result = VariableIsNull(
-        operation_params, pd.DataFrame.copy(define_metadata), cache, mock_data_service
+        operation_params, PandasDataset(define_metadata.data), cache, mock_data_service
     ).execute()
     assert operation_params.operation_id in result
     assert result[operation_params.operation_id].to_list() == [True, False]

--- a/tests/unit/test_operations/test_variable_library_metadata.py
+++ b/tests/unit/test_operations/test_variable_library_metadata.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.variable_library_metadata import (
     VariableLibraryMetadata,
 )
@@ -13,8 +15,11 @@ import json
 
 
 @pytest.mark.parametrize(
-    "target, standard, standard_version, expected_result",
-    [("core", "sdtmig", "3-1-2", {"STUDYID": "Req", "DOMAIN": "Req"})],
+    "target, standard, standard_version, expected_result, dataset_type",
+    [
+        ("core", "sdtmig", "3-1-2", {"STUDYID": "Req", "DOMAIN": "Req"}, PandasDataset),
+        ("core", "sdtmig", "3-1-2", {"STUDYID": "Req", "DOMAIN": "Req"}, DaskDataset),
+    ],
 )
 @patch(
     "cdisc_rules_engine.services.cdisc_library_service.CDISCLibraryClient.get_sdtmig"
@@ -25,6 +30,7 @@ def test_get_variable_metadata_for_given_standard(
     standard,
     standard_version,
     expected_result,
+    dataset_type,
     mock_data_service,
     operation_params: OperationParams,
 ):
@@ -39,9 +45,9 @@ def test_get_variable_metadata_for_given_standard(
     mock_get_sdtmig.return_value = mock_sdtmig_details
     dataset_path = "study/bundle/blah"
     datasets_map = {
-        "DM": pd.DataFrame.from_dict({"STUDYID": [4, 7, 9], "DOMAIN": [12, 6, 1]}),
-        "EX": pd.DataFrame.from_dict({"STUDYID": [4, 8, 12], "DOMAIN": [12, 6, 1]}),
-        "DM2": pd.DataFrame.from_dict({"STUDYID": [4, 7, 9], "DOMAIN": [12, 6, 1]}),
+        "DM": dataset_type.from_dict({"STUDYID": [4, 7, 9], "DOMAIN": [12, 6, 1]}),
+        "EX": dataset_type.from_dict({"STUDYID": [4, 8, 12], "DOMAIN": [12, 6, 1]}),
+        "DM2": dataset_type.from_dict({"STUDYID": [4, 7, 9], "DOMAIN": [12, 6, 1]}),
     }
 
     datasets = [

--- a/tests/unit/test_operations/test_variable_names.py
+++ b/tests/unit/test_operations/test_variable_names.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.variable_names import VariableNames
 from cdisc_rules_engine.models.operation_params import OperationParams
 import pandas as pd
@@ -11,8 +13,17 @@ import json
 
 
 @pytest.mark.parametrize(
-    "target, standard, standard_version, expected_result",
-    [({"STUDYID", "DOMAIN"}, "sdtmig", "3-1-2", {"STUDYID", "DOMAIN"})],
+    "target, standard, standard_version, expected_result, dataset_type",
+    [
+        (
+            {"STUDYID", "DOMAIN"},
+            "sdtmig",
+            "3-1-2",
+            {"STUDYID", "DOMAIN"},
+            PandasDataset,
+        ),
+        ({"STUDYID", "DOMAIN"}, "sdtmig", "3-1-2", {"STUDYID", "DOMAIN"}, DaskDataset),
+    ],
 )
 @patch(
     "cdisc_rules_engine.services.cdisc_library_service.CDISCLibraryClient.get_sdtmig"
@@ -23,6 +34,7 @@ def test_get_variable_names_for_given_standard(
     standard,
     standard_version,
     expected_result,
+    dataset_type,
     mock_data_service,
     operation_params: OperationParams,
 ):
@@ -37,9 +49,9 @@ def test_get_variable_names_for_given_standard(
     mock_get_sdtmig.return_value = mock_sdtmig_details
     dataset_path = "study/bundle/blah"
     datasets_map = {
-        "AE": pd.DataFrame.from_dict({"STUDYID": [4, 7, 9], "DOMAIN": [12, 6, 1]}),
-        "EX": pd.DataFrame.from_dict({"STUDYID": [4, 8, 12], "DOMAIN": [12, 6, 1]}),
-        "AE2": pd.DataFrame.from_dict({"STUDYID": [4, 7, 9], "DOMAIN": [12, 6, 1]}),
+        "AE": dataset_type.from_dict({"STUDYID": [4, 7, 9], "DOMAIN": [12, 6, 1]}),
+        "EX": dataset_type.from_dict({"STUDYID": [4, 8, 12], "DOMAIN": [12, 6, 1]}),
+        "AE2": dataset_type.from_dict({"STUDYID": [4, 7, 9], "DOMAIN": [12, 6, 1]}),
     }
 
     datasets = [

--- a/tests/unit/test_operations/test_variable_value_count.py
+++ b/tests/unit/test_operations/test_variable_value_count.py
@@ -1,40 +1,41 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
 from cdisc_rules_engine.operations.variable_value_count import VariableValueCount
 from cdisc_rules_engine.models.operation_params import OperationParams
-import pandas as pd
 import pytest
 import os
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 
 
 @pytest.mark.parametrize(
-    "target, expected",
+    "target, expected, dataset_type",
     [
-        ("DOMAIN", {12: 2, 6: 2, 1: 2}),
-        ("STUDYID", {4: 2, 7: 1, 9: 1, 8: 1, 12: 1}),
-        ("AESEQ", {1: 1, 2: 1, 3: 1}),
-        ("EXSEQ", {1: 1, 2: 1, 3: 1}),
-        ("--SEQ", {1: 2, 2: 2, 3: 2}),
-        ("COOLVAR", {}),
+        ("DOMAIN", {12: 2, 6: 2, 1: 2}, PandasDataset),
+        ("STUDYID", {4: 2, 7: 1, 9: 1, 8: 1, 12: 1}, DaskDataset),
+        ("AESEQ", {1: 1, 2: 1, 3: 1}, PandasDataset),
+        ("EXSEQ", {1: 1, 2: 1, 3: 1}, DaskDataset),
+        ("--SEQ", {1: 2, 2: 2, 3: 2}, PandasDataset),
+        ("COOLVAR", {}, PandasDataset),
     ],
 )
 def test_variable_value_count(
-    target, expected, mock_data_service, operation_params: OperationParams
+    target, expected, dataset_type, mock_data_service, operation_params: OperationParams
 ):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     dataset_path = os.path.join("study", "bundle", "blah")
     datasets_map = {
-        "AE": pd.DataFrame.from_dict(
+        "AE": dataset_type.from_dict(
             {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
         ),
-        "EX": pd.DataFrame.from_dict(
+        "EX": dataset_type.from_dict(
             {"STUDYID": [4, 8, 12], "EXSEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
         ),
-        "AE2": pd.DataFrame.from_dict(
+        "AE2": dataset_type.from_dict(
             {"STUDYID": [4, 7, 9], "AESEQ": [1, 2, 3], "DOMAIN": [12, 6, 1]}
         ),
     }
@@ -47,8 +48,8 @@ def test_variable_value_count(
     mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
         os.path.split(name)[-1]
     )
-    mock_data_service.join_split_datasets.side_effect = lambda func, files: pd.concat(
-        [func(f) for f in files]
+    mock_data_service.join_split_datasets.side_effect = (
+        lambda func, files: dataset_type().concat([func(f) for f in files])
     )
     operation_params.datasets = datasets
     operation_params.original_target = target

--- a/tests/unit/test_operations/test_whodrug_references_validator.py
+++ b/tests/unit/test_operations/test_whodrug_references_validator.py
@@ -1,4 +1,6 @@
 from cdisc_rules_engine.config.config import ConfigService
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.whodrug_references_validator import (
     WhodrugReferencesValidator,
 )
@@ -9,10 +11,14 @@ from cdisc_rules_engine.services.cache.cache_service_factory import CacheService
 from cdisc_rules_engine.services.data_services.data_service_factory import (
     DataServiceFactory,
 )
+import pytest
 
 
+@pytest.mark.parametrize("dataset_type", [(PandasDataset), (DaskDataset)])
 def test_valid_whodrug_references(
-    installed_whodrug_dictionaries: dict, operation_params: OperationParams
+    installed_whodrug_dictionaries: dict,
+    operation_params: OperationParams,
+    dataset_type,
 ):
     """
     Unit test for valid_whodrug_references function.
@@ -21,7 +27,7 @@ def test_valid_whodrug_references(
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
     # create a dataset where 2 rows reference invalid terms
-    invalid_df = pd.DataFrame.from_dict(
+    invalid_df = dataset_type.from_dict(
         {
             "DOMAIN": [
                 "AE",


### PR DESCRIPTION
This PR updates the operators to work with the new dataset abstraction instead of raw datasets.

Steps to test:

1. run unit tests