### PR TITLE
ISS-704: Add missing operator tests.

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -926,29 +926,11 @@ class DataframeType(BaseType):
         value = other_value.get("comparator")
         if not isinstance(value, str):
             raise Exception("Comparator must be a single String value")
-
-        return not (
-            False
-            in self.value.groupby(value)
-            .agg(lambda x: list(x))[target]
-            .map(lambda x: sorted(x) == x)
-            .tolist()
-        )
+        return self.value.is_column_sorted_within(value, target)
 
     @type_operator(FIELD_DATAFRAME)
     def is_not_ordered_set(self, other_value):
-        target = self.replace_prefix(other_value.get("target"))
-        value = other_value.get("comparator")
-        if not isinstance(value, str):
-            raise Exception("Comparator must be a single String value")
-
-        return (
-            False
-            in self.value.groupby(value)
-            .agg(lambda x: list(x))[target]
-            .map(lambda x: sorted(x) == x)
-            .tolist()
-        )
+        return not self.is_ordered_set(other_value)
 
     @type_operator(FIELD_DATAFRAME)
     def is_valid_reference(self, other_value):

--- a/cdisc_rules_engine/models/dataset/dask_dataset.py
+++ b/cdisc_rules_engine/models/dataset/dask_dataset.py
@@ -3,6 +3,7 @@ import dask.dataframe as dd
 import dask.array as da
 import pandas as pd
 import numpy as np
+import re
 from typing import List, Union
 
 DEFAULT_NUM_PARTITIONS = 4
@@ -249,3 +250,11 @@ class DaskDataset(PandasDataset):
     def astype(self, dtype, **kwargs):
         self._data = self._data.astype(dtype, **kwargs)
         return self
+
+    def filter(self, **kwargs):
+        columns_regex = kwargs.get("regex")
+        columns_subset = [
+            column for column in self.columns if re.match(columns_regex, column)
+        ]
+        new_data = self._data[columns_subset]
+        return self.__class__(new_data)

--- a/cdisc_rules_engine/models/dataset/dataset_interface.py
+++ b/cdisc_rules_engine/models/dataset/dataset_interface.py
@@ -197,3 +197,9 @@ class DatasetInterface(ABC):
         """
         Sort the dataframe by the provided columns
         """
+
+    @abstractmethod
+    def is_column_sorted_within(self, group, column):
+        """
+        Returns true if the column is sorted within each grouping otherwise false
+        """

--- a/cdisc_rules_engine/models/dataset/pandas_dataset.py
+++ b/cdisc_rules_engine/models/dataset/pandas_dataset.py
@@ -76,6 +76,15 @@ class PandasDataset(DatasetInterface):
     def groupby(self, by: List[str], **kwargs):
         return self.__class__(self._data.groupby(by, **kwargs))
 
+    def is_column_sorted_within(self, group, column):
+        return (
+            False
+            not in self.groupby(group)[column]
+            .apply(list)
+            .map(lambda x: sorted(x) == x)
+            .values
+        )
+
     def concat(self, other: Union[DatasetInterface, List[DatasetInterface]], **kwargs):
         if isinstance(other, list):
             new_data = self._data.copy()

