### PR TITLE
updated schema for TIG 1.0

### DIFF
--- a/resources/schema/CORE-base.json
+++ b/resources/schema/CORE-base.json
@@ -119,6 +119,21 @@
       },
       "type": "array"
     },
+    "DomainStructure": {
+      "additionalProperties": false,
+      "properties": {
+        "Exclude": {
+          "$ref": "#/$defs/Domains"
+        },
+        "Include": {
+          "$ref": "#/$defs/Domains"
+        },
+        "include_split_datasets": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "JoinType": {
       "enum": ["inner", "left"],
       "type": "string"
@@ -495,19 +510,13 @@
           "type": "object"
         },
         "Domains": {
-          "additionalProperties": false,
-          "properties": {
-            "Exclude": {
-              "$ref": "#/$defs/Domains"
-            },
-            "Include": {
-              "$ref": "#/$defs/Domains"
-            },
-            "include_split_datasets": {
-              "type": "boolean"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/DomainStructure"
+        },
+        "Dataset or Domain or Item Group": {
+          "$ref": "#/$defs/DomainStructure"
+        },
+        "Use Case": {
+          "type": "string"
         },
         "Entities": {
           "anyOf": [

--- a/resources/schema/Organization_CDISC.json
+++ b/resources/schema/Organization_CDISC.json
@@ -234,6 +234,50 @@
           {
             "properties": {
               "Name": {
+                "const": "TIG"
+              },
+              "References": {
+                "items": {
+                  "properties": {
+                    "Criteria": {
+                      "properties": {
+                        "Type": {
+                          "const": "Success"
+                        }
+                      },
+                      "required": ["Type"],
+                      "type": "object"
+                    },
+                    "Origin": {
+                      "const": "TIG Conformance Rules"
+                    },
+                    "Rule Identifier": {
+                      "properties": {
+                        "Id": {
+                          "pattern": "^TIG\\d{4}$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "Version": {
+                      "enum": ["1.0"]
+                    }
+                  },
+                  "type": "object"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "Version": {
+                "enum": ["1.0"]
+              }
+            },
+            "type": "object"
+          },
+          {
+            "properties": {
+              "Name": {
                 "const": "USDM"
               },
               "References": {


### PR DESCRIPTION
This PR updates the standards and rules schema for the TIG conformance rules per the specs laid out by Els.  I have added the layout of rules she provided me and what these updates are based on
[TIG.authorities(1).xlsx](https://github.com/user-attachments/files/17903802/TIG.authorities.1.xlsx)
