### PR TITLE
updated test, validate commands

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -64,7 +64,7 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
         standard = standards_data.get("product")
         standard_version = standards_data.get("version")
         standard_substandard = None
-        if standard.lower() == "tig":
+        if standard and standard.lower() == "tig":
             standard_substandard = (
                 rule.get("Authorities", [])[0]
                 .get("Standards", [])[0]
@@ -98,6 +98,7 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
             standard_version,
             standard_substandard,
             codelists,
+            rule,
         )
         result = tester.validate(rule)
         result_json = json.dumps(result)

--- a/cdisc_rule_tester/models/rule_tester.py
+++ b/cdisc_rule_tester/models/rule_tester.py
@@ -63,7 +63,7 @@ class RuleTester:
             variable_codelist_map=self.cache.get(variable_codelist_cache_key),
             ct_package_metadata=ct_package_metadata,
         )
-        if not standard and not standard_version:
+        if not standard and not standard_version and rule:
             standard = (
                 rule.get("Authorities")[0].get("Standards")[0].get("Name").lower()
             )

--- a/cdisc_rule_tester/models/rule_tester.py
+++ b/cdisc_rule_tester/models/rule_tester.py
@@ -32,10 +32,10 @@ class RuleTester:
         standard_version: str = "",
         standard_substandard: str = None,
         codelists=[],
+        rule=None,
     ):
         self.datasets = [DummyDataset(dataset_data) for dataset_data in datasets]
         self.cache = cache or InMemoryCacheService()
-
         standard_details_cache_key = get_standard_details_cache_key(
             standard, standard_version, standard_substandard
         )
@@ -63,11 +63,24 @@ class RuleTester:
             variable_codelist_map=self.cache.get(variable_codelist_cache_key),
             ct_package_metadata=ct_package_metadata,
         )
+        if not standard and not standard_version:
+            standard = (
+                rule.get("Authorities")[0].get("Standards")[0].get("Name").lower()
+            )
+            standard_substandard = (
+                rule.get("Authorities")[0].get("Standards")[0].get("Substandard", None)
+            )
+            if standard_substandard is not None:
+                standard_substandard = standard_substandard.lower()
+            standard_version = (
+                rule.get("Authorities")[0].get("Standards")[0].get("Version")
+            )
         self.data_service = DummyDataService.get_instance(
             self.cache,
             ConfigService(),
             standard=standard,
             standard_version=standard_version,
+            standard_substandard=standard_substandard,
             data=self.datasets,
             define_xml=define_xml,
             library_metadata=self.library_metadata,
@@ -77,6 +90,7 @@ class RuleTester:
             self.data_service,
             standard=standard,
             standard_version=standard_version,
+            standard_substandard=standard_substandard,
             library_metadata=self.library_metadata,
         )
         self.engine.rule_processor = RuleProcessor(

--- a/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
@@ -33,6 +33,7 @@ class BaseDatasetBuilder:
         define_xml_path,
         standard,
         standard_version,
+        standard_substandard,
         library_metadata=LibraryMetadataContainer(),
     ):
         self.data_service = data_service
@@ -46,6 +47,7 @@ class BaseDatasetBuilder:
         self.define_xml_path = define_xml_path
         self.standard = standard
         self.standard_version = standard_version
+        self.standard_substandard = standard_substandard
         self.library_metadata = library_metadata
         self.dataset_implementation = self.data_service.dataset_implementation
 

--- a/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
+++ b/cdisc_rules_engine/dataset_builders/dataset_builder_factory.py
@@ -94,6 +94,7 @@ class DatasetBuilderFactory(FactoryInterface):
             kwargs.get("define_xml_path"),
             kwargs.get("standard"),
             kwargs.get("standard_version"),
+            kwargs.get("standard_substandard", None),
             kwargs.get("library_metadata"),
         )
         return builder

--- a/cdisc_rules_engine/models/operation_params.py
+++ b/cdisc_rules_engine/models/operation_params.py
@@ -26,6 +26,7 @@ class OperationParams:
     standard_version: str
 
     # Optional parameters with defaults
+    standard_substandard: str = None
     attribute_name: str = None
     case_sensitive: bool = True
     codelist: str = None

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -44,6 +44,7 @@ from cdisc_rules_engine.dataset_builders import builder_factory
 from cdisc_rules_engine.models.external_dictionaries_container import (
     ExternalDictionariesContainer,
 )
+import traceback
 
 
 class RulesEngine:
@@ -58,6 +59,7 @@ class RulesEngine:
         self.config = config_obj or default_config
         self.standard = kwargs.get("standard")
         self.standard_version = (kwargs.get("standard_version") or "").replace(".", "-")
