### PR TITLE
CG0138: contains_special_topics fix

### DIFF
--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -295,12 +295,18 @@ class BaseDataService(DataServiceInterface, ABC):
         Checks if the given dataset-class string ends with a particular variable string.
         Returns True/False
         """
-        if "DOMAIN" not in dataset.values and "RDOMAIN" not in dataset.values:
+
+        def check_presence(key):
+            in_dataset = key in dataset
+            in_values = hasattr(dataset, "values") and key in dataset.values
+            return in_dataset or in_values
+
+        if not check_presence("DOMAIN") and not check_presence("RDOMAIN"):
             return False
-        elif "DOMAIN" in dataset.values:
-            return domain.upper() + variable in dataset.values
-        elif "RDOMAIN" in dataset.values:
-            return variable in dataset.values
+        elif check_presence("DOMAIN"):
+            return check_presence(domain.upper() + variable)
+        elif check_presence("RDOMAIN"):
+            return check_presence(variable)
 
     def _domain_starts_with(self, domain, variable):
         """

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -295,12 +295,12 @@ class BaseDataService(DataServiceInterface, ABC):
         Checks if the given dataset-class string ends with a particular variable string.
         Returns True/False
         """
-        if "DOMAIN" not in dataset and "RDOMAIN" not in dataset.values:
+        if "DOMAIN" not in dataset.values and "RDOMAIN" not in dataset.values:
             return False
         elif "DOMAIN" in dataset.values:
-            return domain.upper() + variable in dataset
+            return domain.upper() + variable in dataset.values
         elif "RDOMAIN" in dataset.values:
-            return variable in dataset
+            return variable in dataset.values
 
     def _domain_starts_with(self, domain, variable):
         """

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -224,7 +224,6 @@ class BaseDataService(DataServiceInterface, ABC):
         name = class_data.get("name")
         if name:
             return convert_library_class_name_to_ct_class(name)
-
         return self._handle_special_cases(dataset, domain, file_path, datasets)
 
     def _get_standard_data(self):
@@ -296,11 +295,11 @@ class BaseDataService(DataServiceInterface, ABC):
         Checks if the given dataset-class string ends with a particular variable string.
         Returns True/False
         """
-        if "DOMAIN" not in dataset and "RDOMAIN" not in dataset:
+        if "DOMAIN" not in dataset and "RDOMAIN" not in dataset.values:
             return False
-        elif "DOMAIN" in dataset:
+        elif "DOMAIN" in dataset.values:
             return domain.upper() + variable in dataset
-        elif "RDOMAIN" in dataset:
+        elif "RDOMAIN" in dataset.values:
             return variable in dataset
 
     def _domain_starts_with(self, domain, variable):


### PR DESCRIPTION
https://jira.cdisc.org/browse/CORERULES-888?jql=project%20%3D%20CORERULES%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC

There is an error in engine causing the rule to be skipped as the dataset object was not parsed correctly in contains_special_topics.  This was leading engine to think returning None instead of True, leading to domain skipping.  I created a helper function that preserves the way it was checking for the column topics but also checks in dataset.values as these columns may not be contained as keys in the dataframe object.

To test: run CG0138 against test data, the rule should no longer be skipped