### PR TITLE
docker image gitaction

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,0 +1,61 @@
+name: Build and Push Docker Image
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  check-if-latest:
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check_latest.outputs.is_latest }}
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Get current release tag
+        id: get_version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      # Check if the current tag is the latest release tag
+      - name: Check if this is the latest release
+        id: check_latest
+        run: |
+          latest_tag=$(
+          latest_tag=$(
+          curl -L \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest \
+              | jq -r '.tag_name'
+          )
+          current_tag="${GITHUB_REF#refs/tags/}"
+          if [[ "$latest_tag" == "$current_tag" ]]; then
+              echo "is_latest=true" >> $GITHUB_OUTPUT
+              echo "This is the latest release: $latest_tag"
+          else
+              echo "is_latest=false" >> $GITHUB_OUTPUT
+              echo "This is NOT the latest release. Latest is: $latest_tag, current is: $current_tag"
+          fi
+
+  build-and-push:
+    needs: check-if-latest
+    if: needs.check-if-latest.outputs.is_latest == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            cdiscdocker/cdisc-rules-engine:latest
+            cdiscdocker/cdisc-rules-engine:${{ needs.check-if-latest.outputs.version }}


### PR DESCRIPTION
This creates a gitaction that updates the image on dockerhub.
local dockerfile always grabs latest but if they grab the image from dockerhub, latest is not being updated.  This adds a automated step when a release is published that checks if the current release tag is also the tag version on latest.  If it is, it builds and pushes to dockerhub both as latest, and as the specific version of the release.

testing this locally might be a challenge.  What I would do is merge it, run the action (it will check the current release and notice it is not latest but it should go through the steps of getting the release tags.  except the image build and upload which wont be used until we do a latest release).   The build is taken exactly from the dockerhub docs (links to this url: https://github.com/marketplace/actions/build-and-push-docker-images)
