### PR TITLE
restore substandard

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -63,7 +63,7 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:  # 
         standards_data = json_data.get("standard", {})
         standard = standards_data.get("product")
         standard_version = standards_data.get("version")
-        standard_substandard = None
+        standard_substandard = standards_data.get("substandard")
         codelists = json_data.get("codelists", [])
         cache = InMemoryCacheService()
         if standards_data or codelists:


### PR DESCRIPTION
restores deleted logic--this gets substandard for library tab.  test tig0016a (read description of rule as there are 2, look for part B) and test against Part B negative data