### PR TITLE
fix bug-168

### DIFF
--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -485,6 +485,8 @@ class RuleProcessor:
             target_names: List[str] = []
             conditions: ConditionInterface = rule["conditions"]
             for condition in conditions.values():
+                if condition.get("operator") == "not_exists":
+                    continue
                 target: str = condition["value"].get("target")
                 if target is None:
                     continue


### PR DESCRIPTION
add condition to not return output variables if the operator is "not_exists"
