### PR TITLE
bug: updated local rule parser to fix missing output variables

### DIFF
--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -225,8 +225,8 @@ def load_and_parse_rule(rule_file):
     try:
         with open(rule_file, "r", encoding="utf-8") as file:
             if file_extension in [".yml", ".yaml"]:
-                loaded_data = Rule.from_cdisc_metadata(yaml.safe_load(file))
-                return replace_yml_spaces(loaded_data)
+                loaded_data = yaml.safe_load(file)
+                return Rule.from_cdisc_metadata(replace_yml_spaces(loaded_data))
             elif file_extension == ".json":
                 return Rule.from_cdisc_metadata(json.load(file))
             else:


### PR DESCRIPTION
this PR makes the adjustments recommended by @ASL-rmarshall to confirm the fix.

To test: run a validation with -lr flag using a yaml rule that uses output variables/match datasets.  I used CG0222
[CORE-Report-2024-10-07T16-45-19.xlsx](https://github.com/user-attachments/files/17284349/CORE-Report-2024-10-07T16-45-19.xlsx)
