### PR TITLE
ContentsDefineDatasetBuilder

### DIFF
--- a/cdisc_rules_engine/dataset_builders/contents_define_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/contents_define_dataset_builder.py
@@ -65,10 +65,10 @@ class ContentsDefineDatasetBuilder(BaseDatasetBuilder):
             "define_dataset_name",
             "define_dataset_label",
             "define_dataset_location",
-            "define_dataset_domain" "define_dataset_class",
+            "define_dataset_domain",
+            "define_dataset_class",
             "define_dataset_structure",
             "define_dataset_is_non_standard",
-            "define_dataset_variables",
         ]
         define_metadata = self.get_define_metadata()
         if not define_metadata:


### PR DESCRIPTION
added a missing comma that was causing issues with define_dataset_domain
define_dataset_variables was removed as this is not a piece of metadata that is extracted from the define and will always be 'not found in dataset'
![image](https://github.com/user-attachments/assets/497df0e5-1955-4233-8d45-e703ad6f4049)
