### PR TITLE
updated invalid duration logic

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -810,7 +810,10 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def invalid_duration(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        results = ~vectorized_is_valid_duration(self.value[target])
+        if other_value.get("negative") is False:
+            results = ~vectorized_is_valid_duration(self.value[target], False)
+        else:
+            results = ~vectorized_is_valid_duration(self.value[target], True)
         return self.value.convert_to_series(results)
 
     def date_comparison(self, other_value, operator):

--- a/cdisc_rules_engine/models/rule.py
+++ b/cdisc_rules_engine/models/rule.py
@@ -138,6 +138,8 @@ class Rule:
             data["value"]["regex"] = condition.get("regex")
         if "variables" in condition:
             data["variables"] = condition["variables"]
+        if "negative" in condition:
+            data["value"]["negative"] = condition.get("negative").lower() == "true"
         for optional_parameter in OptionalConditionParameters.values():
             if optional_parameter in condition:
                 data["value"][optional_parameter] = condition.get(optional_parameter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==22.6.0
-business-rules-enhanced==1.4.3
+business-rules-enhanced==1.4.4
 cdisc-library-client==0.1.4
 click==8.1.3
 flake8==5.0.4

--- a/resources/schema/Operator.json
+++ b/resources/schema/Operator.json
@@ -306,7 +306,7 @@
           "const": "invalid_duration"
         }
       },
-      "required": ["operator"],
+      "required": ["operator", "negative"],
       "type": "object"
     },
     {

--- a/resources/schema/Operator.md
+++ b/resources/schema/Operator.md
@@ -489,7 +489,7 @@ Duration ISO-8601 check, returns True if a duration is not in ISO-8601 format. P
 ```yaml
 - name: "BRTHDTC"
   operator: "invalid_duration"
-  negative: False
+  negative: "False"
 ```
 
 # Metadata

--- a/resources/schema/Operator.md
+++ b/resources/schema/Operator.md
@@ -482,13 +482,14 @@ Date check
 
 ## invalid_duration
 
-Duration ISO-8601 check, returns True if a duration is not in ISO-8601 format
+Duration ISO-8601 check, returns True if a duration is not in ISO-8601 format. Parameter `negative` must be given to either allow or disallow negative durations as valid.
 
 > DURVAR is invalid
 
 ```yaml
 - name: "BRTHDTC"
   operator: "invalid_duration"
+  negative: False
 ```
 
 # Metadata

--- a/tests/unit/test_check_operators/test_duration_checks.py
+++ b/tests/unit/test_check_operators/test_duration_checks.py
@@ -37,7 +37,7 @@ from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 def test_invalid_duration(data, dataset_type, expected_result):
     df = dataset_type.from_dict(data)
     dataframe_type = DataframeType({"value": df})
-    result = dataframe_type.invalid_duration({"target": "target"})
+    result = dataframe_type.invalid_duration({"target": "target", "negative": False})
     assert result.equals(df.convert_to_series(expected_result))
 
 
@@ -63,7 +63,7 @@ def test_invalid_duration_edge_cases():
     }
     df = PandasDataset.from_dict(data)
     dataframe_type = DataframeType({"value": df})
-    result = dataframe_type.invalid_duration({"target": "target"})
+    result = dataframe_type.invalid_duration({"target": "target", "negative": False})
     expected = [
         True,
         False,
@@ -81,4 +81,13 @@ def test_invalid_duration_edge_cases():
         False,
         True,
     ]
+    assert result.equals(df.convert_to_series(expected))
+
+
+def test_invalid_duration_negative_positive():
+    data = {"target": ["-P1Y", "P1M", "P1D", "-PT1H", "P1Y2M", "-P1.5D", "P1Y,5M"]}
+    df = PandasDataset.from_dict(data)
+    dataframe_type = DataframeType({"value": df})
+    result = dataframe_type.invalid_duration({"target": "target", "negative": True})
+    expected = [False, False, False, False, False, False, False]
     assert result.equals(df.convert_to_series(expected))

--- a/tests/unit/test_check_operators/test_duration_checks.py
+++ b/tests/unit/test_check_operators/test_duration_checks.py
@@ -46,15 +46,39 @@ def test_invalid_duration_edge_cases():
         "target": [
             "P1Y2M3W4DT5H6M7.89S",
             "PT0.1S",
+            "PT0,1S",
             "P0D",
             "P1Y2M3DT",
             "P1.5Y",
             "P1M2.5D",
             "P 1Y",
+            "P1Y2.5M",
+            "P1.5W",
+            "P1Y,5M",
+            "P1Y2M3.4D5H",
+            "PT1H2M3.4S5M",
+            "P4W",
+            "P1Y1W",
         ]
     }
     df = PandasDataset.from_dict(data)
     dataframe_type = DataframeType({"value": df})
     result = dataframe_type.invalid_duration({"target": "target"})
-    expected = [False, False, False, True, True, True, True]
+    expected = [
+        True,
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+        True,
+        True,
+        False,
+        True,
+    ]
     assert result.equals(df.convert_to_series(expected))


### PR DESCRIPTION
I have updated the testsuite in this PR along with the business rules to update the regex and logic for invalid_duration.  
https://regex101.com/r/rnLW9r/1  here is the new regex pattern along with the test cases.  It may need to be updated for DDF if they desire negative durations.
see: https://en.wikipedia.org/wiki/ISO_8601#Durations for a description of duration ISO8601.  Week dates also describes the week logic as weeks cannot be intermingled with other duration indicators (years, months, days).  , or . can be used for decimals but it must be the smallest unit of the duration.  This should fix the errors in the durations @ASL-rmarshall described