### PR TITLE
removed pyreadstat-test artifact

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -64,13 +64,3 @@ jobs:
             echo "Test validate failed with exit code $exit_code"
           fi
         shell: bash
-      - name: Test pyreadstat
-        run: |
-          cd dist/output/${{ inputs.name }}/core
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            if ./core.exe test-pyreadstat; then echo "test passed"; else echo "test failed"; exit 1; fi
-          else
-            chmod +x core
-            if ./core test-pyreadstat; then echo "test passed"; else echo "test failed"; exit 1; fi
-          fi
-        shell: bash

--- a/core.py
+++ b/core.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import pickle
-import pyreadstat
 import tempfile
 from datetime import datetime
 from multiprocessing import freeze_support
@@ -739,30 +738,11 @@ def list_ct(cache_path: str, subsets: Tuple[str]):
 
 
 @click.command()
-def test_pyreadstat():
-    """**Release Test** for pyreadstat module."""
-    try:
-        import pandas as pd
-
-        df = pd.DataFrame([[1, 2], [3, 4]], columns=["var1", "var2"])
-        temp_path = tempfile.mktemp(suffix=".sav")
-        pyreadstat.write_sav(df, temp_path)
-        df, meta = pyreadstat.read_sav(temp_path)
-        os.unlink(temp_path)
-        print("PyReadstat test passed successfully!")
-        return 0
-    except Exception as e:
-        print(f"PyReadstat test failed: {str(e)}")
-        return 1
-
-
-@click.command()
 def test_validate():
     """**Release Test** validate command for executable."""
     try:
         import sys
         import os
-        import tempfile
         from cdisc_rules_engine.models.validation_args import Validation_args
         from cdisc_rules_engine.models.external_dictionaries_container import (
             ExternalDictionariesContainer,
@@ -862,7 +842,6 @@ def test_validate():
 
 
 cli.add_command(test_validate)
-cli.add_command(test_pyreadstat)
 cli.add_command(validate)
 cli.add_command(update_cache)
 cli.add_command(list_rules)

--- a/resources/schema/Rule_Type.md
+++ b/resources/schema/Rule_Type.md
@@ -349,6 +349,7 @@ Attach define xml metadata at variable level
 - `define_variable_has_comment`
 - `library_variable_name`
 - `library_variable_role`
+- `library_both_variable_role`
 - `library_variable_label`
 - `library_variable_core`
 - `library_variable_order_number`

--- a/resources/schema/Rule_Type.md
+++ b/resources/schema/Rule_Type.md
@@ -349,7 +349,6 @@ Attach define xml metadata at variable level
 - `define_variable_has_comment`
 - `library_variable_name`
 - `library_variable_role`
-- `library_both_variable_role`
 - `library_variable_label`
 - `library_variable_core`
 - `library_variable_order_number`


### PR DESCRIPTION
this was an artifact that I meant to remove.  pyreadstat is used within the XPTreader module so if the XPT validation within the test_validate runs, the pyreadstat module works appropriately.  It was determined this was a good enough test of its functionality and a unittest was unnecessary and clogs up our core.py file.  
this is the test build run without this test to show it has been removed with no impact to release creation:  https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/12871561191