### PR TITLE
Fix TestRule

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -66,9 +66,10 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:  # 
         standard_substandard = standards_data.get("substandard")
         codelists = json_data.get("codelists", [])
         cache = InMemoryCacheService()
+        library_service = CDISCLibraryService(api_key, cache)
+        cache_populator: CachePopulator = CachePopulator(cache, library_service)
+        asyncio.run(cache_populator.load_available_ct_packages())
         if standards_data or codelists:
-            library_service = CDISCLibraryService(api_key, cache)
-            cache_populator: CachePopulator = CachePopulator(cache, library_service)
             if standards_data:
                 asyncio.run(
                     cache_populator.load_standard(
@@ -76,7 +77,6 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:  # 
                     )
                 )
             asyncio.run(cache_populator.load_codelists(codelists))
-        asyncio.run(cache_populator.load_available_ct_packages())
         if not rule:
             raise KeyError("'rule' required in request")
         datasets = json_data.get("datasets")


### PR DESCRIPTION
PR #1176 included a change to `TestRule/__init__.py` to force population of the cache with all published CT packages.  Population of the cache uses a `cache_populator`, but this is only created if `standards_data` or `codelists` are specified with the test data.  However, `standards_data` and `codelists` are not specified for most USDM test data so the call to the undefined `cache_populator` caused an unhandled error, which is reported in the editor as "500 Internal Server Error".

 Creation of the `library_service` and `cache_populator` have therefore been made unconditional so that the `cache_populator` is always defined.