### PR TITLE
Debugging for cache keyerror

### DIFF
--- a/cdisc_rules_engine/services/cache/in_memory_cache_service.py
+++ b/cdisc_rules_engine/services/cache/in_memory_cache_service.py
@@ -7,7 +7,6 @@ from cdisc_rules_engine.interfaces import (
 from cdisc_rules_engine.models.dataset import DatasetInterface
 from cachetools import LRUCache
 import psutil
-from cdisc_rules_engine.services import logger
 from multiprocessing import Lock
 
 
@@ -40,20 +39,8 @@ class InMemoryCacheService(CacheServiceInterface):
     def add(self, cache_key, data):
         if get_data_size(data) > self.max_size:
             return
-        try:
-            with self.cache_lock:
-                self.cache[cache_key] = data
-        except KeyError as e:
-            logger.trace(e)
-            logger.error(
-                f"""Error occurred during validation.
-            Error: {e}
-            Error Type: {type(e)}
-            Error Message: {str(e)}
-            Cache Key: {cache_key}
-            """
-            )
-            raise
+        with self.cache_lock:
+            self.cache[cache_key] = data
 
     def add_dataset(self, cache_key, data):
         with self.dataset_cache_lock:

--- a/cdisc_rules_engine/services/cache/in_memory_cache_service.py
+++ b/cdisc_rules_engine/services/cache/in_memory_cache_service.py
@@ -7,6 +7,7 @@ from cdisc_rules_engine.interfaces import (
 from cdisc_rules_engine.models.dataset import DatasetInterface
 from cachetools import LRUCache
 import psutil
+from cdisc_rules_engine.services import logger
 
 
 def get_data_size(dataset):
@@ -36,7 +37,19 @@ class InMemoryCacheService(CacheServiceInterface):
     def add(self, cache_key, data):
         if get_data_size(data) > self.max_size:
             return
-        self.cache[cache_key] = data
+        try:
+            self.cache[cache_key] = data
+        except KeyError as e:
+            logger.trace(e)
+            logger.error(
+                f"""Error occurred during validation.
+            Error: {e}
+            Error Type: {type(e)}
+            Error Message: {str(e)}
+            Cache Key: {cache_key}
+            """
+            )
+            raise
 
     def add_dataset(self, cache_key, data):
         self.dataset_cache[cache_key] = data

--- a/cdisc_rules_engine/services/cache/in_memory_cache_service.py
+++ b/cdisc_rules_engine/services/cache/in_memory_cache_service.py
@@ -8,6 +8,7 @@ from cdisc_rules_engine.models.dataset import DatasetInterface
 from cachetools import LRUCache
 import psutil
 from cdisc_rules_engine.services import logger
+from multiprocessing import Lock
 
 
 def get_data_size(dataset):
@@ -28,8 +29,10 @@ class InMemoryCacheService(CacheServiceInterface):
 
     def __init__(self, max_size=None, **kwargs):
         self.max_size = max_size or psutil.virtual_memory().available * 0.25
+        self.cache_lock = Lock()
         self.cache = LRUCache(maxsize=self.max_size, getsizeof=asizeof.asizeof)
         self.max_dataset_cache_size = psutil.virtual_memory().available * 0.5
+        self.dataset_cache_lock = Lock()
         self.dataset_cache = LRUCache(
             maxsize=self.max_dataset_cache_size, getsizeof=get_data_size
         )
@@ -38,7 +41,8 @@ class InMemoryCacheService(CacheServiceInterface):
         if get_data_size(data) > self.max_size:
             return
         try:
-            self.cache[cache_key] = data
+            with self.cache_lock:
+                self.cache[cache_key] = data
         except KeyError as e:
             logger.trace(e)
             logger.error(
@@ -52,7 +56,8 @@ class InMemoryCacheService(CacheServiceInterface):
             raise
 
     def add_dataset(self, cache_key, data):
-        self.dataset_cache[cache_key] = data
+        with self.dataset_cache_lock:
+            self.dataset_cache[cache_key] = data
 
     def get_dataset(self, cache_key):
         return self.dataset_cache.get(cache_key, None)
@@ -97,7 +102,8 @@ class InMemoryCacheService(CacheServiceInterface):
         return cache_key in self.cache
 
     def clear(self, cache_key):
-        self.cache.pop(cache_key, "invalid")
+        with self.cache_lock:
+            self.cache.pop(cache_key, "invalid")
 
     def clear_all(self, prefix: str = None):
         if prefix:

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -385,6 +385,9 @@ class RuleProcessor:
         result = operation.execute()
         if not DataProcessor.is_dummy_data(self.data_service):
             try:
+                from time import sleep
+
+                sleep(5)
                 self.cache.add(cache_key, result)
             except Exception as e:
                 logger.trace(e)

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -399,7 +399,7 @@ class RuleProcessor:
                 Operation: {operation_params.operation_name}
                 """
                 )
-                raise e
+                raise
         return result
 
     def is_current_domain(self, dataset, target_domain):

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -384,7 +384,22 @@ class RuleProcessor:
         )
         result = operation.execute()
         if not DataProcessor.is_dummy_data(self.data_service):
-            self.cache.add(cache_key, result)
+            try:
+                self.cache.add(cache_key, result)
+            except Exception as e:
+                logger.trace(e)
+                logger.error(
+                    f"""Error occurred during validation.
+                Error: {e}
+                Error Type: {type(e)}
+                Error Message: {str(e)}
+                Cache Key: {cache_key}
+                Rule: {operation_params.core_id}
+                Dataset: {operation_params.dataset_path}
+                Operation: {operation_params.operation_name}
+                """
+                )
+                raise e
         return result
 
     def is_current_domain(self, dataset, target_domain):

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -384,25 +384,7 @@ class RuleProcessor:
         )
         result = operation.execute()
         if not DataProcessor.is_dummy_data(self.data_service):
-            try:
-                from time import sleep
-
-                sleep(5)
-                self.cache.add(cache_key, result)
-            except Exception as e:
-                logger.trace(e)
-                logger.error(
-                    f"""Error occurred during validation.
-                Error: {e}
-                Error Type: {type(e)}
-                Error Message: {str(e)}
-                Cache Key: {cache_key}
-                Rule: {operation_params.core_id}
-                Dataset: {operation_params.dataset_path}
-                Operation: {operation_params.operation_name}
-                """
-                )
-                raise
+            self.cache.add(cache_key, result)
         return result
 
     def is_current_domain(self, dataset, target_domain):


### PR DESCRIPTION
This simply adds a lock around writes to the in memory cache. This resolves the problem where multiple processes are writing to the same cache at the same time, causing some rules to get skipped randomly.
Evidence that this is working can be viewed by seeing the test suite validation successes from today (4/23): https://github.com/cdisc-org/cdisc-rules-engine/actions/workflows/test_suite.yml