### PR TITLE
filenames PEP compliant

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==24.3.0
-business-rules-enhanced==1.4.4
+business_rules_enhanced==1.4.5
 cdisc-library-client==0.1.5
 click==8.1.7
 flake8==5.0.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     python_requires=">=3.9",
     install_requires=[
         "pandas>=1.3.5",
-        "business-rules-enhanced==1.4.4",
+        "business_rules_enhanced==1.4.5",
         "python-dotenv==0.20.0",
         "cdisc-library-client==0.1.5",
         "odmlib==0.1.4",


### PR DESCRIPTION
I received an email from PyPI: 
"This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'business-rules-enhanced'.

In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://nam12.safelinks.protection.outlook.com/?url=https%3A%2F%2Fpeps.python.org%2Fpep-0625%2F&data=05%7C02%7Csjohnson%40cdisc.org%7C919c1f3a82d245a2b78208dd08d9e423%7C078244a1de674c9e9088986d7f110a37%7C0%7C0%7C638676454120236455%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=s1iq2xcXUzhttqB2tjTm1bQh%2FaM3Gwo1CC1DuW2x7G8%3D&reserved=0). Any source distributions already uploaded will remain in place as-is and do not need to be updated.

Specifically, your recent upload of 'business-rules-enhanced-1.4.5.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'business_rules_enhanced'.

In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames."

this PR matches the changes to the business rules to comply with PEP naming conventions
