### PR TITLE
Logging

### DIFF
--- a/cdisc_rules_engine/exceptions/custom_exceptions.py
+++ b/cdisc_rules_engine/exceptions/custom_exceptions.py
@@ -45,29 +45,36 @@ class VariableMetadataNotFoundError(EngineError):
     )
 
 
-class DomainNotFoundInDefineXMLError(Exception):
+class DomainNotFoundError(EngineError):
+    """Raised when a required domain is not found in the dataset"""
+
+    code = 404
+    description = "Domain Not Found"
+
+
+class DomainNotFoundInDefineXMLError(EngineError):
     code = 400
     description = "Domain is not found in Define XML file"
 
 
-class InvalidDatasetFormat(Exception):
+class InvalidDatasetFormat(EngineError):
     code = 400
     description = "Dataset data is malformed."
 
 
-class NumberOfAttemptsExceeded(Exception):
+class NumberOfAttemptsExceeded(EngineError):
     pass
 
 
-class InvalidDictionaryVariable(Exception):
+class InvalidDictionaryVariable(EngineError):
     description = (
         "Provided dictionary variable does not correspond to a dictionary term type"
     )
 
 
-class UnsupportedDictionaryType(Exception):
+class UnsupportedDictionaryType(EngineError):
     description = "Specified dictionary type is not supported by the rules engine."
 
 
-class FailedSchemaValidation(Exception):
+class FailedSchemaValidation(EngineError):
     description = "Error Occured in Schema Validation"

--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -91,11 +91,28 @@ class BaseOperation:
             logger.debug(f"error in operation {self.params.operation_name}: {str(e)}")
             raise
         except Exception as e:
+            error_message = str(e)
             # Log unexpected errors
             logger.error(
                 f"error in operation {self.params.operation_name}: {str(e)}",
                 exc_info=True,
             )
+            if isinstance(e, TypeError) and any(
+                phrase in error_message
+                for phrase in [
+                    "NoneType",
+                    "None",
+                    "object is None",
+                    "'NoneType'",
+                    "None has no attribute",
+                    "unsupported operand type",
+                    "bad operand type",
+                    "object is not",
+                    "cannot be None",
+                ]
+            ):
+                return None
+            raise
 
     def _handle_operation_result(self, result) -> DatasetInterface:
         if self.evaluation_dataset.is_series(result):

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -14,6 +14,7 @@ from cdisc_rules_engine.exceptions.custom_exceptions import (
     RuleFormatError,
     VariableMetadataNotFoundError,
     FailedSchemaValidation,
+    DomainNotFoundError,
 )
 from cdisc_rules_engine.interfaces import (
     CacheServiceInterface,
@@ -189,21 +190,6 @@ class RulesEngine:
                 logger.info(f"Skipped domain {dataset_domain}.")
                 error_obj: ValidationErrorContainer = ValidationErrorContainer(
                     status=ExecutionStatus.SKIPPED.value
-                )
-                error_obj.domain = dataset_domain
-                return [error_obj.to_representation()]
-        except TypeError as te:
-            if "Domain" in str(te) and "not found in dataset" in str(te):
-                error_obj = ValidationErrorContainer(
-                    dataset=os.path.basename(dataset_path),
-                    error="Domain Not Found",
-                    message=str(te),
-                    status=ExecutionStatus.SKIPPED,
-                )
-                return [error_obj.to_representation()]
-            else:
-                error_obj: ValidationErrorContainer = self.handle_validation_exceptions(
-                    te, dataset_path, dataset_path
                 )
                 error_obj.domain = dataset_domain
                 return [error_obj.to_representation()]
@@ -501,30 +487,20 @@ class RulesEngine:
                     message=message,
                     status=ExecutionStatus.SKIPPED.value,
                 )
