### PR TITLE
added null filter

### DIFF
--- a/cdisc_rules_engine/services/reporting/base_report.py
+++ b/cdisc_rules_engine/services/reporting/base_report.py
@@ -123,24 +123,32 @@ class BaseReport(ABC):
                         "row": error.get("row", ""),
                         "SEQ": error.get("SEQ", ""),
                     }
-
+                    values = [
+                        str(error.get("value", {}).get(variable))
+                        for variable in variables
+                    ]
+                    processed_values = self.process_values(", ".join(values))
                     if self._item_type == "list":
                         error_item["variables"] = ", ".join(variables)
-                        error_item["values"] = ", ".join(
-                            [
-                                str(error.get("value", {}).get(variable))
-                                for variable in variables
-                            ]
-                        )
-                        errors = errors + [[*error_item.values()]]
+                        error_item["values"] = processed_values
+                        errors.append(list(error_item.values()))
                     elif self._item_type == "dict":
                         error_item["variables"] = variables
-                        error_item["values"] = [
-                            str(error.get("value", {}).get(variable))
-                            for variable in variables
-                        ]
-                        errors = errors + [error_item]
+                        error_item["values"] = processed_values
+                        errors.append(error_item)
         return errors
+
+    def process_values(self, values: str) -> str:
+        if values is None or values == "":
+            return "null"
+        processed_values = []
+        for value in values.split(","):
+            value = value.strip()
+            if value == "" or value.lower() == "none":
+                processed_values.append("null")
+            else:
+                processed_values.append(value)
+        return ", ".join(processed_values)
 
     def get_rules_report_data(self) -> List[List]:
         """

--- a/cdisc_rules_engine/services/reporting/base_report.py
+++ b/cdisc_rules_engine/services/reporting/base_report.py
@@ -75,11 +75,11 @@ class BaseReport(ABC):
             else (x["dataset"], x["core_id"]),
         )
 
-    def get_detailed_data(self) -> List[List]:
+    def get_detailed_data(self, excel=False) -> List[List]:
         detailed_data = []
         for validation_result in self._results:
             detailed_data = detailed_data + self._generate_error_details(
-                validation_result
+                validation_result, excel
             )
         return sorted(
             detailed_data,
@@ -89,7 +89,7 @@ class BaseReport(ABC):
         )
 
     def _generate_error_details(
-        self, validation_result: RuleValidationResult
+        self, validation_result: RuleValidationResult, excel
     ) -> List[List]:
         """
         Generates the Issue details data that goes into the excel export.
@@ -127,7 +127,7 @@ class BaseReport(ABC):
                         str(error.get("value", {}).get(variable))
                         for variable in variables
                     ]
-                    processed_values = self.process_values(", ".join(values))
+                    processed_values = self.process_values(values, excel)
                     if self._item_type == "list":
                         error_item["variables"] = ", ".join(variables)
                         error_item["values"] = processed_values
@@ -138,17 +138,17 @@ class BaseReport(ABC):
                         errors.append(error_item)
         return errors
 
-    def process_values(self, values: str) -> str:
-        if values is None or values == "":
-            return "null"
+    def process_values(self, values: List[str], excel: bool) -> Union[str, List[str]]:
+        if not values or values is None:
+            return "null" if excel else ["null"]
         processed_values = []
-        for value in values.split(","):
+        for value in values:
             value = value.strip()
             if value == "" or value.lower() == "none":
                 processed_values.append("null")
             else:
                 processed_values.append(value)
-        return ", ".join(processed_values)
+        return ", ".join(processed_values) if excel else processed_values
 
     def get_rules_report_data(self) -> List[List]:
         """

--- a/cdisc_rules_engine/services/reporting/excel_report.py
+++ b/cdisc_rules_engine/services/reporting/excel_report.py
@@ -48,7 +48,7 @@ class ExcelReport(BaseReport):
     ) -> Workbook:
         wb = excel_open_workbook(self._template.read())
         summary_data = self.get_summary_data()
-        detailed_data = self.get_detailed_data()
+        detailed_data = self.get_detailed_data(excel=True)
         rules_report_data = self.get_rules_report_data()
         excel_update_worksheet(wb["Issue Summary"], summary_data, dict(wrap_text=True))
         excel_update_worksheet(wb["Issue Details"], detailed_data, dict(wrap_text=True))

--- a/tests/unit/test_services/test_reporting/test_excel_export.py
+++ b/tests/unit/test_services/test_reporting/test_excel_export.py
@@ -174,12 +174,12 @@ def test_get_rules_report_data():
             assert report_data[i] == expected_reports[i]
 
 
-def test_get_detailed_data():
+def test_get_detailed_data(excel=True):
     with open(test_report_template, "rb") as f:
         report: ExcelReport = ExcelReport(
             [], "test", mock_validation_results, 10.1, MagicMock(), f
         )
-        detailed_data = report.get_detailed_data()
+        detailed_data = report.get_detailed_data(excel=True)
         errors = [
             [
                 mock_validation_results[0].id,


### PR DESCRIPTION
added a filter that processes errors before the report to replace blanks and None with null.
to test: you can run the certification datasets from Nick.  Here is an example of the before and after.  It also does this for json output.
[CORE-Report-2024-10-10T12-28-09.xlsx](https://github.com/user-attachments/files/17332605/CORE-Report-2024-10-10T12-28-09.xlsx)
[CORE-Report-2024-10-10T13-35-03.xlsx](https://github.com/user-attachments/files/17332606/CORE-Report-2024-10-10T13-35-03.xlsx)