--- a/tests/unit/test_check_operators/test_additional_column_checks.py
+++ b/tests/unit/test_check_operators/test_additional_column_checks.py
@@ -1,0 +1,232 @@
+from cdisc_rules_engine.check_operators.dataframe_operators import DataframeType
+import pytest
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+
+
+@pytest.mark.parametrize(
+    "dataset_type, data, expected_result",
+    [
+        (
+            PandasDataset,
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    1,
+                ],
+                "TSVAL": [
+                    None,
+                    None,
+                    "another value",
+                    None,
+                ],  # original column may be empty
+                "TSVAL1": [
+                    "value",
+                    "value",
+                    "value",
+                    None,
+                ],  # valid since TSVAL2 is also null in the same row
+                "TSVAL2": [None, "value 2", "value 2", None],
+            },
+            [False, False, False, False],
+        ),
+        (
+            DaskDataset,
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    1,
+                ],
+                "TSVAL": [
+                    None,
+                    None,
+                    "another value",
+                    None,
+                ],  # original column may be empty
+                "TSVAL1": [
+                    "value",
+                    "value",
+                    "value",
+                    None,
+                ],  # valid since TSVAL2 is also null in the same row
+                "TSVAL2": [None, "value 2", "value 2", None],
+            },
+            [False, False, False, False],
+        ),
+        (
+            PandasDataset,
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    1,
+                ],
+                "TSVAL": [
+                    "value",
+                    None,
+                    "another value",
+                    None,
+                ],  # original column may be empty
+                "TSVAL1": ["value", None, "value", "value"],  # invalid column
+                "TSVAL2": ["value 2", "value 2", "value 2", None],
+                "TSVAL3": ["value 3", "value 3", None, "value 3"],
+            },
+            [False, True, False, True],
+        ),
+        (
+            DaskDataset,
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    1,
+                ],
+                "TSVAL": [
+                    "value",
+                    None,
+                    "another value",
+                    None,
+                ],  # original column may be empty
+                "TSVAL1": ["value", None, "value", "value"],  # invalid column
+                "TSVAL2": ["value 2", "value 2", "value 2", None],
+                "TSVAL3": ["value 3", "value 3", None, "value 3"],
+            },
+            [False, True, False, True],
+        ),
+    ],
+)
+def test_additional_columns_empty(dataset_type, data, expected_result):
+    """
+    Unit test for additional_columns_empty operator.
+    """
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).additional_columns_empty(
+        {
+            "target": "TSVAL",
+        }
+    )
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "dataset_type, data, expected_result",
+    [
+        (
+            PandasDataset,
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    1,
+                ],
+                "TSVAL": [
+                    "value",
+                    None,
+                    "another value",
+                    None,
+                ],  # original column may be empty
+                "TSVAL1": ["value", None, "value", "value"],
+                "TSVAL2": ["value 2", "value 2", "value 2", "value 2"],
+            },
+            [
+                True,
+                False,
+                True,
+                True,
+            ],
+        ),
+        (
+            DaskDataset,
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    1,
+                ],
+                "TSVAL": [
+                    "value",
+                    None,
+                    "another value",
+                    None,
+                ],  # original column may be empty
+                "TSVAL1": ["value", None, "value", "value"],
+                "TSVAL2": ["value 2", "value 2", "value 2", "value 2"],
+            },
+            [
+                True,
+                False,
+                True,
+                True,
+            ],
+        ),
+        (
+            PandasDataset,
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    1,
+                ],
+                "TSVAL": [
+                    "value",
+                    None,
+                    "another value",
+                    None,
+                ],  # original column may be empty
+                "TSVAL1": ["value", "value", "value", "value"],
+                "TSVAL2": ["value 2", "value 2", "value 2", "value 2"],
+            },
+            [
+                True,
+                True,
+                True,
+                True,
+            ],
+        ),
+        (
+            DaskDataset,
+            {
+                "USUBJID": [
+                    1,
+                    1,
+                    1,
+                    1,
+                ],
+                "TSVAL": [
+                    "value",
+                    None,
+                    "another value",
+                    None,
+                ],  # original column may be empty
+                "TSVAL1": ["value", "value", "value", "value"],
+                "TSVAL2": ["value 2", "value 2", "value 2", "value 2"],
+            },
+            [
+                True,
+                True,
+                True,
+                True,
+            ],
+        ),
+    ],
+)
+def test_additional_columns_not_empty(dataset_type, data, expected_result):
+    """
+    Unit test for additional_columns_empty operator.
+    """
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).additional_columns_not_empty(
+        {
+            "target": "TSVAL",
+        }
+    )
+    assert result.equals(df.convert_to_series(expected_result))

