### PR TITLE
Bypass InMemoryCacheService

### DIFF
--- a/core.py
+++ b/core.py
@@ -391,39 +391,17 @@ def update_cache(
     cache_populator = CachePopulator(
         cache, library_service, local_rules, local_rules_id, remove_rules, cache_path
     )
-    cache = asyncio.run(cache_populator.load_cache_data())
     if remove_rules:
-        cache_populator.save_removed_rules_locally(
-            os.path.join(cache_path, DefaultFilePaths.LOCAL_RULES_CACHE_FILE.value),
-            remove_rules,
-        )
+        cache_populator.save_removed_rules_locally()
         print("Local rules removed from cache")
     elif local_rules and local_rules_id:
-        cache_populator.save_local_rules_locally(
-            os.path.join(cache_path, DefaultFilePaths.LOCAL_RULES_CACHE_FILE.value),
-            local_rules_id,
-        )
+        cache_populator.save_local_rules_locally()
         print("Local rules saved to cache")
+    elif not local_rules and not remove_rules:
+        asyncio.run(cache_populator.update_cache())
     else:
-        cache_populator.save_rules_locally(
-            os.path.join(cache_path, DefaultFilePaths.RULES_CACHE_FILE.value)
-        )
-        cache_populator.save_ct_packages_locally(f"{cache_path}")
-        cache_populator.save_standards_metadata_locally(
-            os.path.join(cache_path, DefaultFilePaths.STANDARD_DETAILS_CACHE_FILE.value)
-        )
-        cache_populator.save_standards_models_locally(
-            os.path.join(cache_path, DefaultFilePaths.STANDARD_MODELS_CACHE_FILE.value)
-        )
-        cache_populator.save_variable_codelist_maps_locally(
-            os.path.join(
-                cache_path, DefaultFilePaths.VARIABLE_CODELIST_CACHE_FILE.value
-            )
-        )
-        cache_populator.save_variables_metadata_locally(
-            os.path.join(
-                cache_path, DefaultFilePaths.VARIABLE_METADATA_CACHE_FILE.value
-            )
+        raise ValueError(
+            "Must Specify either local_rules_path and local_rules_id, remove_local_rules, or neither"
         )
     print("Cache updated successfully")
 

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -1,6 +1,7 @@
 import json
 import yaml
 
+from cdisc_rules_engine.enums.default_file_paths import DefaultFilePaths
 from cdisc_rules_engine.interfaces import CacheServiceInterface
 from cdisc_rules_engine.models.dictionaries.dictionary_types import DictionaryTypes
 from cdisc_rules_engine.interfaces.data_service_interface import DataServiceInterface
@@ -173,9 +174,9 @@ def get_rules(args) -> List[dict]:
 
 def rule_cache_file(args) -> str:
     if args.local_rules_cache:
-        return os.path.join(args.cache, "local_rules.pkl")
+        return os.path.join(args.cache, DefaultFilePaths.LOCAL_RULES_CACHE_FILE.value)
     else:
-        return os.path.join(args.cache, "rules.pkl")
+        return os.path.join(args.cache, DefaultFilePaths.RULES_CACHE_FILE.value)
 
 
 def load_rules_from_cache(args) -> List[dict]:


### PR DESCRIPTION
This update has the `update-cache` command bypass the inmemorycache. See the connected issue for the reasons.

To test, simply run the `update-cache` command and then run a validation. The update-cache command should take significantly less time than main. The resulting cache files should be the same size (and in most cases where ordering is preserved, the same content). The exception would be the rules cache which has updated rules files.