### PR TITLE
added invalid_duration ISO8601 operator

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -4,6 +4,7 @@ from business_rules.fields import FIELD_DATAFRAME
 from business_rules.utils import (
     flatten_list,
     vectorized_is_valid,
+    vectorized_is_valid_duration,
     vectorized_is_complete_date,
     vectorized_get_dict_key,
     vectorized_is_in,
@@ -792,6 +793,12 @@ class DataframeType(BaseType):
     def invalid_date(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
         results = ~vectorized_is_valid(self.value[target])
+        return self.value.convert_to_series(results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def invalid_duration(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        results = ~vectorized_is_valid_duration(self.value[target])
         return self.value.convert_to_series(results)
 
     def date_comparison(self, other_value, operator):

--- a/resources/schema/Operator.json
+++ b/resources/schema/Operator.json
@@ -303,6 +303,15 @@
     {
       "properties": {
         "operator": {
+          "const": "invalid_duration"
+        }
+      },
+      "required": ["operator"],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "operator": {
           "const": "invalid_date"
         }
       },

--- a/resources/schema/Operator.md
+++ b/resources/schema/Operator.md
@@ -480,6 +480,17 @@ Date check
   operator: "invalid_date"
 ```
 
+## invalid_duration
+
+Duration ISO-8601 check
+
+> DURVAR is invalid
+
+```yaml
+- name: "BRTHDTC"
+  operator: "invalid_duration"
+```
+
 # Metadata
 
 ## exists

--- a/resources/schema/Operator.md
+++ b/resources/schema/Operator.md
@@ -482,7 +482,7 @@ Date check
 
 ## invalid_duration
 
-Duration ISO-8601 check
+Duration ISO-8601 check, returns True if a duration is not in ISO-8601 format
 
 > DURVAR is invalid
 

--- a/tests/unit/test_check_operators/test_duration_checks.py
+++ b/tests/unit/test_check_operators/test_duration_checks.py
@@ -50,10 +50,11 @@ def test_invalid_duration_edge_cases():
             "P1Y2M3DT",
             "P1.5Y",
             "P1M2.5D",
+            "P 1Y",
         ]
     }
     df = PandasDataset.from_dict(data)
     dataframe_type = DataframeType({"value": df})
     result = dataframe_type.invalid_duration({"target": "target"})
-    expected = [False, False, False, True, True, True]
+    expected = [False, False, False, True, True, True, True]
     assert result.equals(df.convert_to_series(expected))

--- a/tests/unit/test_check_operators/test_duration_checks.py
+++ b/tests/unit/test_check_operators/test_duration_checks.py
@@ -1,0 +1,59 @@
+import pytest
+from cdisc_rules_engine.check_operators.dataframe_operators import DataframeType
+from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+
+
+@pytest.mark.parametrize(
+    "data,dataset_type,expected_result",
+    [
+        (
+            {"target": ["P1Y", "P1M", "P1D", "PT1H"]},
+            PandasDataset,
+            [False, False, False, False],
+        ),
+        (
+            {"target": ["P1Y2M3D", "P1DT2H3M", "PT1H30M", "P1W"]},
+            DaskDataset,
+            [False, False, False, False],
+        ),
+        (
+            {"target": ["P", "1Y", "PT", "P1S"]},
+            PandasDataset,
+            [True, True, True, True],
+        ),
+        (
+            {"target": ["P1Y1M1DT1H1M1.5S", "PT1.5S", "P1DT1H1M1.123S", "P1YT"]},
+            DaskDataset,
+            [False, False, False, True],
+        ),
+        (
+            {"target": ["P-1Y", "P1M2D3H", "P1D1H", "PT24H"]},
+            PandasDataset,
+            [True, True, True, False],
+        ),
+    ],
+)
+def test_invalid_duration(data, dataset_type, expected_result):
+    df = dataset_type.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.invalid_duration({"target": "target"})
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+def test_invalid_duration_edge_cases():
+    data = {
+        "target": [
+            "P1Y2M3W4DT5H6M7.89S",
+            "PT0.1S",
+            "P0D",
+            "P1Y2M3DT",
+            "P1.5Y",
+            "P1M2.5D",
+        ]
+    }
+    df = PandasDataset.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.invalid_duration({"target": "target"})
+    expected = [False, False, False, True, True, True]
+    assert result.equals(df.convert_to_series(expected))


### PR DESCRIPTION
this PR adds the testing, documentation, and functionality for an invalid_duration check that returns a bool based on whether or not a given duration matches ISO 8601 formatting.