### PR TITLE
removed parquet/dask logic with usdm

### DIFF
--- a/cdisc_rules_engine/services/data_services/data_service_factory.py
+++ b/cdisc_rules_engine/services/data_services/data_service_factory.py
@@ -91,6 +91,7 @@ class DataServiceFactory(FactoryInterface):
         if (
             self.max_dataset_size
             and self.max_dataset_size >= self.dataset_size_threshold
+            and self.data_service_name != "usdm"
         ):
             # Use large dataset class
             logger.info("Using DASK dataset implementation")

--- a/cdisc_rules_engine/services/data_services/usdm_data_service.py
+++ b/cdisc_rules_engine/services/data_services/usdm_data_service.py
@@ -205,10 +205,14 @@ class USDMDataService(BaseDataService):
         return datasets
 
     def to_parquet(self, file_path: str) -> str:
-        json = self._reader_factory.get_service("USDM").from_file(
-            extract_file_name_from_path_string(file_path).split(".")[1].upper()
-        )
-        return self.__get_dataset(json).data.to_parquet(file_path)
+        """
+        Stub implementation to satisfy abstract interface requirements.
+
+        This method exists only to fulfill the abstract method requirement from the parent class.
+        While implemented to prevent TypeError, it is not intended to be called in this class.
+        Other classes implementing this interface make actual use of to_parquet().
+        """
+        raise NotImplementedError("to_parquet is not supported for this class")
 
     def __get_record_data(self, node: dict, parent="") -> dict:
         if type(node) is dict:

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -140,7 +140,7 @@ def run_validation(args: Validation_args):
     )
     datasets = get_datasets(data_service, args.dataset_paths)
     created_files = []
-    if large_dataset_validation:
+    if large_dataset_validation and data_service.standard != "usdm":
         # convert all files to parquet temp files
         engine_logger.warning(
             "Large datasets must use parquet format, converting all datasets to parquet"


### PR DESCRIPTION
this PR implements some filters to prevent USDM datasets from entering Dask/Parquet logic per the discussions in CORE Scrum and with Richard regarding technical hurdles--mainly related to the processing/caching overhead that takes place prior to to_parquet() being invoked and the size of USDM datasets anticipated.

To test--run a USDM validation with DATASET_SIZE_THRESHOLD in .env set to 0 to force daskdataset implementation with logger enabled.