--- a/tests/unit/test_check_operators/test_codelist_checks.py
+++ b/tests/unit/test_check_operators/test_codelist_checks.py
@@ -1,0 +1,283 @@
+from cdisc_rules_engine.check_operators.dataframe_operators import DataframeType
+import pytest
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        (
+            "define_variable_name",
+            "define_variable_controlled_terms",
+            PandasDataset,
+            [True, True, True],
+        ),
+        (
+            "define_variable_name",
+            "define_variable_controlled_terms",
+            DaskDataset,
+            [True, True, True],
+        ),
+        (
+            "define_variable_name",
+            "define_variable_invalid_terms",
+            PandasDataset,
+            [True, True, False],
+        ),
+        (
+            "define_variable_name",
+            "define_variable_invalid_terms",
+            DaskDataset,
+            [True, True, False],
+        ),
+    ],
+)
+def test_references_correct_codelist(target, comparator, dataset_type, expected_result):
+    data = {
+        "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR"],
+        "define_variable_controlled_terms": ["C123", "C456", "C789"],
+        "define_variable_invalid_terms": ["C123", "C456", "C786"],
+    }
+
+    df = dataset_type.from_dict(data)
+
+    column_codelist_map = {
+        "TEST": ["C123", "C456"],
+        "COOLVAR": ["C123", "C456"],
+        "ANOTHERVAR": ["C789"],
+    }
+    dft = DataframeType({"value": df, "column_codelist_map": column_codelist_map})
+
+    result = dft.references_correct_codelist(
+        {"target": target, "comparator": comparator}
+    )
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        (
+            "define_variable_name",
+            "define_variable_controlled_terms",
+            PandasDataset,
+            [False, False, False],
+        ),
+        (
+            "define_variable_name",
+            "define_variable_controlled_terms",
+            DaskDataset,
+            [False, False, False],
+        ),
+        (
+            "define_variable_name",
+            "define_variable_invalid_terms",
+            PandasDataset,
+            [False, False, True],
+        ),
+        (
+            "define_variable_name",
+            "define_variable_invalid_terms",
+            DaskDataset,
+            [False, False, True],
+        ),
+    ],
+)
+def test_does_not_reference_correct_codelist(
+    target, comparator, dataset_type, expected_result
+):
+    data = {
+        "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR"],
+        "define_variable_controlled_terms": ["C123", "C456", "C789"],
+        "define_variable_invalid_terms": ["C123", "C456", "C786"],
+    }
+
+    df = dataset_type.from_dict(data)
+
+    column_codelist_map = {
+        "TEST": ["C123", "C456"],
+        "COOLVAR": ["C123", "C456"],
+        "ANOTHERVAR": ["C789"],
+    }
+    dft = DataframeType({"value": df, "column_codelist_map": column_codelist_map})
+
+    result = dft.does_not_reference_correct_codelist(
+        {"target": target, "comparator": comparator}
+    )
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        (
+            "define_variable_controlled_terms",
+            "define_variable_allowed_terms",
+            PandasDataset,
+            [True, True, True],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_allowed_terms",
+            DaskDataset,
+            [True, True, True],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_invalid_allowed_terms",
+            PandasDataset,
+            [False, False, True],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_invalid_allowed_terms",
+            DaskDataset,
+            [False, False, True],
+        ),
+    ],
+)
+def test_uses_valid_codelist_terms(target, comparator, dataset_type, expected_result):
+    data = {
+        "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR"],
+        "define_variable_controlled_terms": ["C123", "C456", "C789"],
+        "define_variable_allowed_terms": [["A", "B"], ["C", "D"], ["E", "F"]],
+        "define_variable_invalid_allowed_terms": [["A", "L"], ["C", "Z"], ["E", "F"]],
+    }
+
+    codelist_term_map = [
+        {
+            "C123": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C"],
+            },
+            "C456": {"extensible": False, "allowed_terms": ["A", "B", "b", "C", "D"]},
+            "C789": {"extensible": False, "allowed_terms": ["E", "F", "b", "C"]},
+        }
+    ]
+
+    df = dataset_type.from_dict(data)
+    dft = DataframeType({"value": df, "codelist_term_maps": codelist_term_map})
+
+    result = dft.uses_valid_codelist_terms({"target": target, "comparator": comparator})
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        (
+            "define_variable_controlled_terms",
+            "define_variable_allowed_terms",
+            PandasDataset,
+            [True, True, True],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_allowed_terms",
+            DaskDataset,
+            [True, True, True],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_invalid_allowed_terms",
+            PandasDataset,
+            [False, True, True],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_invalid_allowed_terms",
+            DaskDataset,
+            [False, True, True],
+        ),
+    ],
+)
+def test_uses_valid_codelist_terms_with_extensible_codelist(
+    target, comparator, dataset_type, expected_result
+):
+    data = {
+        "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR"],
+        "define_variable_controlled_terms": ["C123", "C456", "C789"],
+        "define_variable_allowed_terms": [["A", "B"], ["C", "D"], ["E", "F"]],
+        "define_variable_invalid_allowed_terms": [["A", "L"], ["C", "Z"], ["E", "F"]],
+    }
+
+    extensible_codelist_term_map = [
+        {
+            "C123": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C"],
+            },
+            "C456": {"extensible": True, "allowed_terms": ["A", "B", "b", "C", "D"]},
+            "C789": {"extensible": False, "allowed_terms": ["E", "F", "b", "C"]},
+        }
+    ]
+
+    df = dataset_type.from_dict(data)
+
+    # Test extensible flag
+    dft = DataframeType(
+        {"value": df, "codelist_term_maps": extensible_codelist_term_map}
+    )
+
+    result = dft.uses_valid_codelist_terms({"target": target, "comparator": comparator})
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        (
+            "define_variable_controlled_terms",
+            "define_variable_allowed_terms",
+            PandasDataset,
+            [False, False, False],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_allowed_terms",
+            DaskDataset,
+            [False, False, False],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_invalid_allowed_terms",
+            PandasDataset,
+            [True, True, False],
+        ),
+        (
+            "define_variable_controlled_terms",
+            "define_variable_invalid_allowed_terms",
+            DaskDataset,
+            [True, True, False],
+        ),
+    ],
+)
+def test_does_not_use_valid_codelist_terms(
+    target, comparator, dataset_type, expected_result
+):
+    data = {
+        "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR"],
+        "define_variable_controlled_terms": ["C123", "C456", "C789"],
+        "define_variable_allowed_terms": [["A", "B"], ["C", "D"], ["E", "F"]],
+        "define_variable_invalid_allowed_terms": [["A", "L"], ["C", "Z"], ["E", "F"]],
+    }
+
+    codelist_term_map = [
+        {
+            "C123": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C"],
+            },
+            "C456": {"extensible": False, "allowed_terms": ["A", "B", "b", "C", "D"]},
+            "C789": {"extensible": False, "allowed_terms": ["E", "F", "b", "C"]},
+        }
+    ]
+
+    df = dataset_type.from_dict(data)
+    dft = DataframeType({"value": df, "codelist_term_maps": codelist_term_map})
+
+    result = dft.does_not_use_valid_codelist_terms(
+        {"target": target, "comparator": comparator}
+    )
+    assert result.equals(df.convert_to_series(expected_result))

