### PR TITLE
Dask Fix

### DIFF
--- a/cdisc_rules_engine/services/data_services/base_data_service.py
+++ b/cdisc_rules_engine/services/data_services/base_data_service.py
@@ -184,7 +184,9 @@ class BaseDataService(DataServiceInterface, ABC):
         """
         Gets metadata of a dataset and returns it as a DataFrame.
         """
-        dataset_metadata = self.get_raw_dataset_metadata(dataset_name=dataset_name)
+        dataset_metadata = self.get_raw_dataset_metadata(
+            dataset_name=dataset_name, **params
+        )
         metadata_to_return: dict = {
             "dataset_size": [dataset_metadata.file_size],
             "dataset_location": [dataset_metadata.filename],


### PR DESCRIPTION
While looking to update the template, I was having issues getting the pandas to align with the dask.
Rules CG0017, CG0334, and CG0333 all were skipping consistently with Dask.
[Copy of implementation_comparison.xlsx](https://github.com/user-attachments/files/19674184/Copy.of.implementation_comparison.xlsx)

They are all contents metadata checks involving some type of split/relational dataset being validated for pandas but not dask.  The issue was the call from the builder to the dataservice--the dataservice was calling get_metadata without relaying the params (this contains the datasets before they were converted to parquet).
By adding this the dataservice can correctly retrieve the original dataset and then get the metadata from it.

This turns out to be the issue for all the rules that were skipping.

to test: run validation specify rule "CORE-000510", "CORE-000538", "CORE-000540", with dask enable