### PR TITLE
Schema and docs update for is_unique_set supporting CG0019

### DIFF
--- a/resources/schema/Operator.json
+++ b/resources/schema/Operator.json
@@ -405,7 +405,7 @@
           "const": "is_not_unique_set"
         }
       },
-      "required": ["operator", "value"],
+      "required": ["operator"],
       "type": "object"
     },
     {
@@ -468,7 +468,7 @@
           "const": "is_unique_set"
         }
       },
-      "required": ["operator", "value"],
+      "required": ["operator"],
       "type": "object"
     },
     {

--- a/resources/schema/Operator.md
+++ b/resources/schema/Operator.md
@@ -727,6 +727,8 @@ Multiple grouping variables:
 
 Relationship Integrity Check
 
+`name` can be a variable containing a list of columns and `value` does not need to be present
+
 > --SEQ is unique within DOMAIN, USUBJID, and --TESTCD
 
 ```yaml
@@ -741,6 +743,8 @@ Relationship Integrity Check
 ## is_not_unique_set
 
 Complement of `is_unique_set`
+
+`name` can be a variable containing a list of columns and `value` does not need to be present
 
 > --SEQ is not unique within DOMAIN, USUBJID, and --TESTCD
 


### PR DESCRIPTION
`is_unique_set`
`name` can be a variable containing a list of columns and `value` does not need to be present