### PR TITLE
added aprelsupp logic

### DIFF
--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -198,7 +198,7 @@ class BaseOperation:
             and target_metadata.is_supp
         ):
             domain_for_library = "SUPPQUAL"
-        elif target_metadata and target_metadata.name.lower().startswith("REL"):
+        elif target_metadata and "rel" in target_metadata.name.lower():
             domain_for_library = target_metadata.name
         else:
             domain_for_library = self.params.domain


### PR DESCRIPTION
this PR tweaks https://github.com/cdisc-org/cdisc-rules-engine/pull/1209 so that it will work for RELREC, RELSUP, but also APRELSUP by using contains instead of startswith

