### PR TITLE
business rule version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==24.10.0
-business_rules_enhanced==1.4.5
+business_rules_enhanced==1.4.6
 cdisc-library-client==0.1.6
 click==8.1.7
 flake8==5.0.4

--- a/tests/unit/test_check_operators/test_duration_checks.py
+++ b/tests/unit/test_check_operators/test_duration_checks.py
@@ -59,6 +59,7 @@ def test_invalid_duration_edge_cases():
             "PT1H2M3.4S5M",
             "P4W",
             "P1Y1W",
+            None,
         ]
     }
     df = PandasDataset.from_dict(data)
@@ -79,6 +80,7 @@ def test_invalid_duration_edge_cases():
         True,
         True,
         False,
+        True,
         True,
     ]
     assert result.equals(df.convert_to_series(expected))


### PR DESCRIPTION
incremented version to match updated business rules.

to test these PRs:
take any of the rules from invalid_duration operator DDF0061/DDF0062 and make one of the values being checked into (i.e., NULL, None, NaN, etc.) to test