### PR TITLE
ISS-709 - Fix contained by operator

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -76,8 +76,6 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def exists(self, other_value):
         target_column = self.replace_prefix(other_value.get("target"))
-        print(target_column in self.value)
-        print(len(self.value))
         return self.value.convert_to_series(
             [target_column in self.value] * len(self.value)
         )

--- a/cdisc_rules_engine/models/dataset/pandas_dataset.py
+++ b/cdisc_rules_engine/models/dataset/pandas_dataset.py
@@ -62,10 +62,8 @@ class PandasDataset(DatasetInterface):
     def __contains__(self, item: str) -> bool:
         return item in self._data
 
-    def get(self, column: str, default=None):
-        if column in self._data:
-            return self._data[column]
-        return default
+    def get(self, target: Union[str, List[str]], default=None):
+        return self._data.get(target, default)
 
     def groupby(self, by: List[str], **kwargs):
         return self.__class__(self._data.groupby(by, **kwargs))

--- a/tests/unit/test_check_operators/test_containment_checks.py
+++ b/tests/unit/test_check_operators/test_containment_checks.py
@@ -159,3 +159,79 @@ def test_not_contains_all(data, comparator, dataset_type, expected_result):
         {"target": "target", "comparator": comparator}
     )
     assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,dataset_type, expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "btt", "lll"]},
+            ["Ctt", "B", "A"],
+            PandasDataset,
+            [True, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"]},
+            ["C", "Z", "A"],
+            DaskDataset,
+            [True, False, True],
+        ),
+        (
+            {"target": [1, 2, 3], "VAR2": [[1, 2], [3], [3]]},
+            "VAR2",
+            PandasDataset,
+            [True, False, True],
+        ),
+        (
+            {"target": [1, 2, 3], "VAR2": [[1, 2], [3], [3]]},
+            "VAR2",
+            DaskDataset,
+            [True, False, True],
+        ),
+    ],
+)
+def test_is_contained_by(data, comparator, dataset_type, expected_result):
+    df = dataset_type.from_dict(data)
+    dataframe_operator = DataframeType({"value": df})
+    result = dataframe_operator.is_contained_by(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,dataset_type, expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "btt", "lll"]},
+            ["Ctt", "B", "A"],
+            PandasDataset,
+            [False, True, False],
+        ),
+        (
+            {"target": ["A", "B", "C"]},
+            ["C", "Z", "A"],
+            DaskDataset,
+            [False, True, False],
+        ),
+        (
+            {"target": [1, 2, 3], "VAR2": [[1, 2], [2], [2]]},
+            "VAR2",
+            PandasDataset,
+            [False, False, True],
+        ),
+        (
+            {"target": [1, 2, 3], "VAR2": [[1, 2], [2], [2]]},
+            "VAR2",
+            DaskDataset,
+            [False, False, True],
+        ),
+    ],
+)
+def test_is_not_contained_by(data, comparator, dataset_type, expected_result):
+    df = dataset_type.from_dict(data)
+    dataframe_operator = DataframeType({"value": df})
+    result = dataframe_operator.is_not_contained_by(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(df.convert_to_series(expected_result))

--- a/tests/unit/test_check_operators/test_containment_checks.py
+++ b/tests/unit/test_check_operators/test_containment_checks.py
@@ -235,3 +235,83 @@ def test_is_not_contained_by(data, comparator, dataset_type, expected_result):
         {"target": "target", "comparator": comparator}
     )
     assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,dataset_type, expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "btt", "lll"]},
+            ["ctt", "b", "a"],
+            PandasDataset,
+            [True, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"]},
+            ["c", "z", "a"],
+            DaskDataset,
+            [True, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": [["a", "b"], ["c"], ["c"]]},
+            "VAR2",
+            PandasDataset,
+            [True, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": [["a", "b"], ["c"], ["c"]]},
+            "VAR2",
+            DaskDataset,
+            [True, False, True],
+        ),
+    ],
+)
+def test_is_contained_by_case_insensitive(
+    data, comparator, dataset_type, expected_result
+):
+    df = dataset_type.from_dict(data)
+    dataframe_operator = DataframeType({"value": df})
+    result = dataframe_operator.is_contained_by_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data,comparator,dataset_type, expected_result",
+    [
+        (
+            {"target": ["Ctt", "Btt", "A"], "VAR2": ["A", "btt", "lll"]},
+            ["ctt", "b", "a"],
+            PandasDataset,
+            [False, True, False],
+        ),
+        (
+            {"target": ["A", "B", "C"]},
+            ["c", "z", "a"],
+            DaskDataset,
+            [False, True, False],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": [["a", "b"], ["b"], ["b"]]},
+            "VAR2",
+            PandasDataset,
+            [False, False, True],
+        ),
+        (
+            {"target": ["A", "B", "C"], "VAR2": [["a", "b"], ["b"], ["b"]]},
+            "VAR2",
+            DaskDataset,
+            [False, False, True],
+        ),
+    ],
+)
+def test_is_not_contained_by_case_insensitive(
+    data, comparator, dataset_type, expected_result
+):
+    df = dataset_type.from_dict(data)
+    dataframe_operator = DataframeType({"value": df})
+    result = dataframe_operator.is_not_contained_by_case_insensitive(
+        {"target": "target", "comparator": comparator}
+    )
+    assert result.equals(df.convert_to_series(expected_result))


### PR DESCRIPTION
This PR fixes the `get` method implementation on the Dataset Interfaces to resolve the issues found in #709 

Steps to test:
* Test the rule and data found in the issue and verify the results are what you would expect
* Unit tests pass