### PR TITLE
Docker

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -12,25 +12,38 @@ jobs:
     steps:
       - name: Get current release tag
         id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+            echo "Running on branch instead of tag"
+          fi
 
       # Check if the current tag is the latest release tag
       - name: Check if this is the latest release
         id: check_latest
         run: |
           latest_tag=$(
-          curl -L \
+            curl -L \
               -H "Accept: application/vnd.github+json" \
               https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest \
               | jq -r '.tag_name'
           )
-          current_tag="${GITHUB_REF#refs/tags/}"
-          if [[ "$latest_tag" == "$current_tag" ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            current_tag="${GITHUB_REF#refs/tags/}"
+            if [[ "$latest_tag" == "$current_tag" ]]; then
               echo "is_latest=true" >> $GITHUB_OUTPUT
               echo "This is the latest release: $latest_tag"
-          else
+            else
               echo "is_latest=false" >> $GITHUB_OUTPUT
               echo "This is NOT the latest release. Latest is: $latest_tag, current is: $current_tag"
+            fi
+          else
+            # Running on a branch, not a tag
+            current_tag="${GITHUB_REF#refs/heads/}"
+            echo "is_latest=false" >> $GITHUB_OUTPUT
+            echo "This is NOT a release. Running on branch: $current_tag, latest release is: $latest_tag"
           fi
 
   build-and-push:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -12,38 +12,25 @@ jobs:
     steps:
       - name: Get current release tag
         id: get_version
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-            echo "Running on branch instead of tag"
-          fi
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       # Check if the current tag is the latest release tag
       - name: Check if this is the latest release
         id: check_latest
         run: |
           latest_tag=$(
-            curl -L \
+          curl -L \
               -H "Accept: application/vnd.github+json" \
               https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest \
               | jq -r '.tag_name'
           )
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            current_tag="${GITHUB_REF#refs/tags/}"
-            if [[ "$latest_tag" == "$current_tag" ]]; then
+          current_tag="${GITHUB_REF#refs/tags/}"
+          if [[ "$latest_tag" == "$current_tag" ]]; then
               echo "is_latest=true" >> $GITHUB_OUTPUT
               echo "This is the latest release: $latest_tag"
-            else
+          else
               echo "is_latest=false" >> $GITHUB_OUTPUT
               echo "This is NOT the latest release. Latest is: $latest_tag, current is: $current_tag"
-            fi
-          else
-            # Running on a branch, not a tag
-            current_tag="${GITHUB_REF#refs/heads/}"
-            echo "is_latest=false" >> $GITHUB_OUTPUT
-            echo "This is NOT a release. Running on branch: $current_tag, latest release is: $latest_tag"
           fi
 
   build-and-push:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,0 +1,61 @@
+name: Build and Push Docker Image
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  check-if-latest:
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check_latest.outputs.is_latest }}
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Get current release tag
+        id: get_version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      # Check if the current tag is the latest release tag
+      - name: Check if this is the latest release
+        id: check_latest
+        run: |
+          latest_tag=$(
+          latest_tag=$(
+          curl -L \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest \
+              | jq -r '.tag_name'
+          )
+          current_tag="${GITHUB_REF#refs/tags/}"
+          if [[ "$latest_tag" == "$current_tag" ]]; then
+              echo "is_latest=true" >> $GITHUB_OUTPUT
+              echo "This is the latest release: $latest_tag"
+          else
+              echo "is_latest=false" >> $GITHUB_OUTPUT
+              echo "This is NOT the latest release. Latest is: $latest_tag, current is: $current_tag"
+          fi
+
+  build-and-push:
+    needs: check-if-latest
+    if: needs.check-if-latest.outputs.is_latest == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            cdiscdocker/cdisc-rules-engine:latest
+            cdiscdocker/cdisc-rules-engine:${{ needs.check-if-latest.outputs.version }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -19,7 +19,6 @@ jobs:
         id: check_latest
         run: |
           latest_tag=$(
-          latest_tag=$(
           curl -L \
               -H "Accept: application/vnd.github+json" \
               https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest \


### PR DESCRIPTION
there was a syntax error, causing the last run to fail @RamilCDISC 
see: https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/14410095271

note: GITHUB_REF value is refs/heads/docker which is the branch name, when this is triggered on a release, it will be the version and trigger the build