### PR TITLE
Missing keys bug

### DIFF
--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -189,7 +189,7 @@ def load_rules_from_local(args) -> List[dict]:
         rule = load_and_parse_rule(rule_file)
         if rule:
             process_rule(rule, args, rule_data, rules, keys)
-
+    missing_keys = set()
     if keys:
         missing_keys = keys - rule_data.keys()
     if missing_keys:

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -189,10 +189,9 @@ def load_rules_from_local(args) -> List[dict]:
         rule = load_and_parse_rule(rule_file)
         if rule:
             process_rule(rule, args, rule_data, rules, keys)
-    missing_keys = set()
+
     if keys:
         missing_keys = keys - rule_data.keys()
-    if missing_keys:
         missing_keys_str = ", ".join(missing_keys)
         engine_logger.error(
             f"Specified rules not found in the local directory: {missing_keys_str}"

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -190,8 +190,10 @@ def load_rules_from_local(args) -> List[dict]:
         if rule:
             process_rule(rule, args, rule_data, rules, keys)
 
+    missing_keys = set()
     if keys:
         missing_keys = keys - rule_data.keys()
+    if missing_keys:
         missing_keys_str = ", ".join(missing_keys)
         engine_logger.error(
             f"Specified rules not found in the local directory: {missing_keys_str}"


### PR DESCRIPTION
the if check on line 195 needs an initialized missing_keys value to check truthy/falsiness.  

python .\core.py validate -s sdtmig -v 3-4 --local_rules C:\TEMP\core-windows\my_rules -d ..\m5\datasets\cdiscpilot01\tabulations\sdtm\  this was the command run by Anthony

resulting in this error:
Traceback (most recent call last):
  File "C:\TEMP\cdisc-rules-engine-main\core.py", line 516, in <module>
    cli()
  File "C:\TEMP\cdisc-rules-engine-main\venv\lib\site-packages\click\core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "C:\TEMP\cdisc-rules-engine-main\venv\lib\site-packages\click\core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "C:\TEMP\cdisc-rules-engine-main\venv\lib\site-packages\click\core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\TEMP\cdisc-rules-engine-main\venv\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\TEMP\cdisc-rules-engine-main\venv\lib\site-packages\click\core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "C:\TEMP\cdisc-rules-engine-main\venv\lib\site-packages\click\decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "C:\TEMP\cdisc-rules-engine-main\core.py", line 240, in validate
    run_validation(
  File "C:\TEMP\cdisc-rules-engine-main\scripts\run_validation.py", line 119, in run_validation
    rules = get_rules(args)
  File "C:\TEMP\cdisc-rules-engine-main\scripts\script_utils.py", line 123, in get_rules
    load_rules_from_local(args) if args.local_rules else load_rules_from_cache(args)
  File "C:\TEMP\cdisc-rules-engine-main\scripts\script_utils.py", line 195, in load_rules_from_local
    if missing_keys:
UnboundLocalError: local variable 'missing_keys' referenced before assignment

since no keys were specified in args.rules using the -r flag, the filter to initialize missing_keys is not entered.  I have removed the if missing_keys filter--this logic should only be entered if rule IDs are specified with the -r flag and we want to determine if rules were specified that are not present in the local directory.  