### PR TITLE
removed xml code

### DIFF
--- a/cdisc_rules_engine/services/reporting/excel_report.py
+++ b/cdisc_rules_engine/services/reporting/excel_report.py
@@ -120,9 +120,7 @@ class ExcelReport(BaseReport):
             if define_xml_path:
                 define_version = get_define_version([define_xml_path])
             else:
-                define_version: str = self._args.define_version or get_define_version(
-                    self._args.dataset_paths
-                )
+                define_version: str = self._args.define_version
             controlled_terminology = self._args.controlled_terminology_package
             if not controlled_terminology and define_version:
                 if define_xml_path and define_version:


### PR DESCRIPTION
This PR removes the logic that would go into the specified directory and look for a .xml file and assign that to the report, even if that define.xml was not specified in the validation.  Now unless the define_path or define_version are specified, no define_version will show up in report.