### PR TITLE
Enhancement: Controlled terminology and defineXML

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Run `python core.py validate --help` to see the list of validation options.
   -ct, --controlled-terminology-package TEXT
                                   Controlled terminology package to validate
                                   against, can provide more than one
+                                  NOTE: if a defineXML is provided, if it is version 2.1
+                                  engine will use the CT laid out in the define.  If it is
+                                  version 2.0, -ct is expected to specify the CT package
   -o, --output TEXT               Report output file destination and name. Path will be
                                   relative to the validation execution directory
                                   and should end in the desired output filename

--- a/cdisc_rules_engine/operations/codelist_extensible.py
+++ b/cdisc_rules_engine/operations/codelist_extensible.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
+from cdisc_rules_engine.exceptions.custom_exceptions import MissingDataError
 
 
 class CodelistExtensible(BaseOperation):
@@ -12,6 +13,8 @@ class CodelistExtensible(BaseOperation):
             iter(self.library_metadata._ct_package_metadata.values())
         )
         code_obj = ct_package_data["submission_lookup"].get(codelist, None)
+        if code_obj is None:
+            raise MissingDataError(f"Codelist '{codelist}' not found in metadata")
         codelist_id = code_obj.get("codelist")
         is_extensible = False
         if codelist_id in ct_package_data:

--- a/cdisc_rules_engine/operations/codelist_extensible.py
+++ b/cdisc_rules_engine/operations/codelist_extensible.py
@@ -9,9 +9,13 @@ class CodelistExtensible(BaseOperation):
         Returns a Series containing a boolean indicating if the specified codelist is extensible.
         """
         codelist = self.params.codelist
-        ct_package_data = next(
-            iter(self.library_metadata._ct_package_metadata.values())
-        )
+        ct_packages = self.library_metadata._ct_package_metadata
+        if "define_XML_merged_CT" in ct_packages:
+            ct_package_data = ct_packages["define_XML_merged_CT"]
+        else:
+            ct_package_data = next(
+                (pkg for name, pkg in ct_packages.items() if name != "extensible")
+            )
         code_obj = ct_package_data["submission_lookup"].get(codelist, None)
         if code_obj is None:
             raise MissingDataError(f"Codelist '{codelist}' not found in metadata")

--- a/cdisc_rules_engine/operations/codelist_terms.py
+++ b/cdisc_rules_engine/operations/codelist_terms.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 from cdisc_rules_engine.exceptions.custom_exceptions import MissingDataError
+from cdisc_rules_engine.services import logger
 
 
 class CodelistTerms(BaseOperation):
@@ -17,6 +18,16 @@ class CodelistTerms(BaseOperation):
         codelist_level = self.params.level
         check = self.params.returntype
         codes = []
+        try:
+            ct_package_data = next(
+                iter(self.library_metadata._ct_package_metadata.values())
+            )
+        except (AttributeError) as e:
+            logger.warning(
+                "CT package data is not populated: %s "
+                "-- a valid define.xml file or -ct command is required to execute",
+                e,
+            )
         ct_package_data = next(
             iter(self.library_metadata._ct_package_metadata.values())
         )

--- a/cdisc_rules_engine/operations/codelist_terms.py
+++ b/cdisc_rules_engine/operations/codelist_terms.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
+from cdisc_rules_engine.exceptions.custom_exceptions import MissingDataError
 
 
 class CodelistTerms(BaseOperation):
@@ -12,7 +13,6 @@ class CodelistTerms(BaseOperation):
         using the list from comparator and the codelist map.
         Returns a Series of booleans indicating whether each value is valid.
         """
-        # TODO uses 1st map only; may have multiple specified by defineXML, could merge them to keep current logic
         codelists = self.params.codelists
         codelist_level = self.params.level
         check = self.params.returntype
@@ -20,25 +20,43 @@ class CodelistTerms(BaseOperation):
         ct_package_data = next(
             iter(self.library_metadata._ct_package_metadata.values())
         )
+        submission_lookup = ct_package_data["submission_lookup"]
+        lookup_map = {k.lower(): k for k in submission_lookup.keys()}
         for codelist in codelists:
-            codes.append(ct_package_data["submission_lookup"].get(codelist, []))
+            original_key = lookup_map.get(codelist.lower())
+            if original_key is None:
+                raise MissingDataError(f"Codelist '{codelist}' not found in metadata")
+            code_obj = submission_lookup[original_key]
+            codes.append(code_obj)
         values = []
 
         for code_obj in codes:
-            codelist_id = code_obj.get("codelist")
-            if codelist_id in ct_package_data:
-                codelist_info = ct_package_data[codelist_id]
-                if codelist_level == "codelist":
-                    if code_obj.get("term") == "N/A":
-                        if check == "code":
-                            values.append(codelist_id)
-                        else:
-                            values.append(codelist_info["submissionValue"])
-                elif codelist_level == "term":
-                    terms = codelist_info.get("terms", [])
-                    for term in terms:
-                        if check == "value":
-                            values.append(term["submissionValue"])
-                        else:
-                            values.append(term["conceptId"])
+            values.extend(
+                self._get_codelist_values(
+                    code_obj, ct_package_data, codelist_level, check
+                )
+            )
+        return values
+
+    def _get_codelist_values(
+        self, code_obj: dict, ct_package_data: dict, codelist_level: str, check: str
+    ) -> list:
+        """Extract values from a codelist based on level and check type."""
+        values = []
+        codelist_id = code_obj.get("codelist")
+        if codelist_id in ct_package_data:
+            codelist_info = ct_package_data[codelist_id]
+            if codelist_level == "codelist":
+                if code_obj.get("term") == "N/A":
+                    if check == "code":
+                        values.append(codelist_id)
+                    else:
+                        values.append(codelist_info["submissionValue"])
+            elif codelist_level == "term":
+                terms = codelist_info.get("terms", [])
+                for term in terms:
+                    if check == "value":
+                        values.append(term["submissionValue"])
+                    else:
+                        values.append(term["conceptId"])
         return values

