### PR TITLE
Updated target_is_not_sorted_by operator

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -1271,22 +1271,32 @@ class DataframeType(BaseType):
         target: str = self.replace_prefix(other_value.get("target"))
         within: str = self.replace_prefix(other_value.get("within"))
         columns = other_value["comparator"]
+
+        result = pd.Series([True] * len(self.value), index=self.value.index)
         for col in columns:
             comparator: str = self.replace_prefix(col["name"])
-            ascending: str = col["sort_order"] != "DESC"
+            ascending: bool = col["sort_order"].lower() != "desc"
             na_pos: str = col["null_position"]
-
-            grouped_df = (
-                self.value[[target, within, comparator]]
-                .sort_values(by=[within, comparator], na_position=na_pos)
-                .groupby([within])
-                .apply(lambda x: x)
+            sorted_df = self.value[[target, within, comparator]].sort_values(
+                by=[within, comparator], ascending=ascending, na_position=na_pos
             )
-            temp_target = grouped_df.groupby(within).cumcount().apply(lambda x: x + 1)
-            if not ascending:
-                grouped_df = grouped_df.reset_index(drop=True)
-                temp_target = temp_target[::-1].reset_index(drop=True)
-        return temp_target.eq(grouped_df[target]).sort_index(axis=0)
+            # temporary DataFrame to check the order
+            grouped_df = sorted_df.groupby(within)
+            # Series to hold the sorted check results
+            sorted_check = pd.Series(index=sorted_df.index, dtype=bool)
+
+            for name, group in grouped_df:
+                sorted_values = group[target].values
+                expected_values = (
+                    np.sort(sorted_values)
+                    if ascending
+                    else np.sort(sorted_values)[::-1]
+                )
+                sorted_check[group.index] = np.array_equal(
+                    sorted_values, expected_values
+                )
+            result.update(sorted_check)
+        return result
 
     @type_operator(FIELD_DATAFRAME)
     def target_is_not_sorted_by(self, other_value: dict):

--- a/tests/unit/test_check_operators/test_relationship_integrity_checks.py
+++ b/tests/unit/test_check_operators/test_relationship_integrity_checks.py
@@ -819,13 +819,13 @@ def test_target_is_sorted_by(dataset_class):
     valid_desc_df = dataset_class.from_dict(
         {
             "USUBJID": ["CDISC001", "CDISC002", "CDISC002", "CDISC001", "CDISC001"],
-            "SESEQ": [2, 1, 2, 3, 1],
+            "SESEQ": [3, 2, 1, 2, 1],
             "SESTDTC": [
-                "2006-06-02",
+                "2006-06-05",
                 "2006-06-04",
                 "2006-06-01",
-                "2006-06-05",
                 "2006-06-03",
+                "2006-06-02",
             ],
         }
     )
@@ -890,7 +890,7 @@ def test_target_is_sorted_by(dataset_class):
     valid_desc_df = dataset_class.from_dict(
         {
             "USUBJID": [123, 456, 456, 123, 123],
-            "SESEQ": [2, 1, 2, 3, 1],
+            "SESEQ": [1, 2, 1, 3, 2],
             "SESTDTC": [
                 "2006-06-02",
                 "2006-06-04",
@@ -925,7 +925,7 @@ def test_target_is_sorted_by(dataset_class):
     invalid_df = dataset_class.from_dict(
         {
             "USUBJID": ["CDISC001", "CDISC002", "CDISC002", "CDISC001", "CDISC001"],
-            "SESEQ": [1, 2, 3, 1, 2],
+            "SESEQ": [1, 2, 3, 3, 2],
             "SESTDTC": [
                 "2006-06-02",
                 "2006-06-04",
@@ -950,9 +950,9 @@ def test_target_is_sorted_by(dataset_class):
         pd.Series(
             [
                 True,
+                False,
+                False,
                 True,
-                False,
-                False,
                 True,
             ]
         )
@@ -1012,13 +1012,13 @@ def test_target_is_sorted_by(dataset_class):
     valid_mul_df = dataset_class.from_dict(
         {
             "USUBJID": ["CDISC001", "CDISC002", "CDISC002", "CDISC001", "CDISC001"],
-            "SESEQ": [2, 1, 2, 3, 1],
+            "SESEQ": [7, 3, 2, 8, 6],
             "SESTDTC": [
-                "2006-06-02",
+                "2006-06-03",
                 "2006-06-04",
                 "2006-06-01",
                 "2006-06-05",
-                "2006-06-03",
+                "2006-06-01",
             ],
             "STUDYID": [
                 "CDISCPILOT1",
@@ -1028,11 +1028,11 @@ def test_target_is_sorted_by(dataset_class):
                 "CDISCPILOT1",
             ],
             "SEENDTC": [
-                "2006-06-02",
+                "2006-06-03",
                 "2006-06-04",
                 "2006-06-01",
                 "2006-06-05",
-                "2006-06-03",
+                "2006-06-01",
             ],
         }
     )
@@ -1062,14 +1062,14 @@ def test_target_is_sorted_by(dataset_class):
 
     valid_mul_df = dataset_class.from_dict(
         {
-            "USUBJID": ["CDISC001", "CDISC002", "CDISC002", "CDISC001", "CDISC001"],
-            "SESEQ": [1, 2, 1, 3, 2],
+            "USUBJID": ["CDISC001", "CDISC001", "CDISC001", "CDISC001", "CDISC001"],
+            "SESEQ": [1, 2, 5, 8, 12.2],
             "SESTDTC": [
-                "2006-06-02",
-                "2006-06-04",
                 "2006-06-01",
-                "2006-06-05",
+                "2006-06-02",
                 "2006-06-03",
+                "2006-06-04",
+                "2006-06-05",
             ],
             "STUDYID": [
                 "CDISCPILOT1",
@@ -1079,11 +1079,11 @@ def test_target_is_sorted_by(dataset_class):
                 "CDISCPILOT1",
             ],
             "SEENDTC": [
-                "2006-06-03",
-                "2006-06-01",
                 "2006-06-04",
                 "2006-06-05",
-                "2006-06-02",
+                "2006-06-06",
+                "2006-06-07",
+                "2006-06-08",
             ],
         }
     )
@@ -1114,7 +1114,7 @@ def test_target_is_sorted_by(dataset_class):
     invalid_mul_df = dataset_class.from_dict(
         {
             "USUBJID": ["CDISC001", "CDISC002", "CDISC002", "CDISC001", "CDISC001"],
-            "SESEQ": [1, 2, 3, 1, 2],
+            "SESEQ": [1, 2, 1, 1, 2],
             "SESTDTC": [
                 "2006-06-02",
                 "2006-06-04",
@@ -1153,11 +1153,11 @@ def test_target_is_sorted_by(dataset_class):
     assert result.equals(
         pd.Series(
             [
+                False,
                 True,
                 True,
                 False,
                 False,
-                True,
             ]
         )
     )
@@ -1183,7 +1183,7 @@ def test_target_is_sorted_by(dataset_class):
     assert result.equals(
         pd.Series(
             [
-                True,
+                False,
                 True,
                 True,
                 False,
@@ -1213,8 +1213,8 @@ def test_target_is_sorted_by(dataset_class):
     assert result.equals(
         pd.Series(
             [
-                True,
-                True,
+                False,
+                False,
                 False,
                 False,
                 False,


### PR DESCRIPTION
This update no longer expects the seq to start at 1 and allows for sequences to ascend/descend by values other than 1.

Of note, the testing suite has been updated as this implementation does not have the granularity that the past implementation does--if this is an issue, I can edit again.  In this implementation if the entire sequence is not in the selected ascend/descending order requested in the parameters, all values of the sequence are deemed false.  It appears the past implementation did not do this.
