### PR TITLE
Fix JSON reader to Parquet

### DIFF
--- a/cdisc_rules_engine/config/config.py
+++ b/cdisc_rules_engine/config/config.py
@@ -13,7 +13,7 @@ class ConfigService(ConfigInterface):
     _config_keys = []
     _instance = None
     # TODO: Make this configurable via env variable
-    _dataset_size_threshold = psutil.virtual_memory().available * 0.25
+    _default_dataset_size_threshold = psutil.virtual_memory().available * 0.25
 
     def __new__(cls):
         if cls._instance is None:
@@ -26,6 +26,7 @@ class ConfigService(ConfigInterface):
                 "REDIS_ACCESS_KEY",
                 "CDISC_LIBRARY_API_KEY",
                 "DATA_SERVICE_TYPE",
+                "DATASET_SIZE_THRESHOLD",
             ]
 
         return cls._instance
@@ -37,4 +38,10 @@ class ConfigService(ConfigInterface):
             return default
 
     def get_dataset_size_threshold(self):
-        return self._dataset_size_threshold
+        try:
+            return float(
+                self.getValue("DATASET_SIZE_THRESHOLD")
+                or self._default_dataset_size_threshold
+            )
+        except Exception:
+            return self._default_dataset_size_threshold

--- a/cdisc_rules_engine/services/data_readers/json_reader.py
+++ b/cdisc_rules_engine/services/data_readers/json_reader.py
@@ -14,50 +14,64 @@ import tempfile
 
 
 class DatasetJSONReader(DataReaderInterface):
-    def from_file(self, file_path):
-        # Load Dataset-JSON Schema
+    def get_schema(self) -> dict:
         with open(
             os.path.join("resources", "schema", "dataset.schema.json")
         ) as schemajson:
             schema = schemajson.read()
-        schema = json.loads(schema)
+        return json.loads(schema)
 
+    def get_data_key(self, dataset_json: dict) -> str:
+        if "clinicalData" in dataset_json:
+            return "clinicalData"
+        return "referenceData"
+
+    def read_json_file(self, file_path: str) -> dict:
         with open(file_path, "r") as file:
             datasetjson = json.load(file)
+        return datasetjson
 
+    def parse_items_data(self, dataset_json: dict, data_key: str) -> pd.DataFrame:
+        items_data = next(
+            (
+                d
+                for d in dataset_json[data_key]["itemGroupData"].values()
+                if "items" in d
+            ),
+            {},
+        )
+        return pd.DataFrame(
+            [item[1:] for item in items_data.get("itemData", [])],
+            columns=[item["name"] for item in items_data.get("items", [])[1:]],
+        )
+
+    def _raw_dataset_from_file(self, file_path) -> pd.DataFrame:
+        schema = self.get_schema()
+        datasetjson = self.read_json_file(file_path)
+
+        jsonschema.validate(datasetjson, schema)
+        data_key = self.get_data_key(datasetjson)
+        df = self.parse_items_data(datasetjson, data_key)
+        return df.applymap(lambda x: round(x, 15) if isinstance(x, float) else x)
+
+    def from_file(self, file_path):
+        # Load Dataset-JSON Schema
         try:
-            jsonschema.validate(datasetjson, schema)
-            if "clinicalData" in datasetjson:
-                data_key = "clinicalData"
-            elif "referenceData" in datasetjson:
-                data_key = "referenceData"
-
-            items_data = next(
-                (
-                    d
-                    for d in datasetjson[data_key]["itemGroupData"].values()
-                    if "items" in d
-                ),
-                {},
-            )
-            df = pd.DataFrame(
-                [item[1:] for item in items_data.get("itemData", [])],
-                columns=[item["name"] for item in items_data.get("items", [])[1:]],
-            )
-
-            df = df.applymap(lambda x: round(x, 15) if isinstance(x, float) else x)
-
+            df = self._raw_dataset_from_file(file_path)
             if self.dataset_implementation == PandasDataset:
                 return PandasDataset(df)
             else:
-                return DaskDataset(dd.from_pandas(df), npartitions=4)
+                return DaskDataset(
+                    dd.from_pandas(df, npartitions=4), length=len(df.index)
+                )
         except jsonschema.exceptions.ValidationError:
             return PandasDataset(pd.DataFrame())
 
-    def to_parquet(self, file_path: str) -> str:
+    def to_parquet(self, file_path: str) -> (int, str):
         temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".parquet")
-        dataset = self.from_file(file_path)
-        dataset.data.to_parquet(temp_file.name)
+        df = self._raw_dataset_from_file(file_path)
+        df.to_parquet(temp_file.name)
+        return len(df.index), temp_file.name
 
     def read(self, data):
         pass

--- a/cdisc_rules_engine/services/data_readers/json_reader.py
+++ b/cdisc_rules_engine/services/data_readers/json_reader.py
@@ -46,6 +46,7 @@ class DatasetJSONReader(DataReaderInterface):
         )
 
     def _raw_dataset_from_file(self, file_path) -> pd.DataFrame:
+        # Load Dataset-JSON Schema
         schema = self.get_schema()
         datasetjson = self.read_json_file(file_path)
 
@@ -55,7 +56,6 @@ class DatasetJSONReader(DataReaderInterface):
         return df.applymap(lambda x: round(x, 15) if isinstance(x, float) else x)
 
     def from_file(self, file_path):
-        # Load Dataset-JSON Schema
         try:
             df = self._raw_dataset_from_file(file_path)
             if self.dataset_implementation == PandasDataset:


### PR DESCRIPTION
This PR fixes the to_parquet method in the json reader class.

It now writes the raw dataset to the tempfile instead of converting to dask first.

Steps to test:
1. Force the engine to use dask datasets. you can do this by setting the `DATASET_SIZE_THRESHOLD` environment variable to 0
2. Run a validation with dataset json. (I used this one for testing:
[TS_neg.json](https://github.com/cdisc-org/cdisc-rules-engine/files/15287474/TS_neg.json)
3. Verify the validation runs completely.