### PR TITLE
Rename is_consistent_across_dataset to is_inconsistent_across_dataset

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -1014,7 +1014,7 @@ class DataframeType(BaseType):
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)
-    def is_consistent_across_dataset(self, other_value):
+    def is_inconsistent_across_dataset(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         grouping_cols = []

--- a/resources/schema/Operator.json
+++ b/resources/schema/Operator.json
@@ -456,7 +456,7 @@
     {
       "properties": {
         "operator": {
-          "const": "is_consistent_across_dataset"
+          "const": "is_inconsistent_across_dataset"
         }
       },
       "required": ["operator", "value"],

--- a/resources/schema/Operator.md
+++ b/resources/schema/Operator.md
@@ -698,23 +698,23 @@ Complement of `contains_all`
     - "Unplanned Treatment"
 ```
 
-## is_consistent_across_dataset
+## is_inconsistent_across_dataset
 
-Checks if a variable maintains consistent values within groups defined by one or more grouping variables. Groups records by specified value(s) and validates that the target variable maintains the same value within each unique combination of grouping variables
+Checks if a variable maintains consistent values within groups defined by one or more grouping variables. Groups records by specified value(s) and validates that the target variable maintains the same value within each unique combination of grouping variables.
 
-Single grouping variable:
+Single grouping variable - true if the values of BGSTRESU differ within USUBJID:
 
 ```yaml
 - name: "BGSTRESU"
-  operator: is_consistent_across_dataset
+  operator: is_inconsistent_across_dataset
   value: "USUBJID"
 ```
 
-Multiple grouping variables:
+Multiple grouping variables - true if the values of --STRESU differ within each combination of --TESTCD, --CAT, --SCAT, --SPEC, and --METHOD:
 
 ```yaml
 - name: "--STRESU"
-  operator: is_consistent_across_dataset
+  operator: is_inconsistent_across_dataset
   value:
     - "--TESTCD"
     - "--CAT"

--- a/tests/unit/test_check_operators/test_value_set_checks.py
+++ b/tests/unit/test_check_operators/test_value_set_checks.py
@@ -116,7 +116,7 @@ def test_is_consistent_across_dataset(
     df = dataset_type.from_dict(data)
     result = DataframeType(
         {"value": df, "column_prefix_map": {"--": ""}}
-    ).is_consistent_across_dataset({"target": target, "comparator": comparator})
+    ).is_inconsistent_across_dataset({"target": target, "comparator": comparator})
     assert result.equals(df.convert_to_series(expected_result))
 
 
@@ -142,7 +142,7 @@ def test_is_consistent_across_dataset_dask(
     df = dataset_type.from_dict(data)
     result = DataframeType(
         {"value": df, "column_prefix_map": {"--": ""}}
-    ).is_consistent_across_dataset({"target": target, "comparator": comparator})
+    ).is_inconsistent_across_dataset({"target": target, "comparator": comparator})
     assert result.equals(df.convert_to_series(expected_result))
 
 
@@ -162,7 +162,7 @@ def test_is_consistent_across_dataset_with_nulls(
     df = dataset_type.from_dict(data)
     result = DataframeType(
         {"value": df, "column_prefix_map": {"--": ""}}
-    ).is_consistent_across_dataset({"target": target, "comparator": comparator})
+    ).is_inconsistent_across_dataset({"target": target, "comparator": comparator})
     assert result.equals(df.convert_to_series(expected_result))
 
 
@@ -171,5 +171,5 @@ def test_is_consistent_across_dataset_empty_dataset():
     df = PandasDataset.from_dict(data)
     result = DataframeType(
         {"value": df, "column_prefix_map": {"--": ""}}
-    ).is_consistent_across_dataset({"target": "BGSTRESU", "comparator": "USUBJID"})
+    ).is_inconsistent_across_dataset({"target": "BGSTRESU", "comparator": "USUBJID"})
     assert len(result) == 0


### PR DESCRIPTION
Renamed the operator in:
- `cdisc_rules_engine\check_operators\dataframe_operators.py`
- `resources\schema\Operator.json`
- `resources\schema\Operator.md`
- `tests\unit\test_check_operators\test_value_set_checks.py`

Also added some explanatory text to `resources\schema\Operator.md`.
