### PR TITLE
add new argument to get_variables_metadata calls in dataset builders

### DIFF
--- a/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_dataset_builder.py
@@ -14,5 +14,5 @@ class VariablesMetadataDatasetBuilder(BaseDatasetBuilder):
         variable_format
         """
         return self.data_service.get_variables_metadata(
-            self.dataset_path, drop_duplicates=True
+            dataset_name=self.dataset_path, datasets=self.datasets, drop_duplicates=True
         )

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_dataset_builder.py
@@ -33,7 +33,7 @@ class VariablesMetadataWithDefineDatasetBuilder(BaseDatasetBuilder):
         variable_metadata: List[dict] = self.get_define_xml_variables_metadata()
         # get dataset metadata and execute the rule
         content_metadata: DatasetInterface = self.data_service.get_variables_metadata(
-            self.dataset_path, drop_duplicates=True
+            dataset_name=self.dataset_path, datasets=self.datasets, drop_duplicates=True
         )
         define_metadata: DatasetInterface = self.dataset_implementation.from_records(
             variable_metadata

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_with_library_metadata.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_with_library_metadata.py
@@ -23,7 +23,9 @@ class VariablesMetadataWithLibraryMetadataDatasetBuilder(BaseDatasetBuilder):
         # get dataset metadata and execute the rule
         content_variables_metadata: DatasetInterface = (
             self.data_service.get_variables_metadata(
-                self.dataset_path, drop_duplicates=True
+                dataset_name=self.dataset_path,
+                datasets=self.datasets,
+                drop_duplicates=True,
             )
         )
         dataset_contents = self.get_dataset_contents()

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -232,6 +232,7 @@ class RuleProcessor:
             return dataset
 
         dataset_copy = dataset.copy()
+        previous_operations = []
         for operation in operations:
             # change -- pattern to domain name
             original_target: str = operation.get("name")
@@ -272,7 +273,10 @@ class RuleProcessor:
             )
 
             # execute operation
-            dataset_copy = self._execute_operation(operation_params, dataset_copy)
+            dataset_copy = self._execute_operation(
+                operation_params, dataset_copy, previous_operations
+            )
+            previous_operations.append(operation_params.operation_name)
 
             logger.info(
                 f"Processed rule operation. "
@@ -281,7 +285,10 @@ class RuleProcessor:
         return dataset_copy
 
     def _execute_operation(
-        self, operation_params: OperationParams, dataset: DatasetInterface
+        self,
+        operation_params: OperationParams,
+        dataset: DatasetInterface,
+        previous_operations: List[str] = [],
     ):
         """
         Internal method that executes the given operation.
@@ -297,6 +304,8 @@ class RuleProcessor:
             target_variable=operation_params.target,
             dataset_path=operation_params.dataset_path,
         )
+        if previous_operations:
+            cache_key = f'{cache_key}-{";".join(previous_operations)}'
         result: DatasetInterface = self.cache.get(cache_key)
         if result is not None:
             return result

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -192,7 +192,7 @@ class RuleProcessor:
 
         if excluded_classes:
             variables = self.data_service.get_variables_metadata(
-                dataset_name=file_path
+                dataset_name=file_path, datasets=datasets
             ).data.variable_name
             class_name = self.data_service.get_dataset_class(
                 variables, file_path, datasets, domain

--- a/tests/QARegressionTests/test_core/test_validate.py
+++ b/tests/QARegressionTests/test_core/test_validate.py
@@ -82,7 +82,7 @@ class TestValidate(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_required_v_option_missing(self):
         args = [
@@ -118,7 +118,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_with_all_required_options(self):
         args = [
@@ -138,7 +138,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_without_all_required_options(self):
         args = [
@@ -238,7 +238,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(stderr, "")
         self.assertFalse(self.error_message in stdout)
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_less_than_minimum_options(self):
         args = ["python", "-m", "core", "validate", "-s", "sdtmig"]
@@ -330,7 +330,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_with_log_level_info(self):
         args = [
@@ -352,7 +352,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertIn("warning", stderr)
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_with_log_level_error(self):
         args = [
@@ -374,7 +374,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertNotEqual(stderr, "")
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_with_log_level_critical(self):
         args = [
@@ -396,7 +396,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_with_log_level_warn(self):
         args = [
@@ -417,7 +417,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertNotIn("warning", stderr)
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_with_invalid_log_level(self):
         args = [
@@ -457,7 +457,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_high_value_ps(self):
         args = [
@@ -479,7 +479,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_define_xml_path(self):
         args = [
@@ -501,7 +501,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def tearDown(self):
         for file_name in os.listdir("."):

--- a/tests/QARegressionTests/test_core/test_validate.py
+++ b/tests/QARegressionTests/test_core/test_validate.py
@@ -218,7 +218,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(stderr, "")
         self.assertFalse(self.error_message in stdout)
-        self.assertFalse(self.check_issue_summary_tab_empty())
+        self.assertTrue(self.check_issue_summary_tab_empty())
 
     def test_validate_minimum_options(self):
         args = [

--- a/tests/QARegressionTests/test_core/test_validate.py
+++ b/tests/QARegressionTests/test_core/test_validate.py
@@ -82,7 +82,7 @@ class TestValidate(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_required_v_option_missing(self):
         args = [
@@ -118,7 +118,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_with_all_required_options(self):
         args = [
@@ -138,7 +138,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_without_all_required_options(self):
         args = [
@@ -218,7 +218,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(stderr, "")
         self.assertFalse(self.error_message in stdout)
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_minimum_options(self):
         args = [
@@ -238,7 +238,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(stderr, "")
         self.assertFalse(self.error_message in stdout)
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_less_than_minimum_options(self):
         args = ["python", "-m", "core", "validate", "-s", "sdtmig"]
@@ -330,7 +330,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_with_log_level_info(self):
         args = [
@@ -352,7 +352,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertIn("warning", stderr)
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_with_log_level_error(self):
         args = [
@@ -374,7 +374,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertNotEqual(stderr, "")
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_with_log_level_critical(self):
         args = [
@@ -396,7 +396,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_with_log_level_warn(self):
         args = [
@@ -417,7 +417,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertNotIn("warning", stderr)
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_with_invalid_log_level(self):
         args = [
@@ -457,7 +457,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_high_value_ps(self):
         args = [
@@ -479,7 +479,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def test_validate_define_xml_path(self):
         args = [
@@ -501,7 +501,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(self.error_message in stdout)
         self.assertEqual(stderr, "")
-        self.assertTrue(self.check_issue_summary_tab_empty())
+        self.assertFalse(self.check_issue_summary_tab_empty())
 
     def tearDown(self):
         for file_name in os.listdir("."):


### PR DESCRIPTION
Recently a new argument was added to the get_variables_metadata method of the LocalDataService, the dataset builders did not provide this argument. This PR adds the new argument to get_variables_metadata function calls.

Steps to test:

Verify rule CORE-000334 runs correctly on an xpt file