### PR TITLE
is_consistent_across_study

### DIFF
--- a/cdisc_rules_engine/services/logging/console_logger.py
+++ b/cdisc_rules_engine/services/logging/console_logger.py
@@ -59,7 +59,7 @@ class ConsoleLogger(LoggerInterface):
 
     def trace(self, exc: Exception, msg: str, *args, **kwargs):
         current_level = self._logger.getEffectiveLevel()
-        if current_level > 50:
+        if current_level < 50:
             self.display_trace(exc, inspect.currentframe())
 
     def display_trace(self, e: Exception = None, f=None):

--- a/cdisc_rules_engine/services/logging/console_logger.py
+++ b/cdisc_rules_engine/services/logging/console_logger.py
@@ -59,7 +59,7 @@ class ConsoleLogger(LoggerInterface):
 
     def trace(self, exc: Exception, msg: str, *args, **kwargs):
         current_level = self._logger.getEffectiveLevel()
-        if current_level < 50:
+        if current_level > 50:
             self.display_trace(exc, inspect.currentframe())
 
     def display_trace(self, e: Exception = None, f=None):

--- a/resources/schema/Operator.json
+++ b/resources/schema/Operator.json
@@ -456,6 +456,15 @@
     {
       "properties": {
         "operator": {
+          "const": "is_consistent_across_study"
+        }
+      },
+      "required": ["operator", "value"],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "operator": {
           "const": "is_unique_set"
         }
       },

--- a/resources/schema/Operator.md
+++ b/resources/schema/Operator.md
@@ -698,6 +698,31 @@ Complement of `contains_all`
     - "Unplanned Treatment"
 ```
 
+## is_consistent_across_study
+
+Checks if a variable maintains consistent values within groups defined by one or more grouping variables. Groups records by specified value(s) and validates that the target variable maintains the same value within each unique combination of grouping variables
+
+Single grouping variable:
+
+```yaml
+- name: "BGSTRESU"
+  operator: is_consistent_across_study
+  value: "USUBJID"
+```
+
+Multiple grouping variables:
+
+```yaml
+- name: "--STRESU"
+  operator: is_consistent_across_study
+  value:
+    - "--TESTCD"
+    - "--CAT"
+    - "--SCAT"
+    - "--SPEC"
+    - "--METHOD"
+```
+
 ## is_unique_set
 
 Relationship Integrity Check

--- a/tests/unit/test_check_operators/test_value_set_checks.py
+++ b/tests/unit/test_check_operators/test_value_set_checks.py
@@ -121,6 +121,32 @@ def test_is_consistent_across_study(target, comparator, dataset_type, expected_r
 @pytest.mark.parametrize(
     "target, comparator, dataset_type, expected_result",
     [
+        ("BGSTRESU", "USUBJID", DaskDataset, [False, False, True, True]),
+        ("STRESU", "TESTCD", DaskDataset, [True, True, True, False]),
+        ("STRESU", ["TESTCD", "METHOD"], DaskDataset, [False, False, False, False]),
+    ],
+)
+def test_is_consistent_across_study_dask(
+    target, comparator, dataset_type, expected_result
+):
+    data = {
+        "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ2", "SUBJ2"],
+        "BGSTRESU": ["kg", "kg", "g", "mg"],
+        "TESTCD": ["TEST1", "TEST1", "TEST1", "TEST2"],
+        "METHOD": ["M1", "M1", "M2", "M2"],
+        "SPEC": ["S1", "S1", "S1", "S1"],
+        "STRESU": ["mg", "mg", "g", "kg"],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType(
+        {"value": df, "column_prefix_map": {"--": ""}}
+    ).is_consistent_across_study({"target": target, "comparator": comparator})
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
         ("BGSTRESU", "USUBJID", PandasDataset, [False, False, True, True]),
     ],
 )

--- a/tests/unit/test_check_operators/test_value_set_checks.py
+++ b/tests/unit/test_check_operators/test_value_set_checks.py
@@ -92,3 +92,56 @@ def test_is_not_ordered_set(target, comparator, dataset_type, expected_result):
         {"target": target, "comparator": comparator}
     )
     assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        ("BGSTRESU", "USUBJID", PandasDataset, [False, False, True, True]),
+        ("STRESU", "TESTCD", PandasDataset, [True, True, True, False]),
+        ("STRESU", ["TESTCD", "METHOD"], PandasDataset, [False, False, False, False]),
+    ],
+)
+def test_is_consistent_across_study(target, comparator, dataset_type, expected_result):
+    data = {
+        "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ2", "SUBJ2"],
+        "BGSTRESU": ["kg", "kg", "g", "mg"],
+        "TESTCD": ["TEST1", "TEST1", "TEST1", "TEST2"],
+        "METHOD": ["M1", "M1", "M2", "M2"],
+        "SPEC": ["S1", "S1", "S1", "S1"],
+        "STRESU": ["mg", "mg", "g", "kg"],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType(
+        {"value": df, "column_prefix_map": {"--": ""}}
+    ).is_consistent_across_study({"target": target, "comparator": comparator})
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "target, comparator, dataset_type, expected_result",
+    [
+        ("BGSTRESU", "USUBJID", PandasDataset, [False, False, True, True]),
+    ],
+)
+def test_is_consistent_across_study_with_nulls(
+    target, comparator, dataset_type, expected_result
+):
+    data = {
+        "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ2", "SUBJ2"],
+        "BGSTRESU": ["kg", "kg", None, "g"],
+    }
+    df = dataset_type.from_dict(data)
+    result = DataframeType(
+        {"value": df, "column_prefix_map": {"--": ""}}
+    ).is_consistent_across_study({"target": target, "comparator": comparator})
+    assert result.equals(df.convert_to_series(expected_result))
+
+
+def test_is_consistent_across_study_empty_dataset():
+    data = {"USUBJID": [], "BGSTRESU": []}
+    df = PandasDataset.from_dict(data)
+    result = DataframeType(
+        {"value": df, "column_prefix_map": {"--": ""}}
+    ).is_consistent_across_study({"target": "BGSTRESU", "comparator": "USUBJID"})
+    assert len(result) == 0


### PR DESCRIPTION
this PR adds is_consistent_across_study operator that takes a target and makes sure it is consistent across values

to test:
run test using operator:
[neg.json](https://github.com/user-attachments/files/18085567/neg.json)
[Rule_underscores.json](https://github.com/user-attachments/files/18085569/Rule_underscores.json)
[send pos.xlsx](https://github.com/user-attachments/files/18085570/send.pos.xlsx)
[send neg.xlsx](https://github.com/user-attachments/files/18085572/send.neg.xlsx)
[pos.json](https://github.com/user-attachments/files/18085573/Datasets.json)
