### PR TITLE
Update dummy_data_service.py

### DIFF
--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -83,7 +83,7 @@ class DummyDataService(BaseDataService):
             filename=dataset_metadata["filename"][0],
             file_size=dataset_metadata["dataset_size"][0],
             full_path=dataset_metadata["filename"][0],
-            record_count=dataset_metadata["length"][0],
+            record_count=dataset_metadata["record_count"][0],
         )
 
     def get_variables_metadata(self, dataset_name: str, **params) -> PandasDataset:


### PR DESCRIPTION
I noticed this issue while working on another one.

when dummy_data_service has get_raw_dataset_metadata invoked,  it will call __get_dataset_metadata which looks like
```
   def __get_dataset_metadata(self, dataset_name: str, **kwargs) -> dict:
        dataset: Optional[DummyDataset] = self.get_dataset_data(dataset_name)
        metadata_to_return = {}
        if dataset:
            metadata_to_return: dict = dataset.get_metadata()
        return metadata_to_return
```
the metadata that is returned by this function is defined by dataset.get_metadata()
```
    def get_metadata(self):
        return {
            "dataset_size": [self.file_size or 1000],
            "dataset_name": [self.name or "test"],
            "dataset_label": [self.label or "test"],
            "filename": [self.filename],
            "record_count": [self.record_count],
        }
```
presently there is no "length" attribute to this metadata but there was prior to the recent large PR: [here](https://github.com/cdisc-org/cdisc-rules-engine/commit/0c42b2830f93aa2482a37f93360855d8a840fed0#diff-6baad80e463f2091069c9bc70c4a5b890e7a4e78740d9612d3e69f7895556d8fL29)  I changed this to reflect the current codebase.