### PR TITLE
Update valid_codelist_dates (#1161)

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -75,8 +75,8 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:  # 
                         standard, standard_version, standard_substandard
                     )
                 )
-                asyncio.run(cache_populator.load_available_ct_packages())
             asyncio.run(cache_populator.load_codelists(codelists))
+        asyncio.run(cache_populator.load_available_ct_packages())
         if not rule:
             raise KeyError("'rule' required in request")
         datasets = json_data.get("datasets")

--- a/cdisc_rules_engine/models/operation_params.py
+++ b/cdisc_rules_engine/models/operation_params.py
@@ -34,6 +34,7 @@ class OperationParams:
     codelist: str = None
     codelists: list = None
     ct_attribute: str = None
+    ct_package_types: List[str] = None
     ct_package: list = None
     ct_packages: list = None
     ct_version: str = None

--- a/cdisc_rules_engine/operations/valid_codelist_dates.py
+++ b/cdisc_rules_engine/operations/valid_codelist_dates.py
@@ -3,12 +3,22 @@ from cdisc_rules_engine.operations.base_operation import BaseOperation
 
 class ValidCodelistDates(BaseOperation):
     """
-    Returns the valid codelist dates for a given standard
+    Returns the valid terminology package dates for a given standard
     Ex:
-        Given a list of codelists: [sdtmct-2023-10-26, sdtmct-2023-12-13,
-                                    adamct-2023-12-13, cdashct-2023-05-19]
+        Given a list of terminology packages:
+            [sdtmct-2023-10-26, sdtmct-2023-12-13,
+             adamct-2023-12-13, cdashct-2023-05-19]
         and standard: sdtmig
         the operation will return ["2023-10-26", "2023-12-13"]
+
+    The default standard (obtained from the validation parameter) can
+    be overridden using the optional `ct_package_types` operation
+    parameter.
+    Ex:
+        Given the same list of terminology packages
+        and `ct_package_types`: ["SDTM", "CDASH"]
+        the operation will return:
+            ["2023-05-19", "2023-10-26", "2023-12-13"]
 
     """
 
@@ -17,11 +27,15 @@ class ValidCodelistDates(BaseOperation):
         ct_packages = self.library_metadata.published_ct_packages
         if not ct_packages:
             return []
-        return [
-            self._parse_date_from_ct_package(package)
-            for package in ct_packages
-            if self._is_applicable_ct_package(package)
-        ]
+        return sorted(
+            list(
+                set(
+                    self._parse_date_from_ct_package(package)
+                    for package in ct_packages
+                    if self._is_applicable_ct_package(package)
+                )
+            )
+        )
 
     def _is_applicable_ct_package(self, package: str) -> bool:
         standard_to_package_type_mapping = {
@@ -29,10 +43,15 @@ class ValidCodelistDates(BaseOperation):
             "sendig": {"sendct"},
             "cdashig": {"cdashct"},
             "adamig": {"sdtmct", "adamct"},
+            "usdm": {"ddfct", "sdtmct"},
         }
         package_type = package.split("-", 1)[0]
-        applicable_package_types = standard_to_package_type_mapping.get(
-            self.params.standard.lower(), set()
+        applicable_package_types = (
+            set(f"{t.lower()}ct" for t in self.params.ct_package_types)
+            if self.params.ct_package_types
+            else standard_to_package_type_mapping.get(
+                self.params.standard.lower(), set()
+            )
         )
         return package_type in applicable_package_types
 

--- a/cdisc_rules_engine/services/cdisc_library_service.py
+++ b/cdisc_rules_engine/services/cdisc_library_service.py
@@ -345,7 +345,7 @@ class CDISCLibraryService:
         }
         # default to sdtmig if no function is found
         return standard_get_function_map.get(
-            standard_type, lambda: self._client.get_sdtmig()
+            standard_type, lambda: self._client.get_sdtmig(version)
         )()
 
     def _get_model(self, standard_type: str, model_version: str) -> dict:

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -1,7 +1,11 @@
 import re
 from typing import Iterable, List, Optional, Set, Union, Tuple
-from cdisc_rules_engine.interfaces.cache_service_interface import CacheServiceInterface
-from cdisc_rules_engine.models.dataset.dataset_interface import DatasetInterface
+from cdisc_rules_engine.interfaces.cache_service_interface import (
+    CacheServiceInterface,
+)
+from cdisc_rules_engine.models.dataset.dataset_interface import (
+    DatasetInterface,
+)
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
@@ -35,7 +39,9 @@ from cdisc_rules_engine.models.external_dictionaries_container import (
     ExternalDictionariesContainer,
 )
 from cdisc_rules_engine.models.sdtm_dataset_metadata import SDTMDatasetMetadata
-from cdisc_rules_engine.interfaces.data_service_interface import DataServiceInterface
+from cdisc_rules_engine.interfaces.data_service_interface import (
+    DataServiceInterface,
+)
 from cdisc_rules_engine.exceptions.custom_exceptions import DomainNotFoundError
 
 
