### PR TITLE
added get_parent_model_column_order error handling

### DIFF
--- a/cdisc_rules_engine/operations/parent_library_model_column_order.py
+++ b/cdisc_rules_engine/operations/parent_library_model_column_order.py
@@ -1,3 +1,4 @@
+from cdisc_rules_engine.exceptions.custom_exceptions import DomainNotFoundError
 from cdisc_rules_engine.operations.library_model_column_order import (
     LibraryModelColumnOrder,
 )
@@ -42,7 +43,10 @@ class ParentLibraryModelColumnOrder(LibraryModelColumnOrder):
     def _get_parent_variable_names_list(self, domain_to_datasets: dict, rdomain: str):
         parent_datasets = domain_to_datasets.get(rdomain, [])
         if len(parent_datasets) < 1:
-            return []
+            raise DomainNotFoundError(
+                f"Operation get_parent_model_column_order requires parent Domain "
+                f"{rdomain} but Domain not found in datasets"
+            )
         parent_dataframe = self.data_service.get_dataset(
             dataset_name=parent_datasets[0].filename
         )


### PR DESCRIPTION
[CG0314.yml.txt](https://github.com/user-attachments/files/20040761/CG0314.yml.txt)
[unit-test-coreid-CG0314-negative-with-ae.xlsx](https://github.com/user-attachments/files/20040762/unit-test-coreid-CG0314-negative-with-ae.xlsx)
[unit-test-coreid-CG0314-negative-without-ae.xlsx](https://github.com/user-attachments/files/20040763/unit-test-coreid-CG0314-negative-without-ae.xlsx)

The test rule and test data are linked above. The data with ae should run and produce a report. The data without ae should show the following error:
> cdisc_rules_engine.exceptions.custom_exceptions.DomainNotFoundError: Operation get_parent_model_column_order requires parent Domain AE but Domain not found in datasets