### PR TITLE
fixed optional schema bug

### DIFF
--- a/cdisc_rules_engine/operations/record_count.py
+++ b/cdisc_rules_engine/operations/record_count.py
@@ -21,11 +21,10 @@ class RecordCount(BaseOperation):
             result = len(filtered)
         if self.params.grouping:
             self.params.target = "size"
-            if filtered is not None:
-                group_df = filtered.groupby(self.params.grouping, as_index=False).size()
-            else:
-                group_df = self.params.dataframe.groupby(
-                    self.params.grouping, as_index=False
-                ).size()
+            group_df = (
+                (filtered if filtered is not None else self.params.dataframe)
+                .groupby(self.params.grouping, as_index=False)
+                .size()
+            )
             return group_df
         return result

--- a/resources/schema/Operations.json
+++ b/resources/schema/Operations.json
@@ -182,7 +182,6 @@
         "operator": { "const": "record_count" }
       },
       "required": ["id", "operator"],
-      "optional": ["filter"],
       "type": "object"
     },
     {
@@ -350,6 +349,7 @@
     "external_dictionary_type": {
       "enum": ["meddra"]
     },
+    "filter": { "type": "object" },
     "group": {
       "items": {
         "$ref": "CORE-base.json#/$defs/VariableName"


### PR DESCRIPTION
Fixed bug described in attached issue. `optional` is not a valid keyword in the version of json-schema that we are using.
Also tweaked the record-count to avoid the repeated code and avoid the dataframe coalesce issue.