### PR TITLE
replaced list with pandas series

### DIFF
--- a/cdisc_rules_engine/utilities/data_processor.py
+++ b/cdisc_rules_engine/utilities/data_processor.py
@@ -87,7 +87,7 @@ class DataProcessor:
     def get_column_values(self, dataset, column):
         if column in dataset:
             return dataset[column]
-        return []
+        return pd.Series([])
 
     def get_columns(self, dataset, columns):
         column_data = {}


### PR DESCRIPTION
the issue arises when a RDOMAIN is used to link the CO dataset to LB in positive 2 but an IDVAR is not present.  We were adding a blank list but it needed to be a pandas series as the .unique() method was called on the return value.

no longer getting errors for positive 2--correctly gives skips
![image](https://github.com/user-attachments/assets/7e409da4-ad45-45be-a14c-6ccf302898c8)

test cg0370 / 371 locally with the changes in editor
