### PR TITLE
Update is_split_dataset

### DIFF
--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -215,8 +215,11 @@ def is_split_dataset(datasets: List[dict], domain: str) -> bool:
         filename_wo_extension = dataset.get("filename", "").split(".")[0].lower()
         if filename_wo_extension == domain.lower():
             domain_match = True
-        if (len(filename_wo_extension) > len(domain) and len(filename_wo_extension) <= len(domain) + 2
-            and filename_wo_extension.startswith(domain.lower())):
+        if (
+            len(filename_wo_extension) > len(domain)
+            and len(filename_wo_extension) <= len(domain) + 2
+            and filename_wo_extension.startswith(domain.lower())
+        ):
             domain_plus_two_match = True
 
         if domain_match and domain_plus_two_match:

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -215,9 +215,8 @@ def is_split_dataset(datasets: List[dict], domain: str) -> bool:
         filename_wo_extension = dataset.get("filename", "").split(".")[0].lower()
         if filename_wo_extension == domain.lower():
             domain_match = True
-        elif len(filename_wo_extension) == len(
-            domain
-        ) + 2 and filename_wo_extension.startswith(domain.lower()):
+        if (len(filename_wo_extension) > len(domain) and len(filename_wo_extension) <= len(domain) + 2
+            and filename_wo_extension.startswith(domain.lower())):
             domain_plus_two_match = True
 
         if domain_match and domain_plus_two_match:


### PR DESCRIPTION
see: ![image](https://github.com/cdisc-org/cdisc-rules-engine/assets/96841389/35d0b358-c99c-4863-b963-848a131d2667)
when looking into another ticket I noticed 2 errors in this function:

- the second filter needed to be a second if statement NOT elif
- the split dataset nomenclature should reflect the above SDTMIG guidance with the domain name followed by 1 or 2 characters.  the former logic only checked for 2