### PR TITLE
Updates for Issue 537

### DIFF
--- a/cdisc_rules_engine/interfaces/config_interface.py
+++ b/cdisc_rules_engine/interfaces/config_interface.py
@@ -8,8 +8,17 @@ class ConfigInterface(ABC):
     classes.
     """
 
+    def __init__(self):
+        self.configs = {}
+
     @abstractmethod
     def getValue(self, key: str, default=None):
         """
         Returns value of a configuration parameter.
         """
+        if key in self.configs:
+            return self.configs[key]
+        return None
+
+    def setValue(self, key: str, value: str):
+        self.configs[key] = value

--- a/tests/unit/test_local_data_service.py
+++ b/tests/unit/test_local_data_service.py
@@ -6,6 +6,7 @@ import pytest
 from cdisc_rules_engine.config.config import ConfigService
 
 from cdisc_rules_engine.services.data_services import LocalDataService
+from unittest.mock import Mock, patch
 
 
 def test_read_metadata():
@@ -71,3 +72,31 @@ def test_get_variables_metdata():
     ]
     for key in expected_keys:
         assert key in data
+
+
+@pytest.mark.parametrize(
+    "file_size, available_memory, expected_library",
+    [
+        (1024 * 1024, 100 * 1024 * 1024, "pandas"),
+        (100 * 1024 * 1024, 10 * 1024 * 1024, "dask"),
+        (70 * 1024 * 1024, 100 * 1024 * 1024, "dask"),
+    ],
+)
+def test_choose_library(file_size, available_memory, expected_library):
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+    data_service = LocalDataService.get_instance(
+        config=ConfigService(), cache_service=mock_cache
+    )
+    mock_virtual_memory = Mock()
+    mock_virtual_memory.available = available_memory
+
+    with patch("psutil.virtual_memory", return_value=mock_virtual_memory):
+
+        File = os.path.join(os.path.dirname(__file__), "test_dataset.csv")
+        with open(File, "wb") as f:
+            f.write(b"a,b\n" * file_size)
+        library = data_service.choose_library(File)
+
+        os.remove(File)
+        assert library == expected_library


### PR DESCRIPTION
The PR adds the changes for fulfilling the issue 537 AC. The changes adds a function to determine either to use dask or pandas.After research i noticed that pandas dataframe fail or become slow when datasets are larger or equivalent to available RAM. Instead of using a fixed threshold, i have set the code to check if the dataset size is larger than 70% available memory then use dask else pandas.

 A config variable can also be set to supersede the normal criteria for determining which dataset to use. If config is set it returns the name of dataset set in the config 