@@ -70,7 +76,10 @@ class RuleProcessor:
 
         # additional check for split domains based on the flag
         is_excluded, is_included = cls._handle_split_domains(
-            dataset_metadata.is_split, include_split_datasets, is_excluded, is_included
+            dataset_metadata.is_split,
+            include_split_datasets,
+            is_excluded,
+            is_included,
         )
 
         return is_included and not is_excluded
@@ -212,7 +221,10 @@ class RuleProcessor:
                 dataset_name=dataset_metadata.full_path, datasets=datasets
             ).data.variable_name
             class_name = self.data_service.get_dataset_class(
-                variables, dataset_metadata.full_path, datasets, dataset_metadata
+                variables,
+                dataset_metadata.full_path,
+                datasets,
+                dataset_metadata,
             )
             if (class_name not in included_classes) and not (
                 class_name == FINDINGS_ABOUT and FINDINGS in included_classes
@@ -224,7 +236,10 @@ class RuleProcessor:
                 dataset_name=dataset_metadata.full_path, datasets=datasets
             ).data.variable_name
             class_name = self.data_service.get_dataset_class(
-                variables, dataset_metadata.full_path, datasets, dataset_metadata
+                variables,
+                dataset_metadata.full_path,
+                datasets,
+                dataset_metadata,
             )
             if class_name and (
                 (class_name in excluded_classes)
@@ -326,6 +341,7 @@ class RuleProcessor:
                 external_dictionaries=external_dictionaries,
                 ct_version=operation.get("version"),
                 ct_attribute=operation.get("attribute"),
+                ct_package_types=operation.get("ct_package_types"),
                 ct_packages=kwargs.get("ct_packages"),
                 ct_package=kwargs.get("codelist_term_maps"),
                 attribute_name=operation.get("attribute_name", ""),

--- a/resources/schema/Operations.json
+++ b/resources/schema/Operations.json
@@ -407,6 +407,27 @@
     "ct_attribute": {
       "type": "string"
     },
+    "ct_package_types": {
+      "items": {
+        "type": "string",
+        "enum": [
+          "ADAM",
+          "CDASH",
+          "COA",
+          "DDF",
+          "DEFINE-XML",
+          "GLOSSARY",
+          "MRCT",
+          "PROTOCOL",
+          "QRS",
+          "QS-FT",
+          "SDTM",
+          "SEND",
+          "TMF"
+        ]
+      },
+      "type": "array"
+    },
     "ct_packages": {
       "items": {
         "type": "string"

--- a/resources/schema/Operations.md
+++ b/resources/schema/Operations.md
@@ -663,9 +663,9 @@ Returns a list of the domains in the study
 
 ## valid_codelist_dates
 
-Returns the valid codelist dates for a given standard
+Returns the valid terminology package dates for a given standard.
 
-Given a list of codelists:
+Given a list of terminology packages:
 
 ```json
 [
@@ -678,10 +678,27 @@ Given a list of codelists:
 
 and standard: `sdtmig`
 
-the operation will return
+the operation will return:
 
 ```json
 ["2023-10-26", "2023-12-13"]
+```
+
+By default, the standard is as specified when running validation - as the validation runtime parameter and/or as specified in the rule header - and the list of terminology packages is obtained from the current cache. If required, the default standard may be overridden using the optional `ct_package_types` parameter. For example, given the same list of terminology packages, the following operation:
+
+```yaml
+Operation:
+  - operator: valid_codelist_dates
+    id: $valid_dates
+    ct_package_types:
+      - SDTM
+      - CDASH
+```
+
+will return:
+
+```json
+["2023-05-19", "2023-10-26", "2023-12-13"]
 ```
 
 # External Dictionary Validation Operations

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -49,6 +49,7 @@ from cdisc_rules_engine.services.reporting import BaseReport, ReportFactory
 from cdisc_rules_engine.utilities.progress_displayers import get_progress_displayer
 from warnings import simplefilter
 import os
+from cdisc_rules_engine.constants.cache_constants import PUBLISHED_CT_PACKAGES
 
 simplefilter(
     action="ignore", category=FutureWarning
@@ -234,6 +235,7 @@ def run_single_rule_validation(
         variables_metadata=cache.get(variable_details_cache_key),
         variable_codelist_map=cache.get(variable_codelist_cache_key),
         ct_package_metadata=ct_package_metadata,
+        published_ct_packages=cache.get(PUBLISHED_CT_PACKAGES),
     )
     if not standard and not standard_version and rule:
         standard = rule.get("Authorities")[0].get("Standards")[0].get("Name").lower()

--- a/tests/unit/test_operations/test_valid_codelist_dates.py
+++ b/tests/unit/test_operations/test_valid_codelist_dates.py
@@ -3,38 +3,77 @@ from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
 )
-from cdisc_rules_engine.operations.valid_codelist_dates import ValidCodelistDates
+from cdisc_rules_engine.operations.valid_codelist_dates import (
+    ValidCodelistDates,
+)
 from cdisc_rules_engine.models.operation_params import OperationParams
-from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
+from cdisc_rules_engine.services.cache.cache_service_factory import (
+    CacheServiceFactory,
+)
 import pytest
 
 
 @pytest.mark.parametrize(
-    "standard, expected",
+    "standard, ct_package_types, expected",
     [
-        ("sdtmig", ["2022-09-30", "2022-12-16"]),
-        ("adamig", ["2022-09-30", "2022-12-16", "2021-12-17", "2022-06-24"]),
-        ("sendig", ["2014-09-26", "2014-12-19"]),
-        ("cdashig", ["2014-09-26", "2015-03-27"]),
+        ("sdtmig", None, ["2022-09-30", "2022-12-16", "2024-09-27"]),
+        (
+            "adamig",
+            None,
+            [
+                "2021-12-17",
+                "2022-06-24",
+                "2022-09-30",
+                "2022-12-16",
+                "2024-09-27",
+            ],
+        ),
+        ("sendig", None, ["2014-09-26", "2014-12-19"]),
+        ("cdashig", None, ["2014-09-26", "2015-03-27"]),
+        (
+            "usdm",
+            None,
+            ["2022-09-30", "2022-12-16", "2022-12-17", "2024-09-27"],
+        ),
+        (
+            "sdtmig",
+            ["SDTM", "CDASH"],
+            [
+                "2014-09-26",
+                "2015-03-27",
+                "2022-09-30",
+                "2022-12-16",
+                "2024-09-27",
+            ],
+        ),
+        ("usdm", ["DDF"], ["2022-12-17", "2024-09-27"]),
     ],
 )
-def test_variable_count(
-    standard, expected, mock_data_service, operation_params: OperationParams
+def test_valid_codelist_dates(
+    standard,
+    expected,
+    ct_package_types,
+    mock_data_service,
+    operation_params: OperationParams,
 ):
     valid_codelists = [
         "sdtmct-2022-09-30",
         "sdtmct-2022-12-16",
+        "sdtmct-2024-09-27",
         "sendct-2014-09-26",
         "sendct-2014-12-19",
         "adamct-2021-12-17",
         "adamct-2022-06-24",
         "cdashct-2014-09-26",
         "cdashct-2015-03-27",
+        "ddfct-2022-12-17",
+        "ddfct-2024-09-27",
     ]
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     library_metadata = LibraryMetadataContainer(published_ct_packages=valid_codelists)
     operation_params.standard = standard
+    operation_params.ct_package_types = ct_package_types
     result = ValidCodelistDates(
         operation_params,
         PandasDataset.from_dict({"test": [1, 2, 33]}),


### PR DESCRIPTION
Updates to support retrieval of valid terminology package dates for USDM and DDF terminology packages. The following files were updated:
- `cdisc_rules_engine/operations/valid_codelist_dates.py`:
    - Added `"usdm": {"ddfct", "sdtmct"}` to `standard_to_package_type_mapping` dictionary.
    - Added processing of new `ct_package_types` operation parameter - the value(s) of this parameter override the decoding of standard to package type.
    - Updated output to be a sorted unique list of dates.
- `cdisc_rules_engine/models/operation_params.py`: added new `ct_package_types` parameter.
- `cdisc_rules_engine/utilities/rule_processor.py`: picked up and passed new `ct_package_types` parameter.
- `resources/schema/Operations.json`: defined `ct_package_types` as an array of enumerated strings. The enumeration values were taken from the published CT package types currently available in the cache.
- `resources/schema/Operations.md`:
    - Replace "codelist dates" with "terminology package dates" in the description.
    - Added description of where default standard and list of terminology package dates come from and a description/example of use of the new `ct_package_types` parameter.
- `TestRule/__init__.py`: changed so that the list of published CT packages is always retrieved, regardless of whether `standard` or `codelists` are specified.
- `scripts/run_validation.py`: picked up published CT packages from the cashed and passed as `published_ct_packages` into `library_metadata` in `run_single_rule_validation` (this was missing, so the operation would never work when run from the editor).
- `tests/unit/test_operations/test_valid_codelist_dates`:
    - Renamed `test_variable_count` method to `test_valid_codelist_dates`.
    - Added `ct_package_types` to parameters and method arguments, and assigned to `operation_params`
    - Updated existing parameters to:
        - Include `None` as `ct_package_types`
        - Reorder date list to be sorted
    - Added 2 parameter sets
        - One for "usdm" standard with no `ct_package_types`
        - One with `standard = "usdm"` and `ct_package_types = ["DDF"]`
    - Added 1 new "sdtmct" package and 2 "ddfct" packages to `valid_codelists` to test for correct selection and removal of duplicate dates.

I also made a minor update for an issue I found during testing:
- `cdisc_rules_engine/services/cdisc_library_service.py`: passed `version` into `self._client.get_sdtmig` when called as a default (because `version` is a required argument and the call fails without it).