### PR TITLE
Fixes for dask skipped rules

### DIFF
--- a/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
@@ -10,6 +10,7 @@ from cdisc_rules_engine.utilities.utils import (
     is_split_dataset,
     get_corresponding_datasets,
     is_supp_dataset,
+    get_dataset_name_from_details,
 )
 from typing import List
 from cdisc_rules_engine import config
@@ -106,7 +107,7 @@ class BaseDatasetBuilder:
     def get_corresponding_datasets_names(self) -> List[str]:
         directory_path = get_directory_path(self.dataset_path)
         return [
-            os.path.join(directory_path, dataset["filename"])
+            os.path.join(directory_path, get_dataset_name_from_details(dataset))
             for dataset in get_corresponding_datasets(self.datasets, self.domain)
         ]
 

--- a/cdisc_rules_engine/dataset_builders/content_metadata_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/content_metadata_dataset_builder.py
@@ -25,5 +25,5 @@ class ContentMetadataDatasetBuilder(BaseDatasetBuilder):
         """
         size_unit: str = self.rule_processor.get_size_unit_from_rule(self.rule)
         return self.data_service.get_dataset_metadata(
-            dataset_name=dataset_name, size_unit=size_unit
+            dataset_name=dataset_name, size_unit=size_unit, datasets=self.datasets
         )

--- a/cdisc_rules_engine/dataset_builders/contents_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/contents_dataset_builder.py
@@ -16,7 +16,9 @@ class ContentsDatasetBuilder(BaseDatasetBuilder):
         """
         Returns the contents of a file as a dataframe for evaluation.
         """
-        return self.data_service.get_dataset(dataset_name=dataset_name)
+        return self.data_service.get_dataset(
+            dataset_name=dataset_name, datasets=self.datasets
+        )
 
     def get_dataset(self, **kwargs):
         # If validating dataset content, ensure split datasets are handled.

--- a/cdisc_rules_engine/models/dataset/dataset_interface.py
+++ b/cdisc_rules_engine/models/dataset/dataset_interface.py
@@ -38,6 +38,13 @@ class DatasetInterface(ABC):
         Create the underlying dataset from provided list of records
         """
 
+    @classmethod
+    @abstractmethod
+    def get_series_values(cls, series) -> list:
+        """
+        Returns the values for a series.
+        """
+
     @abstractmethod
     def __getitem__(self, item: str):
         """
@@ -100,8 +107,9 @@ class DatasetInterface(ABC):
         Return iterator over all dataset rows
         """
 
+    @classmethod
     @abstractmethod
-    def is_series(self, data) -> bool:
+    def is_series(cls, data) -> bool:
         """
         Return true if the data is a series compatible with the underlying dataset
         """
@@ -228,4 +236,11 @@ class DatasetInterface(ABC):
     ):
         """
         Fill NA/NaN values using the specified method.
+        """
+
+    @abstractmethod
+    def get_grouped_size(self, by, **kwargs):
+        """
+        Returns a dataframe containing the sizes of each group in
+        the dataframe.
         """

--- a/cdisc_rules_engine/models/dataset/pandas_dataset.py
+++ b/cdisc_rules_engine/models/dataset/pandas_dataset.py
@@ -76,6 +76,10 @@ class PandasDataset(DatasetInterface):
     def groupby(self, by: List[str], **kwargs):
         return self.__class__(self._data.groupby(by, **kwargs))
 
