### PR TITLE
added rule core_id to operations cache key

### DIFF
--- a/cdisc_rules_engine/models/operation_params.py
+++ b/cdisc_rules_engine/models/operation_params.py
@@ -16,6 +16,7 @@ class OperationParams:
     """
 
     # Required parameters (no defaults) first
+    core_id: str
     dataframe: pd.DataFrame
     dataset_path: str
     datasets: Iterable[SDTMDatasetMetadata]

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -275,6 +275,7 @@ class RuleProcessor:
 
             # get necessary operation
             operation_params = OperationParams(
+                core_id=rule.get("core_id"),
                 operation_id=operation.get("id"),
                 operation_name=operation.get("operator"),
                 dataframe=dataset_copy,
@@ -335,6 +336,7 @@ class RuleProcessor:
         """
         # check cache
         cache_key = get_operations_cache_key(
+            core_id=operation_params.core_id,
             directory_path=operation_params.directory_path,
             operation_name=operation_params.operation_name,
             domain=operation_params.domain,

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -188,6 +188,7 @@ def replace_pattern_in_list_of_strings(
 
 
 def get_operations_cache_key(
+    core_id: str,
     directory_path: str,
     operation_id: str,
     domain: str = None,
@@ -199,7 +200,7 @@ def get_operations_cache_key(
     """
     Creates the cache key for operations.
     """
-    key = f"operations/{directory_path}/{operation_id}"
+    key = f"operations/{core_id}/{directory_path}/{operation_id}"
     optional_items = [domain, operation_name, grouping, target_variable, dataset_path]
     for item in optional_items:
         if item:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1225,6 +1225,7 @@ def installed_meddra_dictionaries(request) -> dict:
 @pytest.fixture(scope="function")
 def operation_params() -> OperationParams:
     return OperationParams(
+        core_id="test_id",
         operation_id="operation_id",
         operation_name="operation_name",
         dataframe=PandasDataset.from_dict({}),

--- a/tests/unit/test_operations/test_codelist_extensible.py
+++ b/tests/unit/test_operations/test_codelist_extensible.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 import pytest
-from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.codelist_extensible import CodelistExtensible
 from cdisc_rules_engine.models.library_metadata_container import (
@@ -37,21 +36,6 @@ def mock_metadata():
             "C3": {"submissionValue": "Codelist3", "terms": []},
         }
     }
-
-
-@pytest.fixture
-def operation_params():
-    return OperationParams(
-        dataframe=PandasDataset.from_dict({}),
-        dataset_path="test_path",
-        datasets={"TEST": PandasDataset.from_dict({})},
-        domain="TEST",
-        directory_path="test_dir",
-        operation_id="test_op",
-        operation_name="test_operation",
-        standard="SDTM",
-        standard_version="1.0",
-    )
 
 
 def test_extensible_codelist(operation_params, mock_metadata):

--- a/tests/unit/test_operations/test_codelist_terms.py
+++ b/tests/unit/test_operations/test_codelist_terms.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 import pytest
-from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.codelist_terms import CodelistTerms
 from cdisc_rules_engine.models.library_metadata_container import (
@@ -33,21 +32,6 @@ def mock_metadata():
             },
         }
     }
-
-
-@pytest.fixture
-def operation_params():
-    return OperationParams(
-        dataframe=PandasDataset.from_dict({}),
-        dataset_path="test_path",
-        datasets={"TEST": PandasDataset.from_dict({})},
-        domain="TEST",
-        directory_path="test_dir",
-        operation_id="test_op",
-        operation_name="test_operation",
-        standard="SDTM",
-        standard_version="1.0",
-    )
 
 
 def test_codelist_level_code(operation_params, mock_metadata):

--- a/tests/unit/test_operations/test_define_codelists.py
+++ b/tests/unit/test_operations/test_define_codelists.py
@@ -1,6 +1,5 @@
 import pytest
 from unittest.mock import MagicMock
-from cdisc_rules_engine.models.operation_params import OperationParams
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.define_xml_extensible_codelists import (
     DefineCodelists,
@@ -19,21 +18,6 @@ def mock_metadata():
             "CODELIST2": {"extended_values": ["EXT4", "EXT5"]},
         }
     }
-
-
-@pytest.fixture
-def operation_params():
-    return OperationParams(
-        dataframe=PandasDataset.from_dict({}),
-        dataset_path="test_path",
-        datasets={"TEST": PandasDataset.from_dict({})},
-        domain="TEST",
-        directory_path="test_dir",
-        operation_id="test_op",
-        operation_name="test_operation",
-        standard="SDTM",
-        standard_version="1.0",
-    )
 
 
 def test_single_codelist_values(operation_params, mock_metadata):


### PR DESCRIPTION
Fixes the operations cache key to include the rule's core_id so that operations with the same operation_id across rules are treated as different datasets.
To see that this is now working, see that the comparison reports in the test_suite github action only have differences in the CDISC RuleID column:
https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/14201138714