--- a/cdisc_rules_engine/operations/codelist_terms.py
+++ b/cdisc_rules_engine/operations/codelist_terms.py
@@ -19,9 +19,13 @@ class CodelistTerms(BaseOperation):
         check = self.params.returntype
         codes = []
         try:
-            ct_package_data = next(
-                iter(self.library_metadata._ct_package_metadata.values())
-            )
+            ct_packages = self.library_metadata._ct_package_metadata
+            if "define_XML_merged_CT" in ct_packages:
+                ct_package_data = ct_packages["define_XML_merged_CT"]
+            else:
+                ct_package_data = next(
+                    (pkg for name, pkg in ct_packages.items() if name != "extensible")
+                )
         except (AttributeError) as e:
             logger.warning(
                 "CT package data is not populated: %s "

--- a/cdisc_rules_engine/operations/define_xml_extensible_codelists.py
+++ b/cdisc_rules_engine/operations/define_xml_extensible_codelists.py
@@ -13,7 +13,7 @@ class DefineCodelists(BaseOperation):
         Returns a list of codelist values from the define.xml file.
         fxn to be be used when a codelist is extensible to acquire the additional values
         """
-        # get define xml - currently expects fine named define.xml
+        # get define xml - currently expects file named define.xml
         define_contents = self.data_service.get_define_xml_contents(
             dataset_name=os.path.join(self.params.directory_path, DEFINE_XML_FILE_NAME)
         )

--- a/cdisc_rules_engine/operations/define_xml_extensible_codelists.py
+++ b/cdisc_rules_engine/operations/define_xml_extensible_codelists.py
@@ -13,24 +13,9 @@ class DefineCodelists(BaseOperation):
         Returns a list of codelist values from the define.xml file.
         fxn to be be used when a codelist is extensible to acquire the additional values
         """
-        # get define xml - currently expects file named define.xml
         define_contents = self.data_service.get_define_xml_contents(
             dataset_name=os.path.join(self.params.directory_path, DEFINE_XML_FILE_NAME)
         )
         define_reader = DefineXMLReaderFactory.from_file_contents(define_contents)
-        variables_metadata = define_reader.extract_variables_metadata(
-            self.params.domain
-        )
-        variable_metadata = {
-            metadata["define_variable_name"]: metadata.get(
-                self.params.attribute_name, ""
-            )
-            for metadata in variables_metadata
-        }
-        return (
-            variable_metadata.get(
-                self.params.target.replace("--", self.params.domain, 1), ""
-            )
-            if self.params.target
-            else variable_metadata
-        )
+        extensible_codelists = define_reader.get_extensible_codelist_mappings()
+        return extensible_codelists

--- a/cdisc_rules_engine/operations/define_xml_extensible_codelists.py
+++ b/cdisc_rules_engine/operations/define_xml_extensible_codelists.py
@@ -13,6 +13,7 @@ class DefineCodelists(BaseOperation):
         Returns a list of codelist values from the define.xml file.
         fxn to be be used when a codelist is extensible to acquire the additional values
         """
+        # get define xml - currently expects fine named define.xml
         define_contents = self.data_service.get_define_xml_contents(
             dataset_name=os.path.join(self.params.directory_path, DEFINE_XML_FILE_NAME)
         )

--- a/cdisc_rules_engine/operations/define_xml_extensible_codelists.py
+++ b/cdisc_rules_engine/operations/define_xml_extensible_codelists.py
@@ -1,10 +1,11 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
-from cdisc_rules_engine.constants.define_xml_constants import DEFINE_XML_FILE_NAME
-from cdisc_rules_engine.services.define_xml.define_xml_reader_factory import (
-    DefineXMLReaderFactory,
-)
-import os
+
+# from cdisc_rules_engine.constants.define_xml_constants import DEFINE_XML_FILE_NAME
+# from cdisc_rules_engine.services.define_xml.define_xml_reader_factory import (
+#     DefineXMLReaderFactory,
+# )
+# import os
 
 
 class DefineCodelists(BaseOperation):
@@ -13,9 +14,20 @@ class DefineCodelists(BaseOperation):
         Returns a list of codelist values from the define.xml file.
         fxn to be be used when a codelist is extensible to acquire the additional values
         """
-        define_contents = self.data_service.get_define_xml_contents(
-            dataset_name=os.path.join(self.params.directory_path, DEFINE_XML_FILE_NAME)
+        # TODO: extensible is populated, parse and return the list of terms
+        # optional codelist and returntype -- allow for sub val or ccode checks
+        # if self.params.codelists:
+        #     codelists = self.params.codelists
+        # if self.params.returntype:
+        #     check = self.params.returntype
+        ct_package_data = next(
+            iter(self.library_metadata._ct_package_metadata.values())
         )
-        define_reader = DefineXMLReaderFactory.from_file_contents(define_contents)
-        extensible_codelists = define_reader.get_extensible_codelist_mappings()
-        return extensible_codelists
+        return ct_package_data
+
+        # define_contents = self.data_service.get_define_xml_contents(
+        #     dataset_name=os.path.join(self.params.directory_path, DEFINE_XML_FILE_NAME)
+        # )
+        # define_reader = DefineXMLReaderFactory.from_file_contents(define_contents)
+        # extensible_codelists = define_reader.get_extensible_codelist_mappings()
+        # return extensible_codelists

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -89,7 +89,7 @@ class OperationsFactory(FactoryInterface):
         "codelist_extensible": CodelistExtensible,
         "codelist_terms": CodelistTerms,
         "dataset_names": DatasetNames,
-        "define_codelists": DefineCodelists,
+        "define_extensible_codelists": DefineCodelists,
         "distinct": Distinct,
         "dy": DayDataValidator,
         "extract_metadata": ExtractMetadata,

--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -27,6 +27,17 @@ class DefineXMLVersion:
     model_package: str
 
 
+@dataclass
+class StandardsCTMetadata:
+    """Represents metadata about a standard referenced in Define-XML"""
+
+    name: str
+    version: str
+    type: str = None
+    publishing_set: str = None
+    oid: str
+
+
 class BaseDefineXMLReader(ABC):
     """
     This class is responsible for extracting

--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -19,6 +19,7 @@ from cdisc_rules_engine.exceptions.custom_exceptions import (
 from cdisc_rules_engine.models.define import ValueLevelMetadata
 from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.utilities.decorators import cached
+from typing import Dict
 
 
 @dataclass
@@ -29,13 +30,12 @@ class DefineXMLVersion:
 
 @dataclass
 class StandardsCTMetadata:
-    """Represents metadata about a standard referenced in Define-XML"""
-
     name: str
     version: str
+    oid: str
+
     type: str = None
     publishing_set: str = None
-    oid: str
 
 
 class BaseDefineXMLReader(ABC):
@@ -54,6 +54,10 @@ class BaseDefineXMLReader(ABC):
     @staticmethod
     @abstractmethod
     def _meta_data_schema() -> type:
+        pass
+
+    @abstractmethod
+    def get_extensible_codelist_mappings() -> Dict:
         pass
 
     def __init__(

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
@@ -43,7 +43,7 @@ class DefineXMLReader20(BaseDefineXMLReader):
         mappings = {}
         for codelist in metadata.CodeList:
             extended_values = []
-            items = codelist.CodeListItem + codelist.EnumeratedItem
+            items = codelist.CodeListItem
             for item in items:
                 if hasattr(item, "ExtendedValue") and item.ExtendedValue == "Yes":
                     extended_values.append(item.CodedValue)

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
@@ -37,3 +37,6 @@ class DefineXMLReader20(BaseDefineXMLReader):
             # v2.0 does not support is_non_standard. Default to blank
             "define_dataset_is_non_standard": "",
         }
+
+    def get_extensible_codelist_mappings(metadata):
+        return

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
@@ -42,22 +42,18 @@ class DefineXMLReader20(BaseDefineXMLReader):
         metadata = self._odm_loader.MetaDataVersion()
         mappings = {}
         for codelist in metadata.CodeList:
-            codelist_nci = "N/A"
-            if hasattr(codelist, "Alias") and codelist.Alias:
-                codelist_nci = (
-                    codelist.Alias[0].Name if codelist.Alias[0].Name else "N/A"
-                )
-            mappings[codelist.Name] = {
-                "codelist_code": codelist_nci,
-                "term_code": "N/A",
-                "extended_values": [],
-            }
-            for item in codelist.CodeListItem + codelist.EnumeratedItem:
-                if getattr(item, "ExtendedValue", "No") == "Yes":
-                    # Extended values won't have an Alias in 2.0
-                    mappings[item.CodedValue] = {
-                        "codelist_code": codelist_nci,
-                        "term_code": "N/A",
-                        "extended_values": [],  # If needed, can still look up allowed values in ItemDef
-                    }
+            extended_values = []
+            items = codelist.CodeListItem + codelist.EnumeratedItem
+            for item in items:
+                if hasattr(item, "ExtendedValue") and item.ExtendedValue == "Yes":
+                    extended_values.append(item.CodedValue)
+            if (
+                extended_values
+                and hasattr(codelist, "Alias")
+                and codelist.Alias is not None
+            ):
+                mappings[codelist.Name] = {
+                    "codelist": codelist.Alias[0].Name,
+                    "extended_values": extended_values,
+                }
         return mappings

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
@@ -38,5 +38,26 @@ class DefineXMLReader20(BaseDefineXMLReader):
             "define_dataset_is_non_standard": "",
         }
 
-    def get_extensible_codelist_mappings(metadata):
-        return
+    def get_extensible_codelist_mappings(self):
+        metadata = self._odm_loader.MetaDataVersion()
+        mappings = {}
+        for codelist in metadata.CodeList:
+            codelist_nci = "N/A"
+            if hasattr(codelist, "Alias") and codelist.Alias:
+                codelist_nci = (
+                    codelist.Alias[0].Name if codelist.Alias[0].Name else "N/A"
+                )
+            mappings[codelist.Name] = {
+                "codelist_code": codelist_nci,
+                "term_code": "N/A",
+                "extended_values": [],
+            }
+            for item in codelist.CodeListItem + codelist.EnumeratedItem:
+                if getattr(item, "ExtendedValue", "No") == "Yes":
+                    # Extended values won't have an Alias in 2.0
+                    mappings[item.CodedValue] = {
+                        "codelist_code": codelist_nci,
+                        "term_code": "N/A",
+                        "extended_values": [],  # If needed, can still look up allowed values in ItemDef
+                    }
+        return mappings

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
@@ -2,9 +2,10 @@ from odmlib.define_2_1.rules.metadata_schema import MetadataSchema
 from cdisc_rules_engine.services.define_xml.base_define_xml_reader import (
     BaseDefineXMLReader,
     DefineXMLVersion,
-    StandardsMetadata,
+    StandardsCTMetadata,
 )
 from typing import List
+from collections import Counter
 
 
 class DefineXMLReader21(BaseDefineXMLReader):
@@ -39,18 +40,156 @@ class DefineXMLReader21(BaseDefineXMLReader):
             "define_dataset_is_non_standard": str(metadata.IsNonStandard or ""),
         }
 
-    def get_ct_standards_metadata(self) -> List[StandardsMetadata]:
+    def get_ct_standards_metadata(self) -> List[StandardsCTMetadata]:
         """Extract standards metadata from Define-XML 2.1"""
         metadata = self._odm_loader.MetaDataVersion()
         standards = []
         for standard in metadata.Standards:
             if standard.Type == "CT":
                 standards.append(
-                    StandardsMetadata(
+                    StandardsCTMetadata(
                         name=standard.Name,
                         version=standard.Version,
                         type=standard.Type,
                         publishing_set=standard.PublishingSet,
+                        oid=standard.OID,
                     )
                 )
-        return standards
+        publishing_set_counts = Counter(
+            standard.PublishingSet
+            for standard in metadata.Standards
+            if standard.Type == "CT"
+        )
+        multiple_sets = {
+            ps: count for ps, count in publishing_set_counts.items() if count > 1
+        }
+        if multiple_sets:
+            map = self.get_multiple_standards_ct_mappings(metadata, standards)
+            return standards, map, True
+        else:
+            return standards, {}, False
+
+    def get_multiple_standards_ct_mappings(self, metadata, standards):
+        combined_CT_package = {"submission_lookup": {}, "no_code": {}}
+        standard_oids = {standard.oid: standard for standard in standards}
+        for codelist in metadata.CodeList:
+            standard_oid = codelist.get("StandardOID", None)
+            standard = standard_oids[standard_oid]
+            standard_key = f"{standard.name.lower()}ct-{standard.version}"
+            if codelist.Alias:
+                codelist_code = codelist.Alias[0].Name
+            codelist_value = codelist.get("Name", None)
+            combined_CT_package["submission_lookup"][codelist_value] = {
+                "codelist": codelist_code,
+                "term": "N/A",
+            }
+            for item in codelist.CodeListItem:
+                nci_code = None
+                if hasattr(item, "Alias"):
+                    for alias in item.Alias:
+                        if hasattr(alias, "Name"):
+                            nci_code = alias.Name
+                            break
+                if nci_code:
+                    combined_CT_package[nci_code] = {
+                        "conceptId": nci_code,
+                        "submissionValue": item.CodedValue,
+                        "extensible": item.ExtendedValue,
+                        "standard": standard_key,
+                    }
+                    combined_CT_package["submission_lookup"][item.CodedValue] = {
+                        "codelist": codelist_code,
+                        "term": nci_code,
+                    }
+                else:
+                    combined_CT_package["no_code"][item.CodedValue] = {
+                        "submissionValue": item.CodedValue,
+                        "extensible": item.ExtendedValue,
+                        "standard": standard_key,
+                        "codelist": codelist_code,
+                        "codelist_value": codelist_value,
+                    }
+        return combined_CT_package
+
+    def get_extensible_codelist_mappings(metadata):  # noqa
+        submission_lookup = {}
+        extended_values = {}
+        for codelist in metadata.CodeList:
+            codelist_nci = "N/A"
+            if hasattr(codelist, "Alias") and codelist.Alias:
+                codelist_nci = (
+                    codelist.Alias[0].Name if codelist.Alias[0].Name else "N/A"
+                )
+            submission_lookup[codelist.Name] = {
+                "codelist_code": codelist_nci,
+                "term_code": "N/A",
+            }
+            # Check for extensible items
+            for item in codelist.CodeListItem + codelist.EnumeratedItem:
+                if item.ExtendedValue == "Yes":
+                    # Get term NCI code
+                    term_nci = "N/A"
+                    if hasattr(item, "Alias") and item.Alias:
+                        term_nci = item.Alias[0].Name if item.Alias[0].Name else "N/A"
+
+                    # Add term to submission lookup
+                    submission_lookup[item.CodedValue] = {
+                        "codelist_code": codelist_nci,
+                        "term_code": term_nci,
+                    }
+
+                    # Find extended values
+                    domain = codelist.OID.split(".")[1]
+                    valuelist = next(
+                        (
+                            vld
+                            for vld in metadata.ValueListDef
+                            if vld.OID == f"VL.SUPP{domain}"
+                        ),
+                        None,
+                    )
+
+                    if valuelist:
+                        for itemref in valuelist.ItemRef:
+                            itemdef = next(
+                                (
+                                    item
+                                    for item in metadata.ItemDef
+                                    if item.OID == itemref.ItemOID
+                                ),
+                                None,
+                            )
+                            if itemdef and hasattr(itemdef, "CodeListRef"):
+                                extended_cl = next(
+                                    (
+                                        cl
+                                        for cl in metadata.CodeList
+                                        if cl.OID == itemdef.CodeListRef.CodeListOID
+                                    ),
+                                    None,
+                                )
+                                if extended_cl:
+                                    ext_values = []
+                                    for ext_item in extended_cl.CodeListItem:
+                                        ext_nci = "N/A"
+                                        if (
+                                            hasattr(ext_item, "Alias")
+                                            and ext_item.Alias
+                                        ):
+                                            ext_nci = (
+                                                ext_item.Alias[0].Name
+                                                if ext_item.Alias[0].Name
+                                                else "N/A"
+                                            )
+                                        ext_values.append(
+                                            {
+                                                "coded_value": ext_item.CodedValue,
+                                                "nci_code": ext_nci,
+                                            }
+                                        )
+                                    extended_values[codelist_nci] = ext_values
+
+        return {
+            "submission_lookup": submission_lookup,
+            "extended_values": extended_values,
+        }

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
@@ -111,7 +111,8 @@ class DefineXMLReader21(BaseDefineXMLReader):
                     }
         return combined_CT_package
 
-    def get_extensible_codelist_mappings(metadata):  # noqa
+    def get_extensible_codelist_mappings(self):  # noqa
+        metadata = self._odm_loader.MetaDataVersion()
         submission_lookup = {}
         extended_values = {}
         for codelist in metadata.CodeList:

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
@@ -2,7 +2,9 @@ from odmlib.define_2_1.rules.metadata_schema import MetadataSchema
 from cdisc_rules_engine.services.define_xml.base_define_xml_reader import (
     BaseDefineXMLReader,
     DefineXMLVersion,
+    StandardsMetadata,
 )
+from typing import List
 
 
 class DefineXMLReader21(BaseDefineXMLReader):
@@ -36,3 +38,19 @@ class DefineXMLReader21(BaseDefineXMLReader):
             "define_dataset_structure": str(metadata.Structure),
             "define_dataset_is_non_standard": str(metadata.IsNonStandard or ""),
         }
+
+    def get_ct_standards_metadata(self) -> List[StandardsMetadata]:
+        """Extract standards metadata from Define-XML 2.1"""
+        metadata = self._odm_loader.MetaDataVersion()
+        standards = []
+        for standard in metadata.Standards:
+            if standard.Type == "CT":
+                standards.append(
+                    StandardsMetadata(
+                        name=standard.Name,
+                        version=standard.Version,
+                        type=standard.Type,
+                        publishing_set=standard.PublishingSet,
+                    )
+                )
+        return standards

--- a/cdisc_rules_engine/services/reporting/excel_report.py
+++ b/cdisc_rules_engine/services/reporting/excel_report.py
@@ -84,7 +84,7 @@ class ExcelReport(BaseReport):
         wb["Conformance Details"]["B7"] = standard.upper()
         wb["Conformance Details"]["B8"] = f"V{version}"
         if cdiscCt:
-            wb["conformance details"]["b9"] = (
+            wb["Conformance Details"]["b9"] = (
                 ", ".join(cdiscCt)
                 if isinstance(cdiscCt, (list, tuple))
                 else str(cdiscCt)

--- a/cdisc_rules_engine/services/reporting/excel_report.py
+++ b/cdisc_rules_engine/services/reporting/excel_report.py
@@ -83,7 +83,14 @@ class ExcelReport(BaseReport):
         # write standards details
         wb["Conformance Details"]["B7"] = standard.upper()
         wb["Conformance Details"]["B8"] = f"V{version}"
-        wb["Conformance Details"]["B9"] = ", ".join(cdiscCt)
+        if cdiscCt:
+            wb["conformance details"]["b9"] = (
+                ", ".join(cdiscCt)
+                if isinstance(cdiscCt, (list, tuple))
+                else str(cdiscCt)
+            )
+        else:
+            wb["conformance details"]["b9"] = ""
         wb["Conformance Details"]["B10"] = define_version
 
         # Populate external dictionary versions

--- a/cdisc_rules_engine/services/reporting/excel_report.py
+++ b/cdisc_rules_engine/services/reporting/excel_report.py
@@ -84,13 +84,13 @@ class ExcelReport(BaseReport):
         wb["Conformance Details"]["B7"] = standard.upper()
         wb["Conformance Details"]["B8"] = f"V{version}"
         if cdiscCt:
-            wb["Conformance Details"]["b9"] = (
+            wb["Conformance Details"]["B9"] = (
                 ", ".join(cdiscCt)
                 if isinstance(cdiscCt, (list, tuple))
                 else str(cdiscCt)
             )
         else:
-            wb["conformance details"]["b9"] = ""
+            wb["Conformance Details"]["B9"] = ""
         wb["Conformance Details"]["B10"] = define_version
 
         # Populate external dictionary versions

--- a/cdisc_rules_engine/services/reporting/excel_report.py
+++ b/cdisc_rules_engine/services/reporting/excel_report.py
@@ -17,6 +17,7 @@ from .excel_writer import (
 )
 from cdisc_rules_engine.utilities.reporting_utilities import (
     get_define_version,
+    get_define_ct,
 )
 from pathlib import Path
 
@@ -111,9 +112,19 @@ class ExcelReport(BaseReport):
                 define_version: str = self._args.define_version or get_define_version(
                     self._args.dataset_paths
                 )
+            controlled_terminology = self._args.controlled_terminology_package
+            if not controlled_terminology and define_version:
+                if define_xml_path and define_version:
+                    controlled_terminology = get_define_ct(
+                        [define_xml_path], define_version
+                    )
+                else:
+                    controlled_terminology = get_define_ct(
+                        self._args.dataset_paths, define_version
+                    )
             report_data = self.get_export(
                 define_version,
-                self._args.controlled_terminology_package,
+                controlled_terminology,
                 self._args.standard,
                 self._args.version.replace("-", "."),
                 dictionary_versions,

--- a/cdisc_rules_engine/services/reporting/json_report.py
+++ b/cdisc_rules_engine/services/reporting/json_report.py
@@ -7,6 +7,7 @@ from cdisc_rules_engine.models.rule_validation_result import RuleValidationResul
 from cdisc_rules_engine.models.validation_args import Validation_args
 from cdisc_rules_engine.utilities.reporting_utilities import (
     get_define_version,
+    get_define_ct,
 )
 from .base_report import BaseReport
 from version import __version__
@@ -106,9 +107,19 @@ class JsonReport(BaseReport):
             define_version: str = self._args.define_version or get_define_version(
                 self._args.dataset_paths
             )
+        controlled_terminology = self._args.controlled_terminology_package
+        if not controlled_terminology and define_version:
+            if define_xml_path and define_version:
+                controlled_terminology = get_define_ct(
+                    [define_xml_path], define_version
+                )
+            else:
+                controlled_terminology = get_define_ct(
+                    self._args.dataset_paths, define_version
+                )
         report_data = self.get_export(
             define_version,
-            list(self._args.controlled_terminology_package),
+            list(controlled_terminology),
             self._args.standard,
             self._args.version.replace("-", "."),
             raw_report=self._args.raw_report,

--- a/cdisc_rules_engine/utilities/reporting_utilities.py
+++ b/cdisc_rules_engine/utilities/reporting_utilities.py
@@ -22,4 +22,27 @@ def get_define_version(dataset_paths: List[str]) -> Optional[str]:
         return None
     path_to_define = os.path.join(path_to_data, DEFINE_XML_FILE_NAME)
     define_xml_reader = DefineXMLReaderFactory.from_filename(path_to_define)
-    return define_xml_reader.get_define_version()
+    version = define_xml_reader.get_define_version()
+    if version == "2.1.0":
+        ct = define_xml_reader.get_ct_version()
+    return version, ct
+
+
+def get_define_ct(dataset_paths: List[str], define_version) -> Optional[str]:
+    """
+    Method used to extract CT version from define xml file located
+    in the same directory with datasets
+    """
+    if not dataset_paths:
+        return None
+    if dataset_paths[0].endswith(".xml") and define_version == "2.1.0":
+        define_xml_reader = DefineXMLReaderFactory.from_filename(dataset_paths[0])
+        return define_xml_reader.get_ct_version()
+    path_to_data = os.path.dirname(dataset_paths[0])
+    if not path_to_data or DEFINE_XML_FILE_NAME not in os.listdir(path_to_data):
+        return None
+    path_to_define = os.path.join(path_to_data, DEFINE_XML_FILE_NAME)
+    define_xml_reader = DefineXMLReaderFactory.from_filename(path_to_define)
+    if define_version == "2.1.0":
+        ct = define_xml_reader.get_ct_version()
+    return ct

--- a/cdisc_rules_engine/utilities/reporting_utilities.py
+++ b/cdisc_rules_engine/utilities/reporting_utilities.py
@@ -23,9 +23,7 @@ def get_define_version(dataset_paths: List[str]) -> Optional[str]:
     path_to_define = os.path.join(path_to_data, DEFINE_XML_FILE_NAME)
     define_xml_reader = DefineXMLReaderFactory.from_filename(path_to_define)
     version = define_xml_reader.get_define_version()
-    if version == "2.1.0":
-        ct = define_xml_reader.get_ct_version()
-    return version, ct
+    return version
 
 
 def get_define_ct(dataset_paths: List[str], define_version) -> Optional[str]:
@@ -35,6 +33,7 @@ def get_define_ct(dataset_paths: List[str], define_version) -> Optional[str]:
     """
     if not dataset_paths:
         return None
+    ct = None
     if dataset_paths[0].endswith(".xml") and define_version == "2.1.0":
         define_xml_reader = DefineXMLReaderFactory.from_filename(dataset_paths[0])
         return define_xml_reader.get_ct_version()

--- a/resources/schema/Operations.json
+++ b/resources/schema/Operations.json
@@ -24,7 +24,7 @@
     {
       "properties": {
         "operator": {
-          "const": "define_codelists"
+          "const": "define_extensible_codelists"
         }
       },
       "required": ["id", "operator", "codelists"],

--- a/resources/schema/Operations.json
+++ b/resources/schema/Operations.json
@@ -24,6 +24,15 @@
     {
       "properties": {
         "operator": {
+          "const": "define_codelists"
+        }
+      },
+      "required": ["id", "operator", "codelists"],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "operator": {
           "const": "define_variable_metadata"
         }
       },

--- a/resources/schema/Operations.md
+++ b/resources/schema/Operations.md
@@ -37,7 +37,7 @@ Returns a list of valid codelist/term values. Used for evaluating whether NCI co
 
 Returns a Series indicating whether a specified `codelist` is extensible. Used in conjunction with `codelist_terms` to determine if values outside the codelist are acceptable. From the above example, `$extensible` will contain a bool if the codelist PKUDUG is extensible in all rows of the column.
 
-## define_codelists
+## define_extensible_codelists
 
 Returns a list of valid extensible codelist term's submission values. Used for evaluating whether submission values are valid based on controlled terminology. Expects the parameter `codelists` which is a list of the codelist submission value(s) to retrieve. If the codelist argument is `["All"]` will return all extensible terms for the CT in a list.
 
@@ -45,7 +45,7 @@ Returns a list of valid extensible codelist term's submission values. Used for e
     {
       "id": "$ext_value",
       "codelist": ["ALL"],
-      "operator": "define_codelists"
+      "operator": "define_extensible_codelists"
     },
 ```
 

--- a/resources/schema/Operations.md
+++ b/resources/schema/Operations.md
@@ -1,6 +1,6 @@
 ## codelist_terms
 
-Returns a list of valid codelist/term values. Used for evaluating whether NCI code or submission values are valid based on controlled terminology. This operator requires the -ct flag to specify the controlled terminology package presently. Expects three parameters: `codelists` which is a list of the codelist submission value(s) to retrieve, `level` which is the level of data (either "codelist" or "term") at which to return data from, and `returntype` which is the type of values to return, either "code" for NCI Code(s) or "value" for submission value(s)
+Returns a list of valid codelist/term values. Used for evaluating whether NCI code or submission values are valid based on controlled terminology. Expects three parameters: `codelists` which is a list of the codelist submission value(s) to retrieve, `level` which is the level of data (either "codelist" or "term") at which to return data from, and `returntype` which is the type of values to return, either "code" for NCI Code(s) or "value" for submission value(s)
 
 ```yaml
 -   "Check": {
@@ -36,6 +36,18 @@ Returns a list of valid codelist/term values. Used for evaluating whether NCI co
 ## codelist_extensible
 
 Returns a Series indicating whether a specified `codelist` is extensible. Used in conjunction with `codelist_terms` to determine if values outside the codelist are acceptable. From the above example, `$extensible` will contain a bool if the codelist PKUDUG is extensible in all rows of the column.
+
+## define_codelists
+
+Returns a list of valid extensible codelist term's submission values. Used for evaluating whether submission values are valid based on controlled terminology. Expects the parameter `codelists` which is a list of the codelist submission value(s) to retrieve. If the codelist argument is `["All"]` will return all extensible terms for the CT in a list.
+
+```yaml
+    {
+      "id": "$ext_value",
+      "codelist": ["ALL"],
+      "operator": "define_codelists"
+    },
+```
 
 ## define_variable_metadata
 

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -94,7 +94,7 @@ def get_library_metadata_from_cache(args) -> LibraryMetadataContainer:  # noqa
             with open(os.path.join(args.cache, file_name), "rb") as f:
                 data = pickle.load(f)
                 ct_package_data[ct_version] = data
-    if define_version.model_package == "define_2_1":
+    if args.define_xml_path and define_version.model_package == "define_2_1":
         (
             standards,
             merged_CT_packages,

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -97,6 +97,7 @@ def get_library_metadata_from_cache(args) -> LibraryMetadataContainer:  # noqa
         (
             standards,
             merged_CT_packages,
+            extensible,
             merged_flag,
         ) = define_xml_reader.get_ct_standards_metadata()
         for standard in standards:
@@ -109,10 +110,13 @@ def get_library_metadata_from_cache(args) -> LibraryMetadataContainer:  # noqa
                     ct_package_data[pickle_filename.split(".")[0]] = data
         if merged_flag:
             ct_package_data["define_XML_merged_CT"] = merged_CT_packages
+            ct_package_data["extensible"] = extensible
+        else:
+            extensible_terms = define_xml_reader.get_extensible_codelist_mappings()
+            ct_package_data["extensible"] = extensible_terms
     if args.define_xml_path:
         extensible_terms = define_xml_reader.get_extensible_codelist_mappings()
         ct_package_data["extensible"] = extensible_terms
-    # TODO: need to update library container to include extensible terms
     return LibraryMetadataContainer(
         standard_metadata=standard_metadata,
         model_metadata=model_details,

--- a/tests/unit/test_operations/test_define_codelists.py
+++ b/tests/unit/test_operations/test_define_codelists.py
@@ -1,0 +1,169 @@
+import pytest
+from unittest.mock import MagicMock
+from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+from cdisc_rules_engine.operations.define_xml_extensible_codelists import (
+    DefineCodelists,
+)
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
+from cdisc_rules_engine.exceptions.custom_exceptions import MissingDataError
+
+
+@pytest.fixture
+def mock_metadata():
+    return {
+        "extensible": {
+            "CODELIST1": {"extended_values": ["EXT1", "EXT2", "EXT3"]},
+            "CODELIST2": {"extended_values": ["EXT4", "EXT5"]},
+        }
+    }
+
+
+@pytest.fixture
+def operation_params():
+    return OperationParams(
+        dataframe=PandasDataset.from_dict({}),
+        dataset_path="test_path",
+        datasets={"TEST": PandasDataset.from_dict({})},
+        domain="TEST",
+        directory_path="test_dir",
+        operation_id="test_op",
+        operation_name="test_operation",
+        standard="SDTM",
+        standard_version="1.0",
+    )
+
+
+def test_single_codelist_values(operation_params, mock_metadata):
+    operation_params.codelists = ["CODELIST1"]
+
+    library_metadata = LibraryMetadataContainer()
+    library_metadata._ct_package_metadata = mock_metadata
+
+    operation = DefineCodelists(
+        operation_params,
+        PandasDataset.from_dict({}),
+        MagicMock(),
+        MagicMock(),
+        library_metadata,
+    )
+
+    result = operation._execute_operation()
+    assert result == ["EXT1", "EXT2", "EXT3"]
+
+
+def test_multiple_codelists_values(operation_params, mock_metadata):
+    operation_params.codelists = ["CODELIST1", "CODELIST2"]
+
+    library_metadata = LibraryMetadataContainer()
+    library_metadata._ct_package_metadata = mock_metadata
+
+    operation = DefineCodelists(
+        operation_params,
+        PandasDataset.from_dict({}),
+        MagicMock(),
+        MagicMock(),
+        library_metadata,
+    )
+
+    result = operation._execute_operation()
+    assert result == ["EXT1", "EXT2", "EXT3", "EXT4", "EXT5"]
+
+
+def test_all_codelists(operation_params, mock_metadata):
+    operation_params.codelists = ["ALL"]
+
+    library_metadata = LibraryMetadataContainer()
+    library_metadata._ct_package_metadata = mock_metadata
+
+    operation = DefineCodelists(
+        operation_params,
+        PandasDataset.from_dict({}),
+        MagicMock(),
+        MagicMock(),
+        library_metadata,
+    )
+
+    result = operation._execute_operation()
+    assert result == ["EXT1", "EXT2", "EXT3", "EXT4", "EXT5"]
+
+
+def test_case_insensitive_codelist_lookup(operation_params, mock_metadata):
+    operation_params.codelists = ["codelist1"]
+
+    library_metadata = LibraryMetadataContainer()
+    library_metadata._ct_package_metadata = mock_metadata
+
+    operation = DefineCodelists(
+        operation_params,
+        PandasDataset.from_dict({}),
+        MagicMock(),
+        MagicMock(),
+        library_metadata,
+    )
+
+    result = operation._execute_operation()
+    assert result == ["EXT1", "EXT2", "EXT3"]
+
+
+def test_missing_codelist(operation_params, mock_metadata):
+    operation_params.codelists = ["NONEXISTENT"]
+
+    library_metadata = LibraryMetadataContainer()
+    library_metadata._ct_package_metadata = mock_metadata
+
+    operation = DefineCodelists(
+        operation_params,
+        PandasDataset.from_dict({}),
+        MagicMock(),
+        MagicMock(),
+        library_metadata,
+    )
+
+    with pytest.raises(
+        MissingDataError, match="Codelist 'NONEXISTENT' not found in metadata"
+    ):
+        operation._execute_operation()
+
+
+def test_missing_codelists_parameter(operation_params, mock_metadata):
+    operation_params.codelists = None
+
+    library_metadata = LibraryMetadataContainer()
+    library_metadata._ct_package_metadata = mock_metadata
+
+    operation = DefineCodelists(
+        operation_params,
+        PandasDataset.from_dict({}),
+        MagicMock(),
+        MagicMock(),
+        library_metadata,
+    )
+
+    with pytest.raises(
+        MissingDataError, match="Codelists operation parameter not provided"
+    ):
+        operation._execute_operation()
+
+
+def test_missing_extensible_metadata(operation_params):
+    operation_params.codelists = ["CODELIST1"]
+
+    library_metadata = LibraryMetadataContainer()
+    library_metadata._ct_package_metadata = {}  # Empty metadata
+
+    operation = DefineCodelists(
+        operation_params,
+        PandasDataset.from_dict({}),
+        MagicMock(),
+        MagicMock(),
+        library_metadata,
+    )
+
+    with pytest.raises(
+        MissingDataError,
+        match="Parsed Extensible terms not found in library CT metadata",
+    ):
+        operation._execute_operation()

--- a/tests/unit/test_services/test_reporting/test_reporting_utilities.py
+++ b/tests/unit/test_services/test_reporting/test_reporting_utilities.py
@@ -10,6 +10,7 @@ path_to_dataset = (
 )
 
 
-def test_get_version_from_define():
+def test_get_version_and_CT_from_define():
     version = get_define_version([path_to_dataset])
-    assert version == "2.1.0"
+    assert version[0] == "2.1.0"
+    assert version[1] == ["sdtmct-2020-12-18"]

--- a/tests/unit/test_services/test_reporting/test_reporting_utilities.py
+++ b/tests/unit/test_services/test_reporting/test_reporting_utilities.py
@@ -10,6 +10,6 @@ path_to_dataset = (
 )
 
 
-def test_get_version_and_CT_from_define():
+def test_get_version_from_define():
     version = get_define_version([path_to_dataset])
     assert version == "2.1.0"

--- a/tests/unit/test_services/test_reporting/test_reporting_utilities.py
+++ b/tests/unit/test_services/test_reporting/test_reporting_utilities.py
@@ -12,5 +12,4 @@ path_to_dataset = (
 
 def test_get_version_and_CT_from_define():
     version = get_define_version([path_to_dataset])
-    assert version[0] == "2.1.0"
-    assert version[1] == ["sdtmct-2020-12-18"]
+    assert version == "2.1.0"


### PR DESCRIPTION
This PR does several things;
- control flow for various inputs using -ct and -dxp.  Engine will now extract the controlled terminology from the defineXML if it is 2.1, otherwise it expects the -ct flag to be used if the define is 2.0
- handle edge case (for SDTM) where multiple CT packages are used in a defineXML and compose and cache a merged CT package for use with the codelist operators to use
- define_extensible_codelists operator which returns the extensible values for a list of codelists
- reporting now gets the controlled terminology from the define if it is 2.1

for testing: this rule triggers the new operator  NOTE: you may need to adjust the logic based on the define you are using as they are all different
[extensible_rule.json](https://github.com/user-attachments/files/17983523/extensible_rule.json)
[Datasets.json](https://github.com/user-attachments/files/17983534/Datasets.json)

these are the different defines to check 2.1/2.0 and 2.1 with multiple CT files:
[Definefiles.zip](https://github.com/user-attachments/files/17983530/Definefiles.zip)