+    def get_grouped_size(self, by, **kwargs):
+        grouped_data = self._data.groupby(by, **kwargs)
+        return grouped_data.size()
+
     def is_column_sorted_within(self, group, column):
         return (
             False
@@ -104,8 +108,15 @@ class PandasDataset(DatasetInterface):
     def iterrows(self):
         return self._data.iterrows()
 
-    def is_series(self, data) -> bool:
+    @classmethod
+    def is_series(cls, data) -> bool:
         return isinstance(data, pd.Series)
+
+    @classmethod
+    def get_series_values(cls, series) -> list:
+        if not cls.is_series(series):
+            return []
+        return series.values
 
     def rename(self, index=None, columns=None, inplace=True):
         self._data.rename(index=index, columns=columns, inplace=inplace)

--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -57,6 +57,8 @@ class BaseOperation:
             # Assume that the operation id has been applied and
             # result matches the length of the evaluation dataset.
             return self.evaluation_dataset.concat(result, axis=1)
+        elif isinstance(result, dict):
+            return self._handle_dictionary_result(result)
         else:
             # Handle single results
 

--- a/cdisc_rules_engine/operations/record_count.py
+++ b/cdisc_rules_engine/operations/record_count.py
@@ -21,16 +21,14 @@ class RecordCount(BaseOperation):
             result = len(filtered)
         if self.params.grouping:
             self.params.target = "size"
-            group_df = self.params.dataframe.groupby(
+            group_df = self.params.dataframe.get_grouped_size(
                 self.params.grouping, as_index=False
-            ).data.size()
+            )
             if filtered is not None:
                 group_df = (
                     group_df[self.params.grouping]
                     .merge(
-                        filtered.groupby(
-                            self.params.grouping, as_index=False
-                        ).data.size(),
+                        filtered.get_grouped_size(self.params.grouping, as_index=False),
                         on=self.params.grouping,
                         how="left",
                     )

--- a/cdisc_rules_engine/operations/variable_count.py
+++ b/cdisc_rules_engine/operations/variable_count.py
@@ -34,10 +34,13 @@ class VariableCount(BaseOperation):
 
     async def _get_dataset_variable_count(self, dataset: dict) -> Counter:
         domain = dataset.get("domain", "")
+        filename = (
+            os.path.split(dataset["full_path"])[-1]
+            if "full_path" in dataset
+            else dataset["filename"]
+        )
         data: pd.DataFrame = self.data_service.get_dataset(
-            dataset_name=os.path.join(
-                self.params.directory_path, dataset.get("filename")
-            )
+            dataset_name=os.path.join(self.params.directory_path, filename)
         )
         target_variable = self.params.original_target.replace("--", domain, 1)
         return 1 if target_variable in data else 0

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -298,7 +298,7 @@ class BaseDataService(DataServiceInterface, ABC):
 
         def check_presence(key):
             in_dataset = key in dataset
-            in_values = hasattr(dataset, "values") and key in dataset.values
+            in_values = key in self.dataset_implementation.get_series_values(dataset)
             return in_dataset or in_values
 
         if not check_presence("DOMAIN") and not check_presence("RDOMAIN"):

--- a/cdisc_rules_engine/services/data_services/local_data_service.py
+++ b/cdisc_rules_engine/services/data_services/local_data_service.py
@@ -188,7 +188,12 @@ class LocalDataService(BaseDataService):
                         "size": os.path.getsize(obj["original_path"]),
                     }
                     file_name = obj["filename"]
-                break
+                    print(file_name)
+                    break
+            # If we reach this line a parquet dataset was provided without a
+            # corresponding xpt or json file. This should not happen
+            # TODO: Implement a DatasetParquetMetadataReader so we don't have to
+            # perform this check.
 
         _metadata_reader_map = {
             DataFormatTypes.XPT.value: DatasetXPTMetadataReader,
@@ -210,7 +215,7 @@ class LocalDataService(BaseDataService):
         Internal method that gets dataset metadata
         and converts file size if needed.
         """
-        metadata: dict = self.read_metadata(dataset_name)
+        metadata: dict = self.read_metadata(dataset_name, kwargs.get("datasets"))
         file_metadata: dict = metadata["file_metadata"]
         size_unit: Optional[str] = kwargs.get("size_unit")
         if size_unit:  # convert file size from bytes to desired unit if needed

--- a/cdisc_rules_engine/services/logging/console_logger.py
+++ b/cdisc_rules_engine/services/logging/console_logger.py
@@ -58,9 +58,9 @@ class ConsoleLogger(LoggerInterface):
         self._logger.log(logging.CRITICAL + 1, msg, *args, **kwargs)
 
     def trace(self, exc: Exception, msg: str, *args, **kwargs):
-        current_level = self._logger.getEffectiveLevel()
-        if current_level > 50:
-            self.display_trace(exc, inspect.currentframe())
+        # current_level = self._logger.getEffectiveLevel()
+        # if current_level > 50:
+        self.display_trace(exc, inspect.currentframe())
 
     def display_trace(self, e: Exception = None, f=None):
         if e is None:

--- a/cdisc_rules_engine/services/logging/console_logger.py
+++ b/cdisc_rules_engine/services/logging/console_logger.py
@@ -58,9 +58,9 @@ class ConsoleLogger(LoggerInterface):
         self._logger.log(logging.CRITICAL + 1, msg, *args, **kwargs)
 
     def trace(self, exc: Exception, msg: str, *args, **kwargs):
-        # current_level = self._logger.getEffectiveLevel()
-        # if current_level > 50:
-        self.display_trace(exc, inspect.currentframe())
+        current_level = self._logger.getEffectiveLevel()
+        if current_level > 50:
+            self.display_trace(exc, inspect.currentframe())
 
     def display_trace(self, e: Exception = None, f=None):
         if e is None:

--- a/cdisc_rules_engine/utilities/data_processor.py
+++ b/cdisc_rules_engine/utilities/data_processor.py
@@ -17,7 +17,10 @@ from cdisc_rules_engine.services.data_services import (
     DataServiceFactory,
     DummyDataService,
 )
-from cdisc_rules_engine.utilities.utils import search_in_list_of_dicts
+from cdisc_rules_engine.utilities.utils import (
+    search_in_list_of_dicts,
+    get_dataset_name_from_details,
+)
 import os
 from cdisc_rules_engine.utilities.sdtm_utilities import add_variable_wildcards
 
@@ -96,7 +99,8 @@ class DataProcessor:
             datasets, lambda item: item.get("domain") == domain
         )
         if domain_details:
-            data_filename = os.path.join(dataset_path, domain_details["filename"])
+            filename = get_dataset_name_from_details(domain_details)
+            data_filename = os.path.join(dataset_path, filename)
             new_data = self.data_service.get_dataset(dataset_name=data_filename)
             reference_data[domain] = self.get_columns(new_data, columns)
         return reference_data

--- a/cdisc_rules_engine/utilities/dataset_preprocessor.py
+++ b/cdisc_rules_engine/utilities/dataset_preprocessor.py
@@ -14,6 +14,7 @@ from cdisc_rules_engine.utilities.utils import (
     replace_pattern_in_list_of_strings,
     search_in_list_of_dicts,
     get_sided_match_keys,
+    get_dataset_name_from_details,
 )
 import os
 
@@ -69,9 +70,8 @@ class DatasetPreprocessor:
             )
             if not file_info:
                 continue
-            other_dataset: DatasetInterface = self._download_dataset(
-                file_info["filename"]
-            )
+            filename = get_dataset_name_from_details(file_info)
+            other_dataset: DatasetInterface = self._download_dataset(filename)
             referenced_targets = set(
                 [
                     target.replace(f"{domain_name}.", "")

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -28,6 +28,7 @@ from cdisc_rules_engine.utilities.utils import (
     is_ap_domain,
     is_supp_domain,
     search_in_list_of_dicts,
+    get_dataset_name_from_details,
 )
 
 
@@ -324,9 +325,10 @@ class RuleProcessor:
                 operation_params.datasets,
                 lambda item: item.get("domain") == operation_params.domain,
             )
+            filename = get_dataset_name_from_details(domain_details)
             file_path: str = os.path.join(
                 get_directory_path(operation_params.dataset_path),
-                domain_details["filename"],
+                filename,
             )
             operation_params.dataframe = self.data_service.get_dataset(
                 dataset_name=file_path

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -246,6 +246,14 @@ def is_supp_dataset(datasets: List[dict], domain: str) -> bool:
     return False
 
 
+def get_dataset_name_from_details(domain_details) -> str:
+    return (
+        os.path.split(domain_details["full_path"])[-1]
+        if "full_path" in domain_details
+        else domain_details["filename"]
+    )
+
+
 def serialize_rule(rule: dict) -> dict:
     """
     Converts rule "conditions" to dict.


### PR DESCRIPTION
This PR adds fixes for skipping rules in the certification datasets when running in dask.

Notable changes:
* Get filename from full_path in dataset details when available. This is due to the fact that we operate on parquet files when running on dask datasets. These files are not stored in the same location as the original files. This was causing many errors.
* Fixes to the base_operation and `record_count` operation

Steps to test
- [ ] Run a validation against the certification datasets using both pandas and dask and verify that all rules are run successfully.
```
python core.py validate -s sdtmig -v 3-3 -r CORE-000004 -r CORE-000073 -r CORE-000081 -r CORE-000094 -r CORE-000097 -r CORE-000115 -r CORE-000119 -r CORE-000124 -r CORE-000136 -r CORE-000142 -r CORE-000152 -r CORE-000178 -r CORE-000199 -r CORE-000201 -r CORE-000202 -r CORE-000211 -r CORE-000213 -r CORE-000214 -r CORE-000217 -r CORE-000220 -r CORE-000236 -r CORE-000238 -r CORE-000239 -r CORE-000251 -r CORE-000272 -r CORE-000291 -r CORE-000308 -r CORE-000334 -r CORE-000337 -r CORE-000352 -r CORE-000355 -r CORE-000356 -r CORE-000358 -r CORE-000363 -r CORE-000365 -r CORE-000370 -r CORE-000373 -r CORE-000376 -r CORE-000384 -r CORE-000464 -r CORE-000468 -r CORE-000484 -r CORE-000504 -r CORE-000510 -r CORE-000527 -r CORE-000535 -r CORE-000536 -r CORE-000210 -d xpt
```