### PR TITLE
Iss 690-estimate XML filesize without reading whole dataset

### DIFF
--- a/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
+++ b/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
@@ -73,6 +73,17 @@ class DatasetXPTMetadataReader:
             pass
         return None
 
+    def _calculate_dataset_length(self):
+        iterator = pd.read_sas(self.file_path, iterator=True, chunksize=1)
+        try:
+            next(iterator)
+            breakpoint()
+        except StopIteration:
+            print("error")
+            breakpoint()
+        # row_size = sum(self._metadata_container["variable_name_to_size_map"].values())
+        # return int(os.path.getsize(self._file_path) / row_size)
+
     def _convert_variable_types(self):
         """
         Converts variable types to the format that

--- a/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
+++ b/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import xport.v56
 from xport import LOG as XPORT_LOG
+import pyreadstat
 
 from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.services.adam_variable_reader import AdamVariableReader
@@ -23,6 +24,7 @@ class DatasetXPTMetadataReader:
         self._metadata_container = None
         self._domain_name = None
         self._dataset_name = file_name.split(".")[0].upper()
+        self._file_path = file_path
 
     def read(self) -> dict:
         """
@@ -47,7 +49,7 @@ class DatasetXPTMetadataReader:
             ).to_dict(),
             "number_of_variables": len(dataset.columns),
             "dataset_label": dataset.dataset_label,
-            "dataset_length": dataset.shape[0],
+            "dataset_length": self._calculate_dataset_length(),
             "domain_name": self._domain_name,
             "dataset_name": self._dataset_name,
             "dataset_modification_date": dataset.modified.isoformat(),
@@ -74,13 +76,21 @@ class DatasetXPTMetadataReader:
         return None
 
     def _calculate_dataset_length(self):
-        iterator = pd.read_sas(self.file_path, iterator=True, chunksize=1)
-        try:
-            next(iterator)
-            breakpoint()
-        except StopIteration:
-            print("error")
-            breakpoint()
+        df, meta = pyreadstat.read_xport(self._file_path, metadataonly=True)
+        meta.variable_storage_width
+        breakpoint()
+        return meta
+        # sas_iterator = pd.read_sas(self._file_path, iterator=True, chunksize=1)
+        # first_chunk = next(sas_iterator)
+        # breakpoint()
+        # return
+
+        # with open(self.file_path, 'rb') as data:
+        #     library = xport.Library(data)
+        #     dataset = next(iter(library))
+        #     record_size = dataset.header.record_size
+        #     start = dataset.header.start
+
         # row_size = sum(self._metadata_container["variable_name_to_size_map"].values())
         # return int(os.path.getsize(self._file_path) / row_size)
 

--- a/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
+++ b/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
@@ -20,7 +20,7 @@ class DatasetXPTMetadataReader:
             self._estimate_dataset_length = True
             self.row_limit = 1
         else:
-            self._estimate_dataset_length = True
+            self._estimate_dataset_length = False
             self.row_limit = 0
         self._metadata_container = {}
         self._domain_name = None

--- a/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
+++ b/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
@@ -1,6 +1,3 @@
-# import pandas as pd
-# import xport.v56
-# from xport import LOG as XPORT_LOG
 import pyreadstat
 
 from cdisc_rules_engine.services import logger

--- a/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
+++ b/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
@@ -90,67 +90,29 @@ class DatasetXPTMetadataReader:
         estimated_rows = (total_size - start - remainder) / row_size
         if row_size < 80:
             padding = self._count_trailing_padding(self._file_path, row_size)
-            breakpoint()
             return (total_size - start - padding) / row_size
-        breakpoint()
         return estimated_rows
 
     def _count_trailing_padding(self, file_path, row_size):
         """
         reads the file from the end in chunks of 80 bytes and counts the total number of trailing padding bytes
         """
+        padding_size = 0
         with open(file_path, "rb") as file:
             file.seek(0, os.SEEK_END)
             file_size = file.tell()
             file.seek(file_size - 1)
 
