### PR TITLE
added min, reset_index to custom datasets

### DIFF
--- a/cdisc_rules_engine/models/dataset/dask_dataset.py
+++ b/cdisc_rules_engine/models/dataset/dask_dataset.py
@@ -258,3 +258,17 @@ class DaskDataset(PandasDataset):
         ]
         new_data = self._data[columns_subset]
         return self.__class__(new_data)
+
+    def min(self, *args, **kwargs):
+        """
+        Return the minimum of the values over the requested axis.
+        """
+        result = self._data.min(*args, **kwargs)
+        return self.__class__(result)
+
+    def reset_index(self, drop=False, **kwargs):
+        """
+        Reset the index of the dataset.
+        """
+        self._data = self._data.reset_index(drop=drop, **kwargs)
+        return self

--- a/cdisc_rules_engine/models/dataset/dataset_interface.py
+++ b/cdisc_rules_engine/models/dataset/dataset_interface.py
@@ -203,3 +203,15 @@ class DatasetInterface(ABC):
         """
         Returns true if the column is sorted within each grouping otherwise false
         """
+
+    @abstractmethod
+    def min(self, *args, **kwargs):
+        """
+        Return the minimum of the values over the requested axis.
+        """
+
+    @abstractmethod
+    def reset_index(self, drop=False, **kwargs):
+        """
+        Reset the index of the dataset.
+        """

--- a/cdisc_rules_engine/models/dataset/pandas_dataset.py
+++ b/cdisc_rules_engine/models/dataset/pandas_dataset.py
@@ -228,3 +228,13 @@ class PandasDataset(DatasetInterface):
     def astype(self, dtype, **kwargs):
         self._data = self._data.astype(dtype, **kwargs)
         return self
+
+    def min(self, *args, **kwargs):
+        return self.__class__(self._data.min(*args, **kwargs))
+
+    def reset_index(self, drop=False, **kwargs):
+        """
+        Reset the index of the dataset.
+        """
+        self._data = self._data.reset_index(drop=drop, **kwargs)
+        return self

--- a/cdisc_rules_engine/operations/day_data_validator.py
+++ b/cdisc_rules_engine/operations/day_data_validator.py
@@ -1,15 +1,17 @@
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 from datetime import datetime
 import numpy as np
+from cdisc_rules_engine.services import logger
 
 
 class DayDataValidator(BaseOperation):
     def _execute_operation(self):
-
+        logger.info(
+            f"trying to find '{self.params.target}' in the {self.evaluation_dataset['DOMAIN'].iloc[0]}."
+        )
         dtc_value = self.evaluation_dataset[self.params.target].map(
             self.parse_timestamp
         )
-
         # Always get RFSTDTC column from DM dataset.
         dm_datasets = [
             dataset for dataset in self.params.datasets if dataset["domain"] == "DM"
@@ -19,9 +21,14 @@ class DayDataValidator(BaseOperation):
             return [0] * len(self.evaluation_dataset[self.params.target])
         if len(dm_datasets) > 1:
             files = [dataset["filename"] for dataset in dm_datasets]
-            dm_data = self.data_service.join_split_datasets(files)
+            dm_data = self.data_service.concat_split_datasets(
+                self.data_service.get_dataset, files
+            )
         else:
-            dm_data = self.data_service.get_dataset(dm_datasets[0]["filename"])
+            dm_data = self.data_service.get_dataset(
+                dataset_name=dm_datasets[0].get("full_path")
+                or dm_datasets[0]["filename"]
+            )
 
         new_dataset = self.evaluation_dataset.merge(
             dm_data[["USUBJID", "RFSTDTC"]], on="USUBJID", suffixes=("", "_dm")

--- a/cdisc_rules_engine/operations/variable_value_count.py
+++ b/cdisc_rules_engine/operations/variable_value_count.py
@@ -38,7 +38,7 @@ class VariableValueCount(BaseOperation):
                 os.path.join(self.params.directory_path, dataset.get("filename"))
                 for dataset in get_corresponding_datasets(self.params.datasets, domain)
             ]
-            data: DatasetInterface = self.data_service.join_split_datasets(
+            data: DatasetInterface = self.data_service.concat_split_datasets(
                 self.data_service.get_dataset, files
             )
         else:

--- a/tests/unit/test_operations/test_variable_count.py
+++ b/tests/unit/test_operations/test_variable_count.py
@@ -49,7 +49,7 @@ def test_variable_count(
     mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
         os.path.split(name)[-1]
     )
-    mock_data_service.join_split_datasets.side_effect = lambda func, files: pd.concat(
+    mock_data_service.concat_split_datasets.side_effect = lambda func, files: pd.concat(
         [func(f) for f in files]
     )
     operation_params.datasets = datasets

--- a/tests/unit/test_operations/test_variable_library_metadata.py
+++ b/tests/unit/test_operations/test_variable_library_metadata.py
@@ -58,7 +58,7 @@ def test_get_variable_metadata_for_given_standard(
     mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
         name.split("/")[-1]
     )
-    mock_data_service.join_split_datasets.side_effect = lambda func, files: pd.concat(
+    mock_data_service.concat_split_datasets.side_effect = lambda func, files: pd.concat(
         [func(f) for f in files]
     )
     operation_params.target = target

--- a/tests/unit/test_operations/test_variable_names.py
+++ b/tests/unit/test_operations/test_variable_names.py
@@ -62,7 +62,7 @@ def test_get_variable_names_for_given_standard(
     mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
         name.split("/")[-1]
     )
-    mock_data_service.join_split_datasets.side_effect = lambda func, files: pd.concat(
+    mock_data_service.concat_split_datasets.side_effect = lambda func, files: pd.concat(
         [func(f) for f in files]
     )
     operation_params.target = target

--- a/tests/unit/test_operations/test_variable_value_count.py
+++ b/tests/unit/test_operations/test_variable_value_count.py
@@ -48,7 +48,7 @@ def test_variable_value_count(
     mock_data_service.get_dataset.side_effect = lambda name: datasets_map.get(
         os.path.split(name)[-1]
     )
-    mock_data_service.join_split_datasets.side_effect = (
+    mock_data_service.concat_split_datasets.side_effect = (
         lambda func, files: dataset_type().concat([func(f) for f in files])
     )
     operation_params.datasets = datasets


### PR DESCRIPTION
cg0068 was failing as reset_index() and min() were not added to the custom dataset classes with the large dataset PR.

Note: i accidentally did this fix on my local cg006 branch so the changes from that PR are included.  Whoever reviews this--please do the cg0006 PR prior to this one.