### PR TITLE
restore USDM JSON validate

### DIFF
--- a/cdisc_rules_engine/services/data_services/usdm_data_service.py
+++ b/cdisc_rules_engine/services/data_services/usdm_data_service.py
@@ -119,7 +119,7 @@ class USDMDataService(BaseDataService):
             filename=extract_file_name_from_path_string(dataset_name),
             full_path=dataset_name,
             size=0,
-            records=f"{len(dataset)}",
+            records=len(dataset),
         )
 
     @cached_dataset(DatasetTypes.VARIABLES_METADATA.value)

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -137,7 +137,7 @@ def run_validation(args: Validation_args):
         standard=standard,
         standard_version=standard_version,
         library_metadata=library_metadata,
-    ).get_data_service()
+    ).get_data_service(args.dataset_paths)
     large_dataset_validation: bool = (
         data_service.dataset_implementation != PandasDataset
     )

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -285,6 +285,8 @@ def get_datasets(
     data_service: DataServiceInterface, dataset_paths: Iterable[str]
 ) -> List[dict]:
     datasets = []
+    if data_service.standard == "usdm":
+        return data_service.get_datasets()
     for dataset_path in dataset_paths:
         metadata = data_service.get_raw_dataset_metadata(dataset_name=dataset_path)
         datasets.append(

--- a/tests/unit/test_usdm_data.py
+++ b/tests/unit/test_usdm_data.py
@@ -72,7 +72,7 @@ def test_get_raw_dataset_metadata():
     data = data_service.get_raw_dataset_metadata(
         dataset_name=os.path.join(dataset_path, "Code.json")
     )
-    assert data.records == "117"
+    assert data.records == 117
 
 
 def test_validate_rule_single_dataset_check(dataset_rule_greater_than: dict):


### PR DESCRIPTION
this PR makes all changes recommended by @ASL-rmarshall to restore USDM JSON validate functionality

to test, run a CLI validation using a USDM rule/data. 