### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,6 @@ updates:
     directory: "/"
     open-pull-requests-limit: 5
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
     - "pip dependencies"


### PR DESCRIPTION
Unfortunately, biweekly is not a frequency for depandabot.  I converted it to monthly so that every other sprint, it will add dependancy tickets and will not be adding more tickets mid-sprint