### PR TITLE
added astype()

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -175,7 +175,7 @@ class DataframeType(BaseType):
                 row, target, comparator, value_is_literal, case_insensitive=True
             ),
             axis=1,
-        )
+        ).astype(bool)
 
     @type_operator(FIELD_DATAFRAME)
     def not_equal_to_case_insensitive(self, other_value):

--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -159,7 +159,7 @@ class DataframeType(BaseType):
         return self.value.apply(
             lambda row: self._check_equality(row, target, comparator, value_is_literal),
             axis=1,
-        )
+        ).astype(bool)
 
     @type_operator(FIELD_DATAFRAME)
     def equal_to_case_insensitive(self, other_value):
@@ -175,7 +175,7 @@ class DataframeType(BaseType):
                 row, target, comparator, value_is_literal, case_insensitive=True
             ),
             axis=1,
-        ).astype(bool)
+        )
 
     @type_operator(FIELD_DATAFRAME)
     def not_equal_to_case_insensitive(self, other_value):


### PR DESCRIPTION
As Richard described in the issue, casting the datatype as a bool resolves the issue with empy equal_to series using any or all. 
- For non-empty Series: The apply function works as before, and the result is cast to boolean.
- For empty Series: Instead of returning an empty float64 Series, it returns an empty boolean Series.

I believe this is the most minimal change that doesn't disrupt the operator or involve restructure the existing code.