-        elif isinstance(exception, KeyError):
-            missing_column = str(exception.args[0]).strip("'")
-            traceback_str = str(exception.__traceback__)
-            is_column_access_error = any(
-                pattern in traceback_str
-                for pattern in [
-                    "NoneType",
-                    "object is None",
-                    "'NoneType'",
-                    "None has no attribute",
-                    "unsupported operand type",
-                    "bad operand type",
-                    "object is not",
-                    "cannot be None",
-                ]
+        elif isinstance(exception, DomainNotFoundError):
+            error_obj = ValidationErrorContainer(
+                dataset=os.path.basename(dataset_path),
+                message=str(exception),
+                status=ExecutionStatus.SKIPPED.value,
             )
-            if is_column_access_error:
-                error_obj = ValidationErrorContainer(
-                    dataset=os.path.basename(dataset_path),
-                    error="Column Not Present",
-                    message=f"Rule evaluation skipped - '{missing_column}' not found in dataset",
-                    status=ExecutionStatus.SKIPPED.value,
-                )
-                message = "rule evaluation skipped"
+            message = "rule evaluation skipped - operation domain not found"
+            errors = [error_obj]
+            return ValidationErrorContainer(
+                dataset=os.path.basename(dataset_path),
+                errors=errors,
+                message=message,
+                status=ExecutionStatus.SKIPPED.value,
+            )
         else:
             error_obj = FailedValidationEntity(
                 dataset=os.path.basename(dataset_path),

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -192,6 +192,21 @@ class RulesEngine:
                 )
                 error_obj.domain = dataset_domain
                 return [error_obj.to_representation()]
+        except TypeError as te:
+            if "Domain" in str(te) and "not found in dataset" in str(te):
+                error_obj = ValidationErrorContainer(
+                    dataset=os.path.basename(dataset_path),
+                    error="Domain Not Found",
+                    message=str(te),
+                    status=ExecutionStatus.SKIPPED,
+                )
+                return [error_obj.to_representation()]
+            else:
+                error_obj: ValidationErrorContainer = self.handle_validation_exceptions(
+                    te, dataset_path, dataset_path
+                )
+                error_obj.domain = dataset_domain
+                return [error_obj.to_representation()]
         except Exception as e:
             logger.trace(e, __name__)
             logger.error(
@@ -503,7 +518,7 @@ class RulesEngine:
                 ]
             )
             if is_column_access_error:
-                error_obj = FailedValidationEntity(
+                error_obj = ValidationErrorContainer(
                     dataset=os.path.basename(dataset_path),
                     error="Column Not Present",
                     message=f"Rule evaluation skipped - '{missing_column}' not found in dataset",

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -332,6 +332,10 @@ class RuleProcessor:
                 operation_params.datasets,
                 lambda item: item.get("domain") == operation_params.domain,
             )
+            if domain_details is None:
+                raise TypeError(
+                    f"Domain {operation_params.domain} not found in dataset"
+                )
             filename = get_dataset_name_from_details(domain_details)
             file_path: str = os.path.join(
                 get_directory_path(operation_params.dataset_path),

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -33,6 +33,7 @@ from cdisc_rules_engine.utilities.utils import (
 from cdisc_rules_engine.models.external_dictionaries_container import (
     ExternalDictionariesContainer,
 )
+from cdisc_rules_engine.exceptions.custom_exceptions import DomainNotFoundError
 
 
 class RuleProcessor:
@@ -333,8 +334,9 @@ class RuleProcessor:
                 lambda item: item.get("domain") == operation_params.domain,
             )
             if domain_details is None:
-                raise TypeError(
-                    f"Domain {operation_params.domain} not found in dataset"
+                raise DomainNotFoundError(
+                    f"Operation {operation_params.operation_name} requires Domain "
+                    f"{operation_params.domain} but Domain not found in dataset"
                 )
             filename = get_dataset_name_from_details(domain_details)
             file_path: str = os.path.join(


### PR DESCRIPTION
This PR fixes issues with errors in operations when a domain is not present.  This should result in a scope skip.  There was logic in the check and aggregate operations when executed to catch these missing variable/dataset issues but the domain check fell outside of this.  I have created a custom error with status skip for when it looks for a domain in the operation and it is not present.

This ticket also brings all custom exceptions in line under the EngineError class for consistency as well eliminating un-needed code in the rule engine exceptions

to test: run editor locally with this branch of engine attach to python functions, test TIG0005 with positive data 2 on sharepoint.  TIG0008/9 also experience this
I ran CG0007 to ensure past skips were preserved