### PR TITLE
added regex to schema and properly parse it from rules

### DIFF
--- a/cdisc_rules_engine/models/rule.py
+++ b/cdisc_rules_engine/models/rule.py
@@ -134,6 +134,8 @@ class Rule:
         }
         if condition.get("name"):
             data["value"]["target"] = condition.get("name")
+        if condition.get("regex"):
+            data["value"]["regex"] = condition.get("regex")
         if "variables" in condition:
             data["variables"] = condition["variables"]
         for optional_parameter in OptionalConditionParameters.values():

--- a/resources/schema/Operator.json
+++ b/resources/schema/Operator.json
@@ -943,6 +943,9 @@
     },
     "within": {
       "$ref": "CORE-base.json#/$defs/VariableName"
+    },
+    "regex": {
+      "type": "string"
     }
   },
   "required": ["operator"],


### PR DESCRIPTION
This PR has changed to also include updates to the rule parsing logic to allow CG0334 to run.
[Rule_underscores.json](https://github.com/user-attachments/files/16601510/Rule_underscores.json)
This is the regex rule and there are added changes  to engine to correctly parse the new regex argument off the rule and use it for the rule.