-        padding_size = 0
-        while file.tell() > 0:
-            byte = file.read(1)
-            # may need to change this check to include null bytes; or ASCII 32 digit for space
-            if byte == b" ":
-                padding_size += 1
-                # Move back 2: 1 for the byte just read, 1 more to move to the next byte to check
-                if file.tell() == 1:
-                    break  # if we are at the beginning of the file, break
-                file.seek(file.tell() - 2)
-            else:
-                break
-
+            while file.tell() > 0:
+                byte = file.read(1)
+                if byte == b" ":
+                    padding_size += 1
+                    if file.tell() == 1:
+                        break
+                    file.seek(file.tell() - 2)
+                else:
+                    break
         return padding_size
-        # old padding calculator
-        # chunk_size = 300
-        # padding_chars = (b"\x00", b" ")
-        # total_size = os.path.getsize(file_path)
-        # read_size = min(chunk_size, total_size)
-        # total_padding = 0
-
-        # with open(file_path, "rb") as file:
-        #     offset = total_size
-        #     while offset > 0:
-        #         new_offset = max(0, offset - read_size)
-        #         read_length = offset - new_offset
-        #         file.seek(new_offset)
-        #         data = file.read(read_length)
-
-        #         current_padding = 0
-        #         padding_found = False
-        #         for byte in reversed(data):
-        #             byte = bytes([byte])
-        #             if byte in padding_chars:
-        #                 if not padding_found:
-        #                     padding_found = True
-        #                 current_padding += 1
-        #             else:
-        #                 if padding_found:
-        #                     break
-        #         if current_padding == read_length and padding_found:
-        #             total_padding += current_padding
-        #             offset = new_offset
-        #         else:
-        #             total_padding += current_padding
-        #             break
-        # return total_padding
 
     def _read_header(self, file_path):
         """

--- a/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
+++ b/cdisc_rules_engine/services/datasetxpt_metadata_reader.py
@@ -102,18 +102,20 @@ class DatasetXPTMetadataReader:
         with open(file_path, "rb") as file:
             file.seek(0, os.SEEK_END)
             file_size = file.tell()
-            last_possible_start = max(80, file_size - 80)
-            file.seek(last_possible_start)
-            last_data = file.read(80)
+            file.seek(file_size - 1)
 
         padding_size = 0
-        for i in range(0, 80, row_size):
-            if i + row_size <= len(last_data):
-                potential_record = last_data[i : i + row_size]
-                if all(x == 32 for x in potential_record):
-                    padding_size += row_size
-                else:
-                    break
+        while file.tell() > 0:
+            byte = file.read(1)
+            # may need to change this check to include null bytes; or ASCII 32 digit for space
+            if byte == b" ":
+                padding_size += 1
+                # Move back 2: 1 for the byte just read, 1 more to move to the next byte to check
+                if file.tell() == 1:
+                    break  # if we are at the beginning of the file, break
+                file.seek(file.tell() - 2)
+            else:
+                break
 
         return padding_size
         # old padding calculator

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ openpyxl==3.0.10
 pandas==1.5.2
 pre-commit==2.20.0
 pyinstaller==5.2
-pyreadstat==1.2.7
 pytest==7.1.2
 pytest-asyncio==0.18.3
 pytest-cov==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ openpyxl==3.0.10
 pandas==1.3.5
 pre-commit==2.20.0
 pyinstaller==5.2
+pyreadstat==1.2.7
 pytest==7.1.2
 pytest-asyncio==0.18.3
 pytest-cov==3.0.0

--- a/tests/unit/test_datasetxpt_metadata_reader.py
+++ b/tests/unit/test_datasetxpt_metadata_reader.py
@@ -2,7 +2,7 @@
 This module contains unit tests for DatasetMetadataReader class.
 """
 import os
-
+from unittest.mock import patch
 from cdisc_rules_engine.services.datasetxpt_metadata_reader import (
     DatasetXPTMetadataReader,
 )
@@ -96,3 +96,35 @@ def test_read_metadata_with_variable_formats():
         "",
         "",
     ]
