### PR TITLE
added filters for blank IDVAR/IDVARVAL

### DIFF
--- a/cdisc_rules_engine/utilities/data_processor.py
+++ b/cdisc_rules_engine/utilities/data_processor.py
@@ -216,6 +216,11 @@ class DataProcessor:
             where dataset["ECSEQ"] is equal to 100 or 101
             AND dataset["ECNUM"] is equal to 105.
         """
+        if (
+            other_dataset[column_with_names].str.strip().eq("").all()
+            and other_dataset[column_with_values].str.strip().eq("").all()
+        ):
+            return dataset
         grouped = other_dataset.groupby(column_with_names, group_keys=False)
 
         def filter_dataset_by_group_values(group) -> DatasetInterface:
@@ -248,6 +253,17 @@ class DataProcessor:
         """
         # right dataset holds column names of left dataset.
         # all values in the column are the same
+        if (
+            right_dataset[column_with_names].str.strip().eq("").all()
+            and right_dataset[column_with_values].str.strip().eq("").all()
+        ):
+            return left_dataset.merge(
+                other=right_dataset.data,
+                left_on=left_dataset_match_keys,
+                right_on=right_dataset_match_keys,
+                how="outer",
+                suffixes=("", f".{right_dataset_domain_name}"),
+            )
         left_ds_col_name: str = right_dataset[column_with_names][0]
 
         # convert numeric columns to one data type to avoid merging errors


### PR DESCRIPTION
for this rule check, engine tries to merge on IDVAR/IDVARVAL (in addition to keys) as the supp dataset name sets off that this is a relationship dataset, regardless of whether or not we use the Is Relationship flag in the match dataset portion of the rule.  The IDVARVAL tries to convert the blank '' idvarval to floats, resulting in the error Els reported.  I added filters to check for blank idvar/idvarval so that supp datasets could still be merged without values in these columns to allow this and other checks to occur.
after making it through the dataset_preprocessor.py, the dataframe looks like: 
[merged.docx](https://github.com/user-attachments/files/17512824/merged.docx)
[Rule_underscores.json](https://github.com/user-attachments/files/17512828/Rule_underscores.json)
[Datasets.json](https://github.com/user-attachments/files/17512829/Datasets.json)
The rule still needs to be drafted further to perform the second portion of its check but it is correctly connecting parent and supp now
