### PR TITLE
further updates to FDAB schema

### DIFF
--- a/resources/schema/Organization_FDA.json
+++ b/resources/schema/Organization_FDA.json
@@ -33,6 +33,10 @@
                           },
                           "Document": {
                             "const": "FDA"
+                          },
+                          "Section": {
+                            "pattern": "^(FDAB\\d{3}|TRC\\d{4}[A-Z]|\\d{4}[A-Z])$",
+                            "type": "string"
                           }
                         }
                       }
@@ -57,7 +61,7 @@
                 "Rule Identifier": {
                   "properties": {
                     "Id": {
-                      "pattern": "^(FB|CT|SD|SE)\\d{4}[A-Z]?$",
+                      "pattern": "^(FB|CT|SD|SE)\\d{4}[A-Z]?$|^TRC",
                       "type": "string"
                     }
                   },

--- a/resources/schema/Organization_FDA.json
+++ b/resources/schema/Organization_FDA.json
@@ -35,7 +35,7 @@
                             "const": "FDA"
                           },
                           "Section": {
-                            "pattern": "^(FDAB\\d{3}|TRC\\d{4}[A-Z]|\\d{4}[A-Z])$",
+                            "pattern": "^(FDAB\\d{3}|TRC\\d{4}[A-Z]?|\\d{4}[A-Z])$",
                             "type": "string"
                           }
                         }
@@ -61,7 +61,7 @@
                 "Rule Identifier": {
                   "properties": {
                     "Id": {
-                      "pattern": "^(FB|CT|SD|SE)\\d{4}[A-Z]?$|^TRC",
+                      "pattern": "^(FB|CT|SD|SE)\\d{4}[A-Z]?$|^TRC.*$",
                       "type": "string"
                     }
                   },


### PR DESCRIPTION
Rule: FB4001-4005
![image](https://github.com/cdisc-org/cdisc-rules-engine/assets/96841389/f61be886-678d-489b-978d-15c92e93c153)
- added 'Section' for FDA documents to resolve schema error in above rules

If you sort in rule editor under FDA, there are many rules that begin with TRC - technical rejection criteria.  
- added 'TRC' for Section-- these IDs will be either TRC with 4 digits or TRC with 4 digits then a letter
- also added TRC into Rule ID regex-- allowing patterns for rule ID that start with TRC- prefix