### PR TITLE
Return error when incorrect rule sensitivity

### DIFF
--- a/cdisc_rules_engine/models/actions.py
+++ b/cdisc_rules_engine/models/actions.py
@@ -111,7 +111,9 @@ class COREActions(BaseActions):
                 lambda df_row: self._create_error_object(df_row, data), axis=1
             )
             errors_list: List[ValidationErrorEntity] = errors_series.tolist()
-        else:  # rule sensitivity is not defined
+        elif (
+            self.rule.get("sensitivity") is not None
+        ):  # rule sensitivity is incorrectly defined
             error_entity = ValidationErrorEntity(
                 {
                     "row": 0,
@@ -126,6 +128,11 @@ class COREActions(BaseActions):
                 message="Invalid or undefined sensitivity in the rule",
                 errors=[error_entity],
             )
+        else:  # rule sensitivity is undefined
+            errors_series: pd.Series = errors_df.apply(
+                lambda df_row: self._create_error_object(df_row, data), axis=1
+            )
+            errors_list: List[ValidationErrorEntity] = errors_series.tolist()
         missing_vars = {target: "Not in dataset" for target in targets_not_in_dataset}
         if missing_vars:
             for error in errors_list:

--- a/cdisc_rules_engine/models/actions.py
+++ b/cdisc_rules_engine/models/actions.py
@@ -118,8 +118,8 @@ class COREActions(BaseActions):
                 {
                     "row": 0,
                     "value": {"ERROR": "Invalid or undefined sensitivity in the rule"},
-                    "uSubjId": "2",
-                    "seq": 1,
+                    "uSubjId": "N/A",
+                    "SEQ": 0,
                 }
             )
             return ValidationErrorContainer(

--- a/cdisc_rules_engine/models/actions.py
+++ b/cdisc_rules_engine/models/actions.py
@@ -106,12 +106,26 @@ class COREActions(BaseActions):
                     value=dict(errors_df.iloc[0].to_dict()),
                 )
             ]
-        else:
-            # Rule is treated as record level
+        elif self.rule.get("sensitivity") == Sensitivity.RECORD.value:
             errors_series: pd.Series = errors_df.apply(
                 lambda df_row: self._create_error_object(df_row, data), axis=1
             )
             errors_list: List[ValidationErrorEntity] = errors_series.tolist()
+        else:  # rule sensitivity is not defined
+            error_entity = ValidationErrorEntity(
+                {
+                    "row": 0,
+                    "value": {"ERROR": "Invalid or undefined sensitivity in the rule"},
+                    "uSubjId": "2",
+                    "seq": 1,
+                }
+            )
+            return ValidationErrorContainer(
+                domain=self.domain,
+                targets=sorted(targets),
+                message="Invalid or undefined sensitivity in the rule",
+                errors=[error_entity],
+            )
         missing_vars = {target: "Not in dataset" for target in targets_not_in_dataset}
         if missing_vars:
             for error in errors_list:

--- a/tests/unit/test_rule_tester/test_rule_tester.py
+++ b/tests/unit/test_rule_tester/test_rule_tester.py
@@ -57,10 +57,11 @@ def test_rule_with_errors(mock_get_dataset_class):
     assert "LB" in data
     assert len(data["LB"]) == 1
     assert len(data["LB"][0]["errors"]) == 1
-    error = data["LB"][0]["errors"][0]
-    assert error["row"] == 1
-    assert error["SEQ"] == 1
-    assert error["value"] == {"LBSEQ": 1}
+    error = data["LB"][0]["errors"][0]["value"]
+    assert error["row"] == 0
+    assert error["SEQ"] == 0
+    assert error["uSubjId"] == "N/A"
+    assert error["value"] == {"ERROR": "Invalid or undefined sensitivity in the rule"}
 
 
 @patch("cdisc_rules_engine.services.data_services.DummyDataService.get_dataset_class")


### PR DESCRIPTION
Rules were published with invalid values for sensitivity.  Currently engine assumes record sensitivity if it is not dataset sensitivity.  This change will create an error fed into the report when there is incorrect sensitivity--of note, this will only work when there are errors for the report being generated.  Presuming a rule will have negative and positive data, if it has incorrect sensitivity, when negative data is tested, the issues will state the rule sensitivity is incorrect.