### PR TITLE
updated medrt

### DIFF
--- a/cdisc_rules_engine/models/dictionaries/medrt/terms_factory.py
+++ b/cdisc_rules_engine/models/dictionaries/medrt/terms_factory.py
@@ -48,7 +48,11 @@ class MEDRTTermsFactory(TermsFactoryInterface):
 
     def _parse_term(self, term_xml: ElementTree) -> MEDRTTerm:
         code = term_xml.find("code").text
+        if code is None:
+            raise ValueError(f"Missing 'code' element in term XML: {term_xml}")
         id = term_xml.find("id").text
+        if id is None:
+            raise ValueError(f"Missing 'id' element in term XML: {term_xml}")
         return MEDRTTerm(
             code=code,
             id=id,

--- a/cdisc_rules_engine/models/dictionaries/medrt/terms_factory.py
+++ b/cdisc_rules_engine/models/dictionaries/medrt/terms_factory.py
@@ -47,12 +47,18 @@ class MEDRTTermsFactory(TermsFactoryInterface):
         return ExternalDictionary(data, version=version)
 
     def _parse_term(self, term_xml: ElementTree) -> MEDRTTerm:
-        code = term_xml.find("code").text
-        if code is None:
+        code_element = term_xml.find("code")
+        if code_element is None:
             raise ValueError(f"Missing 'code' element in term XML: {term_xml}")
-        id = term_xml.find("id").text
-        if id is None:
+        code = code_element.text
+        if code is None:
+            raise ValueError(f"Empty 'code' element in term XML: {term_xml}")
+        id_element = term_xml.find("id")
+        if id_element is None:
             raise ValueError(f"Missing 'id' element in term XML: {term_xml}")
+        id = id_element.text
+        if id is None:
+            raise ValueError(f"Empty 'id' element in term XML: {term_xml}")
         return MEDRTTerm(
             code=code,
             id=id,

--- a/resources/schema/ExDictionary.md
+++ b/resources/schema/ExDictionary.md
@@ -71,9 +71,41 @@ Required files: - DD.txt (Drug Dictionary) - DDA.txt (ATC Classification) - INA.
 #### Other Drug Dictionaries
 
 ```
+--medrt TEXT      Path to directory containing MEDRT dictionary files
+                  Dictionary file must be named `Core_MEDRT_*_DTS.xml`
 
---medrt TEXT Path to directory containing MEDRT dictionary files
-Dictionary file must be named `Core_MEDRT_*_DTS.xml`
+                  XML Structure Requirements:
+                  - The XML should contain both term and concept elements
+
+                  Term elements must include:
+                  - <code>: Unique term code (required)
+                  - <id>: Term identifier (required)
+                  - <status>: Term status (optional)
+                  - <name>: Term name (optional)
+
+                  Concept elements must include:
+                  - <name>: Concept name (optional)
+                  - <code>: Concept code (optional)
+                  - <status>: Concept status (optional)
+
+                  Example structure:
+                  <root>
+                    <terms>
+                      <term>
+                        <code>TERM_CODE_VALUE</code>
+                        <id>TERM_ID_VALUE</id>
+                        <status>TERM_STATUS_VALUE</status>
+                        <name>TERM_NAME_VALUE</name>
+                      </term>
+                    </terms>
+                    <concepts>
+                      <concept>
+                        <name>CONCEPT_NAME_VALUE</name>
+                        <code>CONCEPT_CODE_VALUE</code>
+                        <status>CONCEPT_STATUS_VALUE</status>
+                      </concept>
+                    </concepts>
+                  </root>
 
 --unii TEXT Path to directory containing UNII dictionary files
 Required files: - UNII*Records*_._ (tab-delimited file containing UNII codes and terms)

--- a/resources/schema/ExDictionary.md
+++ b/resources/schema/ExDictionary.md
@@ -79,7 +79,7 @@ Required files: - DD.txt (Drug Dictionary) - DDA.txt (ATC Classification) - INA.
 
                   Term elements must include:
                   - <code>: Unique term code (required)
-                  - <id>: Term identifier (required)
+                  - <id>: ConceptID identifier (required)
                   - <status>: Term status (optional)
                   - <name>: Term name (optional)
 


### PR DESCRIPTION
This PR updates the readme as well as updating the error handling.  I received an email from Adam Niemes regarding an issue with medrt.

The Core Rules Engine returned an error: Traceback (most recent call last): File "core.py", line 877, in <module> File "click\core.py", line 1157, in __call__ File "click\core.py", line 1078, in main File "click\core.py", line 1688, in invoke File "click\core.py", line 1434, in invoke File "click\core.py", line 783, in invoke File "click\decorators.py", line 33, in new_func File "core.py", line 315, in validate File "scripts\run_validation.py", line 127, in run_validation File "scripts\script_utils.py", line 150, in fill_cache_with_dictionaries File "cdisc_rules_engine\models\dictionaries\get_dictionary_terms.py", line 16, in extract_dictionary_terms File "cdisc_rules_engine\models\dictionaries\medrt\terms_factory.py", line 39, in install_terms File "cdisc_rules_engine\models\dictionaries\medrt\terms_factory.py", line 50, in _parse_termAttributeError: 'NoneType' object has no attribute 'text'[PYI-52952:ERROR] Failed to execute script 'core' due to unhandled exception!

![image002](https://github.com/user-attachments/assets/ee549eba-dad0-4944-9225-64d5307c7197)
was his format--lacking the id key representing the ConceptID.  I added two error codes and updated the reference guide on what format the XML should have to ensure this issue does not occur