### PR TITLE
update error logic

### DIFF
--- a/cdisc_rules_engine/models/actions.py
+++ b/cdisc_rules_engine/models/actions.py
@@ -206,6 +206,11 @@ class COREActions(BaseActions):
         )
         source_row_number: Optional[pd.Series] = data.get(SOURCE_ROW_NUMBER)
         source_filename: Optional[pd.Series] = data.get(SOURCE_FILENAME)
+        row_dict = df_row.to_dict()
+        filtered_dict = {
+            key: ("null" if pd.isna(value) else value)
+            for key, value in row_dict.items()
+        }
         error_object = ValidationErrorEntity(
             dataset=(
                 path.basename(source_filename[df_row.name])
@@ -217,7 +222,7 @@ class COREActions(BaseActions):
                 if isinstance(source_row_number, pd.Series)
                 else (int(df_row.name) + 1)
             ),  # record number should start at 1, not 0
-            value=dict(df_row.to_dict()),
+            value=filtered_dict,
             usubjid=(
                 str(usubjid[df_row.name]) if isinstance(usubjid, pd.Series) else None
             ),

--- a/tests/unit/test_rules_engine.py
+++ b/tests/unit/test_rules_engine.py
@@ -2036,13 +2036,13 @@ def test_validate_additional_columns(
                 "message": "Inconsistencies found in enumerated TSVAL columns.",
                 "errors": [
                     {
-                        "value": {"TSVAL": None},
+                        "value": {"TSVAL": "null"},
                         "dataset": "ts.xpt",
                         "row": 2,
                         "USUBJID": "1",
                     },
                     {
-                        "value": {"TSVAL": None},
+                        "value": {"TSVAL": "null"},
                         "dataset": "ts.xpt",
                         "row": 4,
                         "USUBJID": "1",
@@ -2153,17 +2153,17 @@ def test_validate_dataset_contents_against_define_and_library_variable_metadata(
                 {
                     "dataset": "filename",
                     "row": 1,
-                    "value": {"AESEV": None, "AESER": "1"},
+                    "value": {"AESEV": "null", "AESER": "1"},
                 },
                 {
                     "dataset": "filename",
                     "row": 2,
-                    "value": {"AESEV": None, "AESER": "2"},
+                    "value": {"AESEV": "null", "AESER": "2"},
                 },
                 {
                     "dataset": "filename",
                     "row": 3,
-                    "value": {"AESEV": "test", "AESER": None},
+                    "value": {"AESEV": "test", "AESER": "null"},
                 },
             ],
         }


### PR DESCRIPTION
I was unable to reproduce this error with Marcelina's original code but I did find a rule where this issue was occurring.
CG0433 - negative dataset.  

The bug was in our create error object--it was converting a pd.series directly to a dictionary without processing any potential NaN's, resulting in incorrect json in editor and the NaN that I suspect Marcelina was encountering.  This PR resolves the issue with CG0433 and would likely resolve the issue Marcelina was having