+
+
+def test_read_header():
+    """
+    Unit test for the method _read_header.
+    Loads test .xpt file and reads the header, returning the start of the dataset.
+    Mock_open cannot simulate partial read() behavior so normal file reading is employed.
+    """
+    test_dataset_path = f"{os.path.dirname(__file__)}/../resources/test_dataset.xpt"
+
+    reader = DatasetXPTMetadataReader(test_dataset_path, file_name="test_dataset.xpt")
+    start_index = reader._read_header(test_dataset_path)
+
+    assert start_index == 3120
+
+
+def test_calculate_dataset_length_with_mocked_header():
+    """
+    Unit test for the method _calculate_dataset_length with mocked _read_header.
+    Calculates the length of the dataset based on the  and row size.
+    """
+    test_dataset_path: str = (
+        f"{os.path.dirname(__file__)}/../resources/test_dataset.xpt"
+    )
+    reader = DatasetXPTMetadataReader(test_dataset_path, file_name="test_dataset.xpt")
+
+    # Mock the _read_header method to return a start position
+    with patch.object(reader, "_read_header", return_value=3120):
+        expected_length = 1583
+        dataset_length = reader._calculate_dataset_length()
+
+    assert dataset_length == expected_length

--- a/tests/unit/test_datasetxpt_metadata_reader.py
+++ b/tests/unit/test_datasetxpt_metadata_reader.py
@@ -48,6 +48,54 @@ def test_read_metadata():
     assert isinstance(metadata["variable_name_to_size_map"], dict)
 
 
+def test_read_metadata_with_estimate():
+    """
+    Unit test for metadata read using estimate length for xpt file.
+    """
+    test_dataset_path: str = (
+        f"{os.path.dirname(__file__)}/../resources/test_dataset.xpt"
+    )
+    with patch.dict(os.environ, {"DATASET_SIZE_THRESHOLD": "1"}):
+        reader = DatasetXPTMetadataReader(
+            test_dataset_path, file_name="test_dataset.xpt"
+        )
+        assert reader._estimate_dataset_length is True
+        assert reader.row_limit == 1
+
+        metadata: dict = reader.read()
+        assert (
+            metadata["dataset_name"] == "TEST_DATASET"
+        ), "Wrong dataset name. Test file has been changed"
+        assert (
+            metadata["domain_name"] == "EX"
+        ), "Wrong domain name. Test file has been changed"
+        assert (
+            metadata["dataset_label"] == "Exposure"
+        ), "Wrong dataset label. Test file has been changed"
+        assert (
+            metadata["number_of_variables"] == 17
+        ), "Wrong number of variables. Test file has been changed"
+        assert (
+            metadata["dataset_length"] == 1583
+        ), "Wrong estimated dataset length. Test file or estimator has been changed"
+        assert (
+            metadata["dataset_modification_date"] == "2020-08-21T09:14:26"
+        ), "Incorrect modification date. Test file has been changed"
+        assert isinstance(metadata["variable_labels"], list)
+        assert isinstance(metadata["variable_names"], list)
+        assert isinstance(metadata["variable_name_to_data_type_map"], dict)
+        assert any(
+            val in ["Char", "Num"]
+            for val in metadata["variable_name_to_data_type_map"].values()
+        )
+        assert any(
+            val not in ["string", "double", "Character", "Numeric"]
+            for val in metadata["variable_name_to_data_type_map"].values()
+        ), "pyreadstat values has not been converted"
+        assert isinstance(metadata["variable_name_to_label_map"], dict)
+        assert isinstance(metadata["variable_name_to_size_map"], dict)
+
+
 def test_read_metadata_with_variable_formats():
     """
     Unit test for function read.


### PR DESCRIPTION
changed XPT metadata reader to no longer read full dataset and instead read only header, 1 row, and end of file to estimate rows.

Works for edge cases --empty dataframe and small row size.  I can provide these datasets to the reviewer as github does not support XPT files and thus I cannot attach them to the PR.