### PR TITLE
update docker trigger

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,8 +1,11 @@
 name: Build and Push Docker Image
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Release CORE Rules Engine"]
+    types:
+      - completed
+    branches:
+      - main
 jobs:
   check-if-latest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The docker image build gitaction triggers on release but it needs to be delayed as it uses the github api to grab the new release and see if it is latest.  It cannot run in parallel so I alterred its run conditions to trigger after the release action successfully runs
https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/14836565275