--- a/tests/unit/test_check_operators/test_date_comparison_checks.py
+++ b/tests/unit/test_check_operators/test_date_comparison_checks.py
@@ -703,3 +703,47 @@ def test_date_greater_than_or_equal_to_date_components(
         {"target": "target", "comparator": comparator, "date_component": date_component}
     )
     assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, dataset_type, expected_result",
+    [
+        ("var1", PandasDataset, [False, False, False]),
+        ("var1", DaskDataset, [False, False, False]),
+        ("var2", PandasDataset, [True, True, True]),
+        ("var2", DaskDataset, [True, True, True]),
+    ],
+)
+def test_is_complete_date(target, dataset_type, expected_result):
+    data = {
+        "var1": ["2021", "2021", "2099"],
+        "var2": ["1997-07-16", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
+    }
+    df = dataset_type.from_dict(data)
+    assert (
+        DataframeType({"value": df})
+        .is_complete_date({"target": target})
+        .equals(df.convert_to_series(expected_result))
+    )
+
+
+@pytest.mark.parametrize(
+    "target, dataset_type, expected_result",
+    [
+        ("var1", PandasDataset, [True, True, True]),
+        ("var1", DaskDataset, [True, True, True]),
+        ("var2", PandasDataset, [False, False, False]),
+        ("var2", DaskDataset, [False, False, False]),
+    ],
+)
+def test_is_incomplete_date(target, dataset_type, expected_result):
+    data = {
+        "var1": ["2021", "2021", "2099"],
+        "var2": ["1997-07-16", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
+    }
+    df = dataset_type.from_dict(data)
+    assert (
+        DataframeType({"value": df})
+        .is_incomplete_date({"target": target})
+        .equals(df.convert_to_series(expected_result))
+    )

--- a/tests/unit/test_check_operators/test_existence.py
+++ b/tests/unit/test_check_operators/test_existence.py
@@ -1,0 +1,66 @@
+from cdisc_rules_engine.check_operators.dataframe_operators import DataframeType
+import pytest
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+
+
+@pytest.mark.parametrize(
+    "target, dataset_type, expected_result",
+    [
+        ("var1", PandasDataset, [True, True, True]),
+        ("var1", DaskDataset, [True, True, True]),
+        ("--r1", PandasDataset, [True, True, True]),
+        ("--r1", DaskDataset, [True, True, True]),
+        ("invalid", PandasDataset, [False, False, False]),
+        ("invalid", DaskDataset, [False, False, False]),
+    ],
+)
+def test_exists(target, dataset_type, expected_result):
+    data = {
+        "var1": [
+            1,
+            2,
+            4,
+        ],
+        "var2": [
+            3,
+            5,
+            6,
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).exists(
+        {"target": target}
+    )
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, dataset_type, expected_result",
+    [
+        ("var1", PandasDataset, [False, False, False]),
+        ("var1", DaskDataset, [False, False, False]),
+        ("--r1", PandasDataset, [False, False, False]),
+        ("--r1", DaskDataset, [False, False, False]),
+        ("invalid", PandasDataset, [True, True, True]),
+        ("invalid", DaskDataset, [True, True, True]),
+    ],
+)
+def test_not_exists(target, dataset_type, expected_result):
+    data = {
+        "var1": [
+            1,
+            2,
+            4,
+        ],
+        "var2": [
+            3,
+            5,
+            6,
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).not_exists(
+        {"target": target}
+    )
+    assert result.equals(df.convert_to_series(expected_result))

--- a/tests/unit/test_check_operators/test_metadata_checks.py
+++ b/tests/unit/test_check_operators/test_metadata_checks.py
@@ -1,0 +1,93 @@
+from cdisc_rules_engine.check_operators.dataframe_operators import DataframeType
+import pytest
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+
+
+@pytest.mark.parametrize("dataset_type", [PandasDataset, DaskDataset])
+def test_conformant_value_length(dataset_type):
+    def filter_func(row):
+        return row["IDVAR1"] == "TEST"
+
+    def length_check(row):
+        return len(row["IDVAR2"]) <= 4
+
+    data = {
+        "RDOMAIN": ["LB", "LB", "AE"],
+        "IDVAR1": ["TEST", "TEST", "AETERM"],
+        "IDVAR2": ["TEST", "TOOLONG", "AETERM"],
+    }
+    df = dataset_type.from_dict(data)
+
+    vlm = [{"filter": filter_func, "length_check": length_check}]
+
+    result = DataframeType(
+        {"value": df, "value_level_metadata": vlm}
+    ).conformant_value_length({})
+    assert result.equals(df.convert_to_series([True, False, False]))
+
+
+@pytest.mark.parametrize("dataset_type", [PandasDataset, DaskDataset])
+def test_conformant_value_data_type(dataset_type):
+    def filter_func(row):
+        return row["IDVAR1"] == "TEST"
+
+    def type_check(row):
+        return isinstance(row["IDVAR2"], str)
+
+    data = {
+        "RDOMAIN": ["LB", "LB", "AE"],
+        "IDVAR1": ["TEST", "TEST", "AETERM"],
+        "IDVAR2": ["TEST", 1, "AETERM"],
+    }
+
+    vlm = [{"filter": filter_func, "type_check": type_check}]
+    df = dataset_type.from_dict(data)
+    result = DataframeType(
+        {"value": df, "value_level_metadata": vlm}
+    ).conformant_value_data_type({})
+    assert result.equals(df.convert_to_series([True, False, False]))
+
+
+@pytest.mark.parametrize("dataset_type", [PandasDataset, DaskDataset])
+def test_variable_metadata_equal_to(dataset_type):
+    data = {
+        "STUDYID": [1, 1, 1, 1],
+        "$CORE_VALUES": [
+            {"STUDYID": "Req", "DOMAIN": "Req"},
+            {"STUDYID": "Req", "DOMAIN": "Req"},
+            {"STUDYID": "Req", "DOMAIN": "Req"},
+            {"STUDYID": "Req", "DOMAIN": "Req"},
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).variable_metadata_equal_to(
+        {"target": "STUDYID", "comparator": "Exp", "metadata": "$CORE_VALUES"}
+    )
+    assert result.equals(df.convert_to_series([False, False, False, False]))
+    result = DataframeType({"value": df}).variable_metadata_equal_to(
+        {"target": "STUDYID", "comparator": "Req", "metadata": "$CORE_VALUES"}
+    )
+    assert result.equals(df.convert_to_series([True, True, True, True]))
+
+
+@pytest.mark.parametrize("dataset_type", [PandasDataset, DaskDataset])
+def test_variable_metadata_not_equal_to(dataset_type):
+    data = {
+        "STUDYID": [1, 1, 1, 1],
+        "$CORE_VALUES": [
+            {"STUDYID": "Req", "DOMAIN": "Req"},
+            {"STUDYID": "Req", "DOMAIN": "Req"},
+            {"STUDYID": "Req", "DOMAIN": "Req"},
+            {"STUDYID": "Req", "DOMAIN": "Req"},
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).variable_metadata_not_equal_to(
+        {"target": "STUDYID", "comparator": "Exp", "metadata": "$CORE_VALUES"}
+    )
+    assert result.equals(df.convert_to_series([True, True, True, True]))
+    result = DataframeType({"value": df}).variable_metadata_not_equal_to(
+        {"target": "STUDYID", "comparator": "Req", "metadata": "$CORE_VALUES"}
+    )
+    assert result.equals(df.convert_to_series([False, False, False, False]))

--- a/tests/unit/test_check_operators/test_prefix_suffix_containment_checks.py
+++ b/tests/unit/test_check_operators/test_prefix_suffix_containment_checks.py
@@ -1,0 +1,140 @@
+from cdisc_rules_engine.check_operators.dataframe_operators import DataframeType
+import pytest
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+
+
+@pytest.mark.parametrize(
+    "dataset_type, target, prefix_length, expected_result",
+    [
+        (PandasDataset, "var1", 2, [True, True, True]),
+        (DaskDataset, "var1", 2, [True, True, True]),
+        (PandasDataset, "var2", 2, [True, False, False]),
+        (DaskDataset, "var2", 2, [True, False, False]),
+    ],
+)
+def test_prefix_is_contained_by(dataset_type, target, prefix_length, expected_result):
+    data = {
+        "var1": ["AETEST", "AETESTCD", "LBTEST"],
+        "var2": ["AETEST", "AFTESTCD", "RRTEST"],
+        "study_domains": [
+            ["DM", "AE", "LB", "TV"],
+            ["DM", "AE", "LB", "TV"],
+            ["DM", "AE", "LB", "TV"],
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    assert (
+        DataframeType({"value": df})
+        .prefix_is_contained_by(
+            {
+                "target": target,
+                "comparator": "study_domains",
+                "prefix": prefix_length,
+            }
+        )
+        .equals(df.convert_to_series(expected_result))
+    )
+
+
+@pytest.mark.parametrize(
+    "dataset_type, target, prefix_length, expected_result",
+    [
+        (PandasDataset, "var1", 2, [False, False, False]),
+        (DaskDataset, "var1", 2, [False, False, False]),
+        (PandasDataset, "var2", 2, [False, True, True]),
+        (DaskDataset, "var2", 2, [False, True, True]),
+    ],
+)
+def test_prefix_is_not_contained_by(
+    dataset_type, target, prefix_length, expected_result
+):
+    data = {
+        "var1": ["AETEST", "AETESTCD", "LBTEST"],
+        "var2": ["AETEST", "AFTESTCD", "RRTEST"],
+        "study_domains": [
+            ["DM", "AE", "LB", "TV"],
+            ["DM", "AE", "LB", "TV"],
+            ["DM", "AE", "LB", "TV"],
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    assert (
+        DataframeType({"value": df})
+        .prefix_is_not_contained_by(
+            {
+                "target": target,
+                "comparator": "study_domains",
+                "prefix": prefix_length,
+            }
+        )
+        .equals(df.convert_to_series(expected_result))
+    )
+
+
+@pytest.mark.parametrize(
+    "dataset_type, target, suffix_length, expected_result",
+    [
+        (PandasDataset, "var1", 2, [True, True, True]),
+        (DaskDataset, "var1", 2, [True, True, True]),
+        (PandasDataset, "var2", 2, [True, True, False]),
+        (DaskDataset, "var2", 2, [True, True, False]),
+    ],
+)
+def test_suffix_is_contained_by(dataset_type, target, suffix_length, expected_result):
+    data = {
+        "var1": ["AETEST", "AETESTCD", "LBTEGG"],
+        "var2": ["AETEST", "AFTESTCD", "RRTELE"],
+        "study_domains": [
+            ["ST", "CD", "GG", "TV"],
+            ["ST", "CD", "GG", "TV"],
+            ["ST", "CD", "GG", "TV"],
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    assert (
+        DataframeType({"value": df})
+        .suffix_is_contained_by(
+            {
+                "target": target,
+                "comparator": "study_domains",
+                "suffix": suffix_length,
+            }
+        )
+        .equals(df.convert_to_series(expected_result))
+    )
+
+
+@pytest.mark.parametrize(
+    "dataset_type, target, suffix_length, expected_result",
+    [
+        (PandasDataset, "var1", 2, [False, False, False]),
+        (DaskDataset, "var1", 2, [False, False, False]),
+        (PandasDataset, "var2", 2, [False, False, True]),
+        (DaskDataset, "var2", 2, [False, False, True]),
+    ],
+)
+def test_suffix_is_not_contained_by(
+    dataset_type, target, suffix_length, expected_result
+):
+    data = {
+        "var1": ["AETEST", "AETESTCD", "LBTEGG"],
+        "var2": ["AETEST", "AFTESTCD", "RRTELE"],
+        "study_domains": [
+            ["ST", "CD", "GG", "TV"],
+            ["ST", "CD", "GG", "TV"],
+            ["ST", "CD", "GG", "TV"],
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    assert (
+        DataframeType({"value": df})
+        .suffix_is_not_contained_by(
+            {
+                "target": target,
+                "comparator": "study_domains",
+                "suffix": suffix_length,
+            }
+        )
+        .equals(df.convert_to_series(expected_result))
+    )

--- a/tests/unit/test_check_operators/test_relationship_integrity_checks.py
+++ b/tests/unit/test_check_operators/test_relationship_integrity_checks.py
@@ -1221,3 +1221,376 @@ def test_target_is_sorted_by(dataset_class):
             ]
         )
     )
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        ("TESTID", "TESTNAME", PandasDataset, [True, False, True, False]),
+        ("TESTID", "TESTNAME", DaskDataset, [True, False, True, False]),
+        ("TESTNAME", "TESTID", PandasDataset, [True, False, True, False]),
+        ("TESTNAME", "TESTID", DaskDataset, [True, False, True, False]),
+    ],
+)
+def test_is_unique_relationship(target, comparator, dataset_type, expected_result):
+    data = {
+        "STUDYID": [
+            "TEST",
+            "TEST-1",
+            "TEST-2",
+            "TEST-3",
+        ],
+        "TESTID": [1, 2, 1, 3],
+        "TESTNAME": [
+            "Functional",
+            "Stress",
+            "Functional",
+            "Stress",
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).is_unique_relationship(
+        {"target": target, "comparator": comparator}
+    )
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, order, dataset_type, data, expected_result",
+    [
+        (
+            "AESEQ",
+            "asc",
+            PandasDataset,
+            {
+                "USUBJID": [
+                    "a",
+                    "a",
+                    "a",
+                    "a",
+                    "a",
+                ],
+                "AESEQ": [
+                    "a",
+                    "b",
+                    "c",
+                    "d",
+                    "e",
+                ],
+            },
+            [True, True, True, True, True],
+        ),
+        (
+            "AESEQ",
+            "asc",
+            DaskDataset,
+            {
+                "USUBJID": [
+                    "a",
+                    "a",
+                    "a",
+                    "a",
+                    "a",
+                ],
+                "AESEQ": [
+                    "a",
+                    "b",
+                    "c",
+                    "d",
+                    "e",
+                ],
+            },
+            [True, True, True, True, True],
+        ),
+        (
+            "AESEQ",
+            "dsc",
+            PandasDataset,
+            {
+                "USUBJID": [
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                ],
+                "AESEQ": [
+                    "2020-02-27",
+                    "2020-02-26",
+                    "2020-02-25",
+                    "2020-02-24",
+                    "2020-02-23",
+                ],
+            },
+            [True, True, True, True, True],
+        ),
+        (
+            "AESEQ",
+            "dsc",
+            DaskDataset,
+            {
+                "USUBJID": [
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                ],
+                "AESEQ": [
+                    "2020-02-27",
+                    "2020-02-26",
+                    "2020-02-25",
+                    "2020-02-24",
+                    "2020-02-23",
+                ],
+            },
+            [True, True, True, True, True],
+        ),
+        (
+            "AESEQ",
+            "dsc",
+            PandasDataset,
+            {
+                "USUBJID": [
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                ],
+                "AESEQ": [
+                    "2020-02-24",
+                    "2020-02-25",
+                    "2020-02-27",
+                    "2020-02-26",
+                    "2020-02-23",
+                ],
+            },
+            [False, False, False, False, True],
+        ),
+        (
+            "AESEQ",
+            "dsc",
+            DaskDataset,
+            {
+                "USUBJID": [
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                ],
+                "AESEQ": [
+                    "2020-02-24",
+                    "2020-02-25",
+                    "2020-02-27",
+                    "2020-02-26",
+                    "2020-02-23",
+                ],
+            },
+            [False, False, False, False, True],
+        ),
+    ],
+)
+def test_is_ordered_by(target, order, dataset_type, data, expected_result):
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).is_ordered_by(
+        {"target": target, "order": order}
+    )
+    print(result)
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, order, dataset_type, data, expected_result",
+    [
+        (
+            "AESEQ",
+            "asc",
+            PandasDataset,
+            {
+                "USUBJID": [
+                    "a",
+                    "a",
+                    "a",
+                    "a",
+                    "a",
+                ],
+                "AESEQ": [
+                    "a",
+                    "b",
+                    "c",
+                    "d",
+                    "e",
+                ],
+            },
+            [False, False, False, False, False],
+        ),
+        (
+            "AESEQ",
+            "asc",
+            DaskDataset,
+            {
+                "USUBJID": [
+                    "a",
+                    "a",
+                    "a",
+                    "a",
+                    "a",
+                ],
+                "AESEQ": [
+                    "a",
+                    "b",
+                    "c",
+                    "d",
+                    "e",
+                ],
+            },
+            [False, False, False, False, False],
+        ),
+        (
+            "AESEQ",
+            "dsc",
+            PandasDataset,
+            {
+                "USUBJID": [
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                ],
+                "AESEQ": [
+                    "2020-02-27",
+                    "2020-02-26",
+                    "2020-02-25",
+                    "2020-02-24",
+                    "2020-02-23",
+                ],
+            },
+            [False, False, False, False, False],
+        ),
+        (
+            "AESEQ",
+            "dsc",
+            DaskDataset,
+            {
+                "USUBJID": [
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                ],
+                "AESEQ": [
+                    "2020-02-27",
+                    "2020-02-26",
+                    "2020-02-25",
+                    "2020-02-24",
+                    "2020-02-23",
+                ],
+            },
+            [False, False, False, False, False],
+        ),
+        (
+            "AESEQ",
+            "dsc",
+            PandasDataset,
+            {
+                "USUBJID": [
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                ],
+                "AESEQ": [
+                    "2020-02-24",
+                    "2020-02-25",
+                    "2020-02-27",
+                    "2020-02-26",
+                    "2020-02-23",
+                ],
+            },
+            [True, True, True, True, False],
+        ),
+        (
+            "AESEQ",
+            "dsc",
+            DaskDataset,
+            {
+                "USUBJID": [
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                    "2020-02-23",
+                ],
+                "AESEQ": [
+                    "2020-02-24",
+                    "2020-02-25",
+                    "2020-02-27",
+                    "2020-02-26",
+                    "2020-02-23",
+                ],
+            },
+            [True, True, True, True, False],
+        ),
+    ],
+)
+def test_is_not_ordered_by(target, order, dataset_type, data, expected_result):
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).is_not_ordered_by(
+        {"target": target, "order": order}
+    )
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "dataset_type",
+    [
+        PandasDataset,
+        DaskDataset,
+    ],
+)
+def test_value_has_multiple_references(dataset_type):
+    data = {
+        "LNKGRP": ["A", "B", "A", "A", "A"],
+        "$VALUE_COUNTS": [
+            {"A": 2, "B": 1},
+            {"A": 2, "B": 1},
+            {"A": 2, "B": 1},
+            {"A": 2, "B": 1},
+            {"A": 2, "B": 1},
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).value_has_multiple_references(
+        {"target": "LNKGRP", "comparator": "$VALUE_COUNTS"}
+    )
+    assert result.equals(df.convert_to_series([True, False, True, True, True]))
+
+
+@pytest.mark.parametrize(
+    "dataset_type",
+    [
+        PandasDataset,
+        DaskDataset,
+    ],
+)
+def test_value_does_not_have_multiple_references(dataset_type):
+    data = {
+        "LNKGRP": ["A", "B", "A", "A", "A"],
+        "$VALUE_COUNTS": [
+            {"A": 2, "B": 1},
+            {"A": 2, "B": 1},
+            {"A": 2, "B": 1},
+            {"A": 2, "B": 1},
+            {"A": 2, "B": 1},
+        ],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).value_does_not_have_multiple_references(
+        {"target": "LNKGRP", "comparator": "$VALUE_COUNTS"}
+    )
+    assert result.equals(df.convert_to_series([False, True, False, False, False]))

--- a/tests/unit/test_check_operators/test_value_set_checks.py
+++ b/tests/unit/test_check_operators/test_value_set_checks.py
@@ -1,0 +1,94 @@
+from cdisc_rules_engine.check_operators.dataframe_operators import DataframeType
+import pytest
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        ("ARM", "LAE", PandasDataset, [True, True, True, True]),
+        ("ARM", ["ARF"], PandasDataset, [True, True, True, True]),
+        ("ARM", ["TAE"], PandasDataset, [False, False, True, True]),
+        ("ARM", ["TAE", "NOT_IN_DS"], PandasDataset, [False, False, True, True]),
+        ("ARM", ["TAE", ["NOT_IN_DS"]], PandasDataset, [False, False, True, True]),
+        ("ARM", ["TAE", ["LAE"]], PandasDataset, [True, True, True, True]),
+        ("ARM", [["LAE", "TAE"]], PandasDataset, [True, True, True, True]),
+        ("--M", "--F", PandasDataset, [True, True, True, True]),
+    ],
+)
+def test_is_unique_set(target, comparator, dataset_type, expected_result):
+    data = {
+        "ARM": ["PLACEBO", "PLACEBO", "A", "A"],
+        "TAE": [1, 1, 1, 2],
+        "LAE": [1, 2, 1, 2],
+        "ARF": [1, 2, 3, 4],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType(
+        {"value": df, "column_prefix_map": {"--": "AR"}}
+    ).is_unique_set({"target": target, "comparator": comparator})
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        ("ARM", "LAE", PandasDataset, [False, False, False, False]),
+        ("ARM", ["ARF"], PandasDataset, [False, False, False, False]),
+        ("ARM", ["TAE"], PandasDataset, [True, True, False, False]),
+        ("ARM", ["TAE", "NOT_IN_DS"], PandasDataset, [True, True, False, False]),
+        ("ARM", ["TAE", ["NOT_IN_DS"]], PandasDataset, [True, True, False, False]),
+        ("ARM", ["TAE", ["LAE"]], PandasDataset, [False, False, False, False]),
+        ("ARM", [["LAE", "TAE"]], PandasDataset, [False, False, False, False]),
+        ("--M", "--F", PandasDataset, [False, False, False, False]),
+    ],
+)
+def test_is_not_unique_set(target, comparator, dataset_type, expected_result):
+    data = {
+        "ARM": ["PLACEBO", "PLACEBO", "A", "A"],
+        "TAE": [1, 1, 1, 2],
+        "LAE": [1, 2, 1, 2],
+        "ARF": [1, 2, 3, 4],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType(
+        {"value": df, "column_prefix_map": {"--": "AR"}}
+    ).is_not_unique_set({"target": target, "comparator": comparator})
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        ("SESEQ", "USUBJID", PandasDataset, True),
+        ("UNORDERED", "USUBJID", PandasDataset, False),
+        ("SESEQ", "USUBJID", DaskDataset, True),
+        ("UNORDERED", "USUBJID", DaskDataset, False),
+    ],
+)
+def test_is_ordered_set(target, comparator, dataset_type, expected_result):
+    data = {"USUBJID": [1, 2, 1, 2], "UNORDERED": [3, 1, 2, 2], "SESEQ": [1, 1, 2, 2]}
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).is_ordered_set(
+        {"target": target, "comparator": comparator}
+    )
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        ("SESEQ", "USUBJID", PandasDataset, False),
+        ("UNORDERED", "USUBJID", PandasDataset, True),
+        ("SESEQ", "USUBJID", DaskDataset, False),
+        ("UNORDERED", "USUBJID", DaskDataset, True),
+    ],
+)
+def test_is_not_ordered_set(target, comparator, dataset_type, expected_result):
+    data = {"USUBJID": [1, 2, 1, 2], "UNORDERED": [3, 1, 2, 2], "SESEQ": [1, 1, 2, 2]}
+    df = dataset_type.from_dict(data)
+    result = DataframeType({"value": df}).is_not_ordered_set(
+        {"target": target, "comparator": comparator}
+    )
+    assert result == expected_result


### PR DESCRIPTION
Steps to test:

1. Unit tests pass
2. Tests exist for the following operators:
```
is_complete_date
exists
additional_columns_empty
variable_metadata_equal_to
is_contained_by
is_contained_by_case_insensitive
prefix_is_contained_by
suffix_is_contained_by
is_unique_set
is_unique_relationship
has_next_corresponding_record
is_ordered_set
is_ordered_by
target_is_sorted_by
value_has_multiple_references
conformant_value_data_type
conformant_value_length
references_correct_codelist
uses_valid_codelist_terms
```