### PR TITLE
added test_release action

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,0 +1,50 @@
+name: Build Binary
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      name:
+        required: true
+        type: string
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        id: pysetup
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          pip install -r requirements.txt
+      - name: Build Binary
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            pyinstaller core.py --dist ./dist/output/${{ inputs.name }} --hidden-import=pyreadstat._readstat_writer --add-data="$env:pythonLocation\Lib\site-packages\xmlschema\schemas;xmlschema/schemas" --add-data="resources/cache;resources/cache" --add-data="resources/templates;resources/templates" --add-data="resources/schema;resources/schema"
+          else
+            pyinstaller core.py --dist ./dist/output/${{ inputs.name }} --hidden-import=pyreadstat._readstat_writer --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates --add-data=resources/schema:resources/schema
+          fi
+        shell: bash
+      - name: Test Binary
+        run: |
+          cd dist/output/${{ inputs.name }}/core
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            if ./core.exe --help; then echo "test passed"; else echo "test failed"; exit 1; fi
+          else
+            chmod +x core
+            if ./core --help; then echo "test passed"; else echo "test failed"; exit 1; fi
+          fi
+        shell: bash
+      - name: Archive Binary
+        id: archive
+        uses: vimtor/action-zip@v1
+        with:
+          files: dist/output/${{ inputs.name }}/core/
+          dest: ${{ inputs.name }}.zip

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -32,6 +32,11 @@ jobs:
             pyinstaller core.py --dist ./dist/output/${{ inputs.name }} --hidden-import=pyreadstat._readstat_writer --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates --add-data=resources/schema:resources/schema
           fi
         shell: bash
+      - name: Archive Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.name }}
+          path: dist/output/${{ inputs.name }}/core/
       - name: Test Binary
         run: |
           cd dist/output/${{ inputs.name }}/core
@@ -42,9 +47,3 @@ jobs:
             if ./core --help; then echo "test passed"; else echo "test failed"; exit 1; fi
           fi
         shell: bash
-      - name: Archive Binary
-        id: archive
-        uses: vimtor/action-zip@v1
-        with:
-          files: dist/output/${{ inputs.name }}/core/
-          dest: ${{ inputs.name }}.zip

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -1,152 +1,22 @@
-name: Test CORE Rules Engine Release
+name: Test CORE Rules Engine
 
 on:
   workflow_dispatch:
 
 jobs:
