### PR TITLE
Actions dependancies

### DIFF
--- a/.github/workflows/rule-tester.yml
+++ b/.github/workflows/rule-tester.yml
@@ -15,9 +15,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install application dependencies
@@ -27,7 +27,7 @@ jobs:
           pip install -r requirements-rule-tester.txt
         shell: bash
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: |
             . 
@@ -42,7 +42,7 @@ jobs:
     if: success()
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: python-app
           path: .

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ Note: The Windows commands provided in this README are written for PowerShell. W
 
 # cdisc-rules-engine
 
-Open source offering of the cdisc rules engine
+Open source offering of the CDISC Rules Engine, a tool designed for validating clinical trial data against data standards.
+To learn more, visit our official CDISC website or for other implementation options, see our DockerHub repository:  
+<br>  
+[CDISC Website](https://www.cdisc.org/)  
+<br>  
+[CDISC Rules Engine on DockerHub](https://hub.docker.com/repository/docker/cdiscdocker/cdisc-rules-engine/general)
 
 ### **Quick start**
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:latest
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /app
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    curl \
+    unzip \
+    jq \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y \
+    python3.10 \
+    python3.10-distutils \
+    && rm -rf /var/lib/apt/lists/*
+# Download the latest release
+RUN LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest | jq -r '.assets[] | select(.name == "core-ubuntu-latest.zip") | .browser_download_url') \
+    && curl -L -o core-ubuntu-latest.zip "$LATEST_RELEASE_URL" \
+    && unzip core-ubuntu-latest.zip -d cdisc-rules-engine \
+    && rm core-ubuntu-latest.zip \
+    && mv cdisc-rules-engine/* . \
+    && rmdir cdisc-rules-engine \
+    && chmod +x /app/core
+CMD ["/bin/sh"]


### PR DESCRIPTION
we are getting failed builds during our 'deploy azure rule tester' pipeline.  V2 of the upload artifact has deprecated.
This PR updates the checkout versioning and upload artifact version as well as setup-python versioning for this pipeline