### PR TITLE
added Domain to prefix check

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -259,7 +259,10 @@ class DataframeType(BaseType):
             if not value_is_literal
             else other_value.get("comparator")
         )
-        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        if comparator == "DOMAIN":
+            comparison_data = self.column_prefix_map["--"]
+        else:
+            comparison_data = self.get_comparator_data(comparator, value_is_literal)
         prefix: int = self.replace_prefix(other_value.get("prefix"))
         return self._check_equality_of_string_part(
             target, comparison_data, "prefix", prefix


### PR DESCRIPTION
The issue stems from domain not being part of dataset metadata but needing to do a dataset name check with the domain.  the check operators not having access to self.params.domain but they do have access to the column_prefix which is set previously in execute_rule() in RulesEngine line 351.  I simply added a filter to grab this prefix, when DOMAIN is specified, which is equal to the domain, thus allowing the check to be performed as desired.

to test: run the rule with the test data