-  build-ubuntu-latest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        id: pysetup
-        with:
-          python-version: "3.9"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-          pip install -r requirements.txt
-      - name: Build Binary
-        run: pyinstaller core.py --dist ./dist/output/ubuntu-latest --hidden-import=pyreadstat._readstat_writer --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates --add-data=resources/schema:resources/schema
-      - name: Test Binary
-        run: |
-          cd dist/output/ubuntu-latest/core
-          chmod +x core
-          if ./core --help; then
-            echo "test passed"
-          else
-            echo "test failed"
-            exit 1
-          fi
-      - name: Archive Artifacts
-        uses: vimtor/action-zip@v1
-        with:
-          files: dist/output/ubuntu-latest/core/
-          dest: core-ubuntu-latest.zip
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: core-ubuntu-latest
-          path: core-ubuntu-latest.zip
-
-  build-ubuntu-20-04:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        id: pysetup
-        with:
-          python-version: "3.9"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-          pip install -r requirements.txt
-      - name: Build Binary
-        run: pyinstaller core.py --dist ./dist/output/ubuntu-20-04 --hidden-import=pyreadstat._readstat_writer --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates --add-data=resources/schema:resources/schema
-      - name: Test Binary
-        run: |
-          cd dist/output/ubuntu-20-04/core
-          chmod +x core
-          if ./core --help; then
-            echo "test passed"
-          else
-            echo "test failed"
-            exit 1
-          fi
-      - name: Archive Artifacts
-        uses: vimtor/action-zip@v1
-        with:
-          files: dist/output/ubuntu-20-04/core/
-          dest: core-ubuntu-20-04.zip
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: core-ubuntu-20-04
-          path: core-ubuntu-20-04.zip
-
-  build-mac:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        id: pysetup
-        with:
-          python-version: "3.9"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-          pip install -r requirements.txt
-      - name: Build Binary
-        run: pyinstaller core.py --dist ./dist/output/mac --hidden-import=pyreadstat._readstat_writer --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates --add-data=resources/schema:resources/schema
-      - name: Test Binary
-        run: |
-          cd dist/output/mac/core
-          chmod +x core
-          if ./core --help; then
-            echo "test passed"
-          else
-            echo "test failed"
-            exit 1
-          fi
-      - name: Archive Artifacts
-        uses: vimtor/action-zip@v1
-        with:
-          files: dist/output/mac/core/
-          dest: core-mac.zip
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: core-mac
-          path: core-mac.zip
-
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        id: pysetup
-        with:
-          python-version: "3.9"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-          pip install -r requirements.txt
-      - name: Build Binary
-        run: pyinstaller core.py --dist ./dist/output/windows --hidden-import=pyreadstat._readstat_writer --add-data="$env:pythonLocation\Lib\site-packages\xmlschema\schemas;xmlschema/schemas" --add-data="resources/cache;resources/cache" --add-data="resources/templates;resources/templates" --add-data="resources/schema;resources/schema"
-      - name: Test Binary
-        run: |
-          cd dist/output/windows/core
-          if ./core.exe --help; then
-            echo "test passed"
-          else
-            echo "test failed"
-            exit 1
-          fi
-      - name: Archive Windows Artifacts
-        uses: vimtor/action-zip@v1
-        with:
-          files: dist/output/windows/core/
-          dest: core-windows.zip
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: core-windows
-          path: core-windows.zip
+  build-binaries:
+    strategy:
+      matrix:
+        include:
+          - os: "ubuntu-latest"
+            name: "core-ubuntu-latest"
+          - os: "ubuntu-20.04"
+            name: "core-ubuntu-20-04"
+          - os: "macos-latest"
+            name: "core-mac"
+          - os: "windows-latest"
+            name: "core-windows"
+    uses: ./.github/workflows/build-binary.yml
+    with:
+      os: ${{ matrix.os }}
+      name: ${{ matrix.name }}

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -1,0 +1,152 @@
+name: Test CORE Rules Engine Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-ubuntu-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        id: pysetup
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          pip install -r requirements.txt
+      - name: Build Binary
+        run: pyinstaller core.py --dist ./dist/output/ubuntu-latest --hidden-import=pyreadstat._readstat_writer --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates --add-data=resources/schema:resources/schema
+      - name: Test Binary
+        run: |
+          cd dist/output/ubuntu-latest/core
+          chmod +x core
+          if ./core --help; then
+            echo "test passed"
+          else
+            echo "test failed"
+            exit 1
+          fi
+      - name: Archive Artifacts
+        uses: vimtor/action-zip@v1
+        with:
+          files: dist/output/ubuntu-latest/core/
+          dest: core-ubuntu-latest.zip
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: core-ubuntu-latest
+          path: core-ubuntu-latest.zip
+
+  build-ubuntu-20-04:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        id: pysetup
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          pip install -r requirements.txt
+      - name: Build Binary
+        run: pyinstaller core.py --dist ./dist/output/ubuntu-20-04 --hidden-import=pyreadstat._readstat_writer --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates --add-data=resources/schema:resources/schema
+      - name: Test Binary
+        run: |
+          cd dist/output/ubuntu-20-04/core
+          chmod +x core
+          if ./core --help; then
+            echo "test passed"
+          else
+            echo "test failed"
+            exit 1
+          fi
+      - name: Archive Artifacts
+        uses: vimtor/action-zip@v1
+        with:
+          files: dist/output/ubuntu-20-04/core/
+          dest: core-ubuntu-20-04.zip
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: core-ubuntu-20-04
+          path: core-ubuntu-20-04.zip
+
+  build-mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        id: pysetup
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          pip install -r requirements.txt
+      - name: Build Binary
+        run: pyinstaller core.py --dist ./dist/output/mac --hidden-import=pyreadstat._readstat_writer --add-data=$pythonLocation/lib/python3.9/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates --add-data=resources/schema:resources/schema
+      - name: Test Binary
+        run: |
+          cd dist/output/mac/core
+          chmod +x core
+          if ./core --help; then
+            echo "test passed"
+          else
+            echo "test failed"
+            exit 1
+          fi
+      - name: Archive Artifacts
+        uses: vimtor/action-zip@v1
+        with:
+          files: dist/output/mac/core/
+          dest: core-mac.zip
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: core-mac
+          path: core-mac.zip
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        id: pysetup
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          pip install -r requirements.txt
+      - name: Build Binary
+        run: pyinstaller core.py --dist ./dist/output/windows --hidden-import=pyreadstat._readstat_writer --add-data="$env:pythonLocation\Lib\site-packages\xmlschema\schemas;xmlschema/schemas" --add-data="resources/cache;resources/cache" --add-data="resources/templates;resources/templates" --add-data="resources/schema;resources/schema"
+      - name: Test Binary
+        run: |
+          cd dist/output/windows/core
+          if ./core.exe --help; then
+            echo "test passed"
+          else
+            echo "test failed"
+            exit 1
+          fi
+      - name: Archive Windows Artifacts
+        uses: vimtor/action-zip@v1
+        with:
+          files: dist/output/windows/core/
+          dest: core-windows.zip
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: core-windows
+          path: core-windows.zip


### PR DESCRIPTION
created test workflow for release that will build binary
tests the --help command on the build
make the releases available as downloadable artifacts in the actions tab
won't create actual GitHub releases or deploy to PyPI

this PR also has a potential hotfit ```--hidden-import=pyreadstat._readstat_writer``` for the missing module which we can test once it is merged and manually triggered