### PR TITLE
added optional letter in ruleID

### DIFF
--- a/resources/schema/Organization_CDISC.json
+++ b/resources/schema/Organization_CDISC.json
@@ -254,7 +254,7 @@
                     "Rule Identifier": {
                       "properties": {
                         "Id": {
-                          "pattern": "^TIG\\d{4}$",
+                          "pattern": "^TIG\\d{4}[a-z]?$",
                           "type": "string"
                         }
                       },


### PR DESCRIPTION
from an email from Els:  For rule ID a tweak is needed because the TIG v1.0 has a conformance rule with ID TIG0016a and this one doesn't get recognized by the scheme.

this schema update allows for the addition lowerecase letter after the 4 digits
