### PR TITLE
bug: fixed NaN issue with unique set

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -877,9 +877,10 @@ class DataframeType(BaseType):
             if target_name in self.value.columns:
                 target_names.append(target_name)
         target_names = list(set(target_names))
-        counts = (
-            self.value[target_names].groupby(target_names)[target].transform("size")
-        )
+        df_group = self.value[target_names].copy()
+        df_group = df_group.fillna("_NaN_")
+        group_sizes = df_group.groupby(target_names).size()
+        counts = df_group.apply(tuple, axis=1).map(group_sizes)
         results = np.where(counts <= 1, True, False)
         return self.value.convert_to_series(results)
 


### PR DESCRIPTION
In pandas, NaN values are not considered equal to each other in groupby operations. This means that two rows with NaN in the same column would be considered different groups.  This was causing all the rows with NaN to be sorted into their own groups and be labeled as true for is_unique_set.  This PR creates a copy of the target names, goes through and changed the values NaN to a string "_NaN_" then does the size calculation.  This allows rows with NaN to be correctly grouped and sized.

to test: run CG0562 using the data @apalmercdisc put in the zenhub ticket.  It would also be worth checking another is_unique_set or is_not_unique_set rule to ensure functionality is preserved.  I ran on SEND163 and the result matches the QC result
pos:
[CORE-Report-2024-10-21T14-38-55.xlsx](https://github.com/user-attachments/files/17465652/CORE-Report-2024-10-21T14-38-55.xlsx)
neg:
[CORE-Report-2024-10-21T14-39-17.xlsx](https://github.com/user-attachments/files/17465653/CORE-Report-2024-10-21T14-39-17.xlsx)
