### PR TITLE
fix print statement

### DIFF
--- a/cdisc_rules_engine/services/reporting/base_report.py
+++ b/cdisc_rules_engine/services/reporting/base_report.py
@@ -166,7 +166,6 @@ class BaseReport(ABC):
         """
         rules_report = []
         for validation_result in self._results:
-            print(validation_result)
             rules_item = {
                 "core_id": validation_result.id,
                 "version": "1",

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -184,7 +184,7 @@ def run_validation(args: Validation_args):
             define_xml_path=args.define_xml_path,
             dictionary_versions=dictionary_versions,
         )
-    print(f"Output: {args.output_file}")
+    print(f"Output: {args.output}")
     engine_logger.info("Cleaning up intermediate files")
     for file in created_files:
         engine_logger.info(f"Deleting file {file}")

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -184,7 +184,7 @@ def run_validation(args: Validation_args):
             define_xml_path=args.define_xml_path,
             dictionary_versions=dictionary_versions,
         )
-
+    print(f"Output: {args.output_file}")
     engine_logger.info("Cleaning up intermediate files")
     for file in created_files:
         engine_logger.info(f"Deleting file {file}")


### PR DESCRIPTION
a print statement was merged into main, leading to many <cdisc_rules_engine.models.rule_validation_result.RuleValidationResult object at 0x00000262E2840EB0> being printed with each validation