+        self.standard_substandard = kwargs.get("standard_substandard") or None
         self.library_metadata = kwargs.get("library_metadata")
         self.max_dataset_size = kwargs.get("max_dataset_size")
         self.dataset_paths = kwargs.get("dataset_paths")
@@ -102,6 +104,7 @@ class RulesEngine:
             InMemoryCacheService.get_instance(),
             self.standard,
             self.standard_version,
+            self.standard_substandard,
             self.library_metadata,
         ).get_dummy_data_service(datasets)
         dataset_dicts = []
@@ -193,7 +196,12 @@ class RulesEngine:
             logger.trace(e, __name__)
             logger.error(
                 f"""Error occurred during validation.
-                Error: {e}. Error message: {str(e)}"""
+            Error: {e}
+            Error Type: {type(e)}
+            Error Message: {str(e)}
+            Full traceback:
+            {traceback.format_exc()}
+            """
             )
             error_obj: ValidationErrorContainer = self.handle_validation_exceptions(
                 e, dataset_path, dataset_path
@@ -218,6 +226,7 @@ class RulesEngine:
             define_xml_path=self.define_xml_path,
             standard=self.standard,
             standard_version=self.standard_version,
+            standard_substandard=self.standard_substandard,
             library_metadata=self.library_metadata,
             dataset_implementation=self.data_service.dataset_implementation,
         )
@@ -346,6 +355,7 @@ class RulesEngine:
             dataset_path,
             standard=self.standard,
             standard_version=self.standard_version,
+            standard_substandard=self.standard_substandard,
             external_dictionaries=self.external_dictionaries,
             ct_packages=ct_packages,
         )

--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -98,6 +98,7 @@ class BaseDataService(DataServiceInterface, ABC):
         )
         self.standard = kwargs.get("standard")
         self.version = (kwargs.get("standard_version") or "").replace(".", "-")
+        self.standard_substandard = kwargs.get("standard_substandard")
         self.library_metadata = kwargs.get("library_metadata")
         self.dataset_implementation = kwargs.get(
             "dataset_implementation", PandasDataset
@@ -227,10 +228,11 @@ class BaseDataService(DataServiceInterface, ABC):
         return self._handle_special_cases(dataset, domain, file_path, datasets)
 
     def _get_standard_data(self):
+
         return (
             self.library_metadata.standard_metadata
             or self.cdisc_library_service.get_standard_details(
-                self.standard, self.version
+                self.standard, self.version, self.standard_substandard
             )
         )
 

--- a/cdisc_rules_engine/services/data_services/data_service_factory.py
+++ b/cdisc_rules_engine/services/data_services/data_service_factory.py
@@ -30,6 +30,7 @@ class DataServiceFactory(FactoryInterface):
         cache_service: CacheServiceInterface,
         standard: str = None,
         standard_version: str = None,
+        standard_substandard: str = None,
         library_metadata: LibraryMetadataContainer = None,
         max_dataset_size: int = 0,
     ):
@@ -43,6 +44,7 @@ class DataServiceFactory(FactoryInterface):
         self.cache_service = cache_service
         self.standard = standard
         self.standard_version = standard_version
+        self.standard_substandard = standard_substandard
         self.library_metadata = library_metadata
         self.max_dataset_size = max_dataset_size
         self.dataset_size_threshold = self.config.get_dataset_size_threshold()
@@ -56,6 +58,7 @@ class DataServiceFactory(FactoryInterface):
                 "usdm",
                 standard=self.standard,
                 standard_version=self.standard_version,
+                standard_substandard=self.standard_substandard,
                 library_metadata=self.library_metadata,
                 dataset_path=dataset_paths[0],
                 dataset_implementation=self.get_dataset_implementation(),
@@ -66,6 +69,7 @@ class DataServiceFactory(FactoryInterface):
                 "local",
                 standard=self.standard,
                 standard_version=self.standard_version,
+                standard_substandard=self.standard_substandard,
                 library_metadata=self.library_metadata,
                 dataset_paths=dataset_paths,
                 dataset_implementation=self.get_dataset_implementation(),
@@ -77,6 +81,7 @@ class DataServiceFactory(FactoryInterface):
             data=data,
             standard=self.standard,
             standard_version=self.standard_version,
+            standard_substandard=self.standard_substandard,
             library_metadata=self.library_metadata,
             dataset_implementation=self.get_dataset_implementation(),
         )

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -224,6 +224,7 @@ class RuleProcessor:
         dataset_path: str,
         standard: str,
         standard_version: str,
+        standard_substandard: str,
         external_dictionaries: ExternalDictionariesContainer = ExternalDictionariesContainer(),
         **kwargs,
     ) -> DatasetInterface:
@@ -262,6 +263,7 @@ class RuleProcessor:
                 grouping=operation.get("group", []),
                 standard=standard,
                 standard_version=standard_version,
+                standard_substandard=standard_substandard,
                 external_dictionaries=external_dictionaries,
                 ct_version=operation.get("version"),
                 ct_attribute=operation.get("attribute"),

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -66,6 +66,7 @@ def validate_single_rule(
         cache=cache,
         standard=args.standard,
         standard_version=args.version.replace(".", "-"),
+        standard_substandard=args.substandard,
         external_dictionaries=args.external_dictionaries,
         ct_packages=args.controlled_terminology_package,
         define_xml_path=args.define_xml_path,
@@ -127,12 +128,14 @@ def run_validation(args: Validation_args):
     max_dataset_size = get_max_dataset_size(args.dataset_paths)
     standard = args.standard
     standard_version = args.version.replace(".", "-")
+    standard_substandard = args.substandard
     data_service = DataServiceFactory(
         config,
         shared_cache,
         max_dataset_size=max_dataset_size,
         standard=standard,
         standard_version=standard_version,
+        standard_substandard=standard_substandard,
         library_metadata=library_metadata,
     ).get_data_service(args.dataset_paths)
     large_dataset_validation: bool = (

--- a/scripts/test_rule.py
+++ b/scripts/test_rule.py
@@ -134,7 +134,7 @@ def test(args: TestArgs):
     with open(args.rule, "r", encoding="utf-8") as f:
         rules = [Rule.from_cdisc_metadata(json.load(f))]
     data_service_factory = DataServiceFactory(
-        config, shared_cache, args.standard, args.version, args.standard_substandard
+        config, shared_cache, args.standard, args.version, args.substandard
     )
     data_service = data_service_factory.get_data_service()
     datasets = []

--- a/scripts/test_rule.py
+++ b/scripts/test_rule.py
@@ -63,6 +63,7 @@ def validate_single_rule(
         cache=cache,
         standard=args.standard,
         standard_version=args.version.replace(".", "-"),
+        standard_substandard=args.substandard,
         ct_packages=args.controlled_terminology_package,
         external_dictionaries=args.external_dictionaries,
         define_xml_path=args.define_xml_path,
@@ -133,7 +134,7 @@ def test(args: TestArgs):
     with open(args.rule, "r", encoding="utf-8") as f:
         rules = [Rule.from_cdisc_metadata(json.load(f))]
     data_service_factory = DataServiceFactory(
-        config, shared_cache, args.standard, args.version
+        config, shared_cache, args.standard, args.version, args.standard_substandard
     )
     data_service = data_service_factory.get_data_service()
     datasets = []

--- a/tests/unit/test_dataset_builders/test_ContentMetadataDatasetBuilder.py
+++ b/tests/unit/test_dataset_builders/test_ContentMetadataDatasetBuilder.py
@@ -305,6 +305,7 @@ def test_ContentMetadataDatasetBuilder_split_datasets(conditions):
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        standard_substandard=None,
         library_metadata=LibraryMetadataContainer(),
     ).build_split_datasets("qscg.xpt")
     expected_output2 = {
@@ -332,6 +333,7 @@ def test_ContentMetadataDatasetBuilder_split_datasets(conditions):
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        standard_substandard=None,
         library_metadata=LibraryMetadataContainer(),
     ).build_split_datasets("qspg.xpt")
     assert result.equals(expected)

--- a/tests/unit/test_dataset_builders/test_contents_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_dataset_builder.py
@@ -319,6 +319,7 @@ def test_ContentDatasetBuilder_split_datasets(conditions):
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        standard_substandard=None,
         library_metadata=LibraryMetadataContainer(),
     ).get_dataset()
     assert result.equals(expected)

--- a/tests/unit/test_dataset_builders/test_contents_define_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_dataset_builder.py
@@ -125,6 +125,7 @@ def test_contents_define_dataset_builder(dataset_path, expected):
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        standard_substandard=None,
         library_metadata=LibraryMetadataContainer(),
     )
 

--- a/tests/unit/test_dataset_builders/test_contents_define_variables_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_variables_dataset_builder.py
@@ -107,6 +107,7 @@ def test_contents_define_variables_dataset_builder(
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        standard_substandard=None,
         library_metadata=LibraryMetadataContainer(),
     ).build()
     expected_data = dataset_implementation.from_dict(expected)

--- a/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_contents_define_vlm_dataset_builder.py
@@ -129,6 +129,7 @@ def test_contents_define_vlm_dataset_builder(
         define_xml_path=None,
         standard="sdtmig",
         standard_version="3-4",
+        standard_substandard=None,
         library_metadata=LibraryMetadataContainer(),
     ).build()
     expected_df = dataset_implementation.from_dict(expected)

--- a/tests/unit/test_dataset_builders/test_define_variables_with_library_metadata.py
+++ b/tests/unit/test_dataset_builders/test_define_variables_with_library_metadata.py
@@ -31,6 +31,7 @@ def test_define_variables_metadata_with_library_metadata_dataset_builder(
     cache = InMemoryCacheService()
     standard = "sdtmig"
     standard_version = "3-4"
+    standard_substandard = None
     standard_data = {
         "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
         "classes": [
@@ -92,6 +93,7 @@ def test_define_variables_metadata_with_library_metadata_dataset_builder(
         define_xml_path=test_define_file_path,
         standard=standard,
         standard_version=standard_version,
+        standard_substandard=standard_substandard,
         library_metadata=library_metadata,
     ).build()
 

--- a/tests/unit/test_dataset_builders/test_variables_metadata_with_define_and_library_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_variables_metadata_with_define_and_library_dataset_builder.py
@@ -119,6 +119,7 @@ def test_build_combined_metadata(
         define_xml_path=str(test_define_file_path),
         standard="sdtmig",
         standard_version="3-4",
+        standard_substandard=None,
         library_metadata=library_metadata,
     )
 

--- a/tests/unit/test_dataset_builders/test_variables_metadata_with_library_metadata_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_variables_metadata_with_library_metadata_dataset_builder.py
@@ -43,6 +43,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder(
     cache = InMemoryCacheService()
     standard = "sdtmig"
     standard_version = "3-4"
+    standard_substandard = None
     standard_data = {
         "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
         "classes": [
@@ -104,6 +105,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder(
         define_xml_path=None,
         standard=standard,
         standard_version=standard_version,
+        standard_substandard=standard_substandard,
         library_metadata=library_metadata,
     ).build()
     assert result.columns.tolist() == [
@@ -160,6 +162,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder_variable_only_i
     cache = InMemoryCacheService()
     standard = "sdtmig"
     standard_version = "3-4"
+    standard_substandard = None
     standard_data = {
         "_links": {"model": {"href": "/mdr/sdtm/2-0"}},
         "classes": [
@@ -282,6 +285,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder_variable_only_i
         define_xml_path=None,
         standard=standard,
         standard_version=standard_version,
+        standard_substandard=standard_substandard,
         library_metadata=library_metadata,
     ).build()
     assert set(result.columns.tolist()) == set(

--- a/tests/unit/test_rule_tester/test_rule_tester.py
+++ b/tests/unit/test_rule_tester/test_rule_tester.py
@@ -27,6 +27,30 @@ def test_rule_with_errors(mock_get_dataset_class):
             },
         }
     ]
+    rule_preprocessed = {
+        "core_id": "QC.CDISC.SDTMIG.CG0032",
+        "classes": {"Include": ["ALL"]},
+        "domains": {"Include": ["ALL"]},
+        "rule_type": "Range & Limit",
+        "sensitivity": "Value",
+        "severity": "error",
+        "Authorities": [{"Standards": [{"Name": "SDTMIG", "Version": "3.4"}]}],
+        "conditions": {
+            "all": [
+                {
+                    "name": "get_dataset",
+                    "operator": "less_than",
+                    "value": {"target": "LBSEQ", "comparator": 2},
+                }
+            ]
+        },
+        "actions": [
+            {
+                "name": "generate_dataset_error_objects",
+                "params": {"message": "LBSEQ less than 2"},
+            }
+        ],
+    }
     rule = {
         "core_id": "QC.CDISC.SDTMIG.CG0032",
         "classes": {"Include": ["ALL"]},
@@ -52,7 +76,7 @@ def test_rule_with_errors(mock_get_dataset_class):
         ],
     }
     mock_get_dataset_class.return_value = None
-    tester = RuleTester(datasets)
+    tester = RuleTester(datasets, rule=rule_preprocessed)
     data = tester.validate(rule)
     assert "LB" in data
     assert len(data["LB"]) == 1
@@ -84,6 +108,30 @@ def test_rule_without_errors(mock_get_dataset_class):
             },
         }
     ]
+    rule_preprocessed = {
+        "core_id": "QC.CDISC.SDTMIG.CG0032",
+        "classes": {"Include": ["ALL"]},
+        "domains": {"Include": ["ALL"]},
+        "rule_type": "Range & Limit",
+        "sensitivity": "Value",
+        "severity": "error",
+        "Authorities": [{"Standards": [{"Name": "SDTMIG", "Version": "3.4"}]}],
+        "conditions": {
+            "all": [
+                {
+                    "name": "get_dataset",
+                    "operator": "greater_than",
+                    "value": {"target": "LBSEQ", "comparator": 2},
+                }
+            ]
+        },
+        "actions": [
+            {
+                "name": "generate_dataset_error_objects",
+                "params": {"message": "LBSEQ less than 2"},
+            }
+        ],
+    }
     rule = {
         "core_id": "QC.CDISC.SDTMIG.CG0032",
         "classes": {"Include": ["ALL"]},
@@ -109,7 +157,7 @@ def test_rule_without_errors(mock_get_dataset_class):
         ],
     }
     mock_get_dataset_class.return_value = None
-    tester = RuleTester(datasets)
+    tester = RuleTester(datasets, rule=rule_preprocessed)
     data = tester.validate(rule)
     assert "LB" in data
     assert len(data["LB"]) == 1
@@ -135,6 +183,30 @@ def test_rule_skipped():
             },
         }
     ]
+    rule_preprocessed = {
+        "core_id": "QC.CDISC.SDTMIG.CG0032",
+        "classes": {"Include": ["ALL"]},
+        "domains": {"Include": ["ALL"]},
+        "rule_type": "Range & Limit",
+        "sensitivity": "Value",
+        "severity": "error",
+        "Authorities": [{"Standards": [{"Name": "SDTMIG", "Version": "3.4"}]}],
+        "conditions": {
+            "all": [
+                {
+                    "name": "get_dataset",
+                    "operator": "greater_than",
+                    "value": {"target": "LBSEQ", "comparator": 2},
+                }
+            ]
+        },
+        "actions": [
+            {
+                "name": "generate_dataset_error_objects",
+                "params": {"message": "LBSEQ less than 2"},
+            }
+        ],
+    }
     rule = {
         "core_id": "QC.CDISC.SDTMIG.CG0032",
         "classes": {"Include": ["ALL"]},
@@ -159,7 +231,7 @@ def test_rule_skipped():
             }
         ],
     }
-    tester = RuleTester(datasets)
+    tester = RuleTester(datasets, rule=rule_preprocessed)
     data = tester.validate(rule)
     assert "LB" in data
     assert len(data["LB"]) == 1

--- a/tests/unit/test_utilities/test_rule_processor.py
+++ b/tests/unit/test_utilities/test_rule_processor.py
@@ -431,6 +431,7 @@ def test_perform_rule_operation(mock_data_service, dataset_implementation):
             "test/",
             standard="sdtmig",
             standard_version="3-1-2",
+            standard_substandard=None,
         )
         assert "$avg_aestdy" in result
         assert "$unique_aestdy" in result
@@ -520,6 +521,7 @@ def test_perform_rule_operation_with_grouping(
             "test/",
             standard="sdtmig",
             standard_version="3-1-2",
+            standard_substandard=None,
         )
         assert "$avg_aestdy" in data
         assert data["$avg_aestdy"].values.tolist() == [25, 35, 25, 35]
@@ -630,6 +632,7 @@ def test_perform_rule_operation_with_multi_key_grouping(
             "test/",
             standard="sdtmig",
             standard_version="3-1-2",
+            standard_substandard=None,
         )
         assert "$avg_aestdy" in data
         assert data["$avg_aestdy"].values.tolist() == [25, 35, 25, 35, 30, 112]
@@ -679,6 +682,7 @@ def test_perform_rule_operation_with_null_operations(
         "test/",
         standard="sdtmig",
         standard_version="3-1-2",
+        standard_substandard=None,
     )
     assert df.equals(new_data)
 
@@ -745,6 +749,7 @@ def test_perform_extract_metadata_operation(
         dataset_path="study/data_bundle/suppec.xpt",
         standard="sdtmig",
         standard_version="3-1-2",
+        standard_substandard=None,
     )
 
     # check result


### PR DESCRIPTION
This PR adds TIG support to test, validate commands as well as adding support to editor without the need for the library tab.
It adds substandard for engine, base dataset builder, dataservices in order to accomplish this

to test: 

crosscheck functionality is preserved via:
- run editor locally with engine endpoint--test usdm/tig/sdtm in editor
- test validation and test commands with different standards

test not needing the library tab on excel data for TIG:
- run TIG0006 in editor with the negative test data from sharepoint that is marked with - no library at end