### PR TITLE
fix for expanding list of columns when column doesn't exist

### DIFF
--- a/cdisc_rules_engine/models/actions.py
+++ b/cdisc_rules_engine/models/actions.py
@@ -71,11 +71,12 @@ class COREActions(BaseActions):
     def _get_target_names_from_list_values(self, target_names, rows_with_error):
         expanded_target_names = set(target_names)
         for target in target_names:
-            for candidate_list in rows_with_error[target]:
-                if isinstance(candidate_list, list):
-                    for value in candidate_list:
-                        if value in self.variable.dataset.columns:
-                            expanded_target_names.add(value)
+            if target in rows_with_error:
+                for candidate_list in rows_with_error[target]:
+                    if isinstance(candidate_list, list):
+                        for value in candidate_list:
+                            if value in self.variable.dataset.columns:
+                                expanded_target_names.add(value)
         return expanded_target_names
 
     def generate_targeted_error_object(


### PR DESCRIPTION
Minor fix for reporting bug with missing variables.

See the attached ticket for test data. I tested with 78 and 98 and got the following results.
[DDF00098 - neg01 result.json.txt](https://github.com/user-attachments/files/19236791/DDF00098.-.neg01.result.json.txt)
[DDF00078 - neg01 result.json.txt](https://github.com/user-attachments/files/19236792/DDF00078.-.neg01.result.json.txt)

Note that the 98 results don't exactly match the original results, but I'm not sure if the original results were correct.