### PR TITLE
Record column

### DIFF
--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -198,7 +198,7 @@ class BaseOperation:
             and target_metadata.is_supp
         ):
             domain_for_library = "SUPPQUAL"
-        elif target_metadata and target_metadata.name.lower().startswith("REL"):
+        elif target_metadata and "rel" in target_metadata.name.lower():
             domain_for_library = target_metadata.name
         else:
             domain_for_library = self.params.domain

--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -172,18 +172,51 @@ class BaseOperation:
         )
 
     def _get_grouping_columns(self) -> List[str]:
-        return (
-            self.params.grouping
-            if not self.params.grouping_aliases
-            else [
-                (
-                    self.params.grouping_aliases[i]
-                    if 0 <= i < len(self.params.grouping_aliases)
-                    else v
-                )
-                for i, v in enumerate(self.params.grouping)
-            ]
-        )
+        if any(item.startswith("$") for item in self.params.grouping):
+            return self._expand_operation_results_in_grouping(self.params.grouping)
+        else:
+            return (
+                self.params.grouping
+                if not self.params.grouping_aliases
+                else [
+                    (
+                        self.params.grouping_aliases[i]
+                        if 0 <= i < len(self.params.grouping_aliases)
+                        else v
+                    )
+                    for i, v in enumerate(self.params.grouping)
+                ]
+            )
+
+    def _expand_operation_results_in_grouping(self, grouping_list):
+        expanded = []
+        for item in grouping_list:
+            if item.startswith("$") and item in self.evaluation_dataset.columns:
+                operation_col = self.evaluation_dataset[item]
+                first_val = operation_col.iloc[0]
+                if operation_col.astype(str).nunique() == 1:
+                    if isinstance(first_val, (list, tuple)):
+                        expanded.extend(first_val)
+                    else:
+                        expanded.append(item)
+                else:
+                    expanded.extend(self._collect_values_from_column(operation_col))
+            else:
+                expanded.append(item)
+        return list(dict.fromkeys(expanded))
+
+    def _collect_values_from_column(self, operation_col):
+        seen = []
+        for val in operation_col:
+            if val is not None:
+                if isinstance(val, (list, tuple)):
+                    for v in val:
+                        if v not in seen:
+                            seen.append(v)
+                else:
+                    if val not in seen:
+                        seen.append(val)
+        return seen
 
     def _get_variables_metadata_from_standard(self) -> List[dict]:
         # TODO: Update to handle other standard types: adam, cdash, etc.

--- a/cdisc_rules_engine/operations/record_count.py
+++ b/cdisc_rules_engine/operations/record_count.py
@@ -22,12 +22,9 @@ class RecordCount(BaseOperation):
             result = len(filtered)
         if self.params.grouping:
             self.params.target = "size"
-            if isinstance(self.params.grouping, list):
-                effective_grouping = self._build_effective_grouping()
-            else:
-                effective_grouping = self.params.grouping
+            effective_grouping, all_na_cols = self._build_effective_grouping()
             group_df = self.params.dataframe.get_grouped_size(
-                effective_grouping, as_index=False
+                effective_grouping, as_index=False, dropna=False
             )
             if filtered is not None:
                 group_df = (
@@ -40,29 +37,43 @@ class RecordCount(BaseOperation):
                     .fillna(0)
                     .astype({self.params.target: int64})
                 )
-            if isinstance(self.params.grouping, list):
-                missing_cols = [
-                    col for col in self.params.grouping if col not in group_df.columns
-                ]
-                for col in missing_cols:
-                    original_col = self.params.dataframe[col]
-                    group_df[col] = None
-                    group_df[col] = group_df[col].astype(original_col.dtype)
+            for col, original_value in all_na_cols.items():
+                group_df[col] = original_value
+                group_df[col] = group_df[col].astype(self.params.dataframe[col].dtype)
             return group_df
         return result
 
-    def _build_effective_grouping(self) -> list:
+    def _build_effective_grouping(self) -> tuple[list, dict]:
+        """
+        Build effective grouping by expanding operation results used to group and track all-NA columns to revert them.
+        NA columns are completely empty and pandas converts them to NaN in the grouping.
+        Returns: (effective_grouping, all_na_cols)
+        """
+        grouping_cols = (
+            self.params.grouping
+            if isinstance(self.params.grouping, list)
+            else [self.params.grouping]
+        )
         effective_grouping = []
-        for col in self.params.grouping:
+        for col in grouping_cols:
             if col in self.params.dataframe.columns:
                 sample_val = self.params.dataframe[col].iloc[0]
                 if isinstance(sample_val, (list, tuple)):
-                    effective_grouping.extend(
-                        [c for c in sample_val if c in self.params.dataframe.columns]
-                    )
-                elif not self.params.dataframe[col].isna().all():
+                    # This is an operation result - expand the list
+                    effective_grouping.extend(sample_val)
+                else:
                     effective_grouping.append(col)
             else:
                 effective_grouping.append(col)
-        # remove duplicates while preserving order
-        return list(dict.fromkeys(effective_grouping))
+        effective_grouping = list(dict.fromkeys(effective_grouping))
+        all_na_cols = {}
+        for col in effective_grouping:
+            if col in self.params.dataframe.columns:
+                if self.params.dataframe[col].isna().all():
+                    all_na_cols[col] = None
+                elif (
+                    self.params.dataframe[col].dtype == "object"
+                    and self.params.dataframe[col].fillna("").str.strip().eq("").all()
+                ):
+                    all_na_cols[col] = ""
+        return effective_grouping, all_na_cols

--- a/resources/schema/CORE-base.json
+++ b/resources/schema/CORE-base.json
@@ -176,6 +176,21 @@
     "VariableName": {
       "pattern": "^(--[A-Z0-9]{1,6}|[A-Z][A-Z0-9]{0,7})$",
       "type": "string"
+    },
+    "OperationResultId": {
+      "pattern": "^\\$[A-Za-z_][A-Za-z0-9_]*$",
+      "type": "string"
+    },
+    "VariableReference": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/VariableName"
+        },
+        {
+          "$ref": "#/$defs/OperationResultId"
+        }
+      ],
+      "description": "Can reference either a dataset variable name or an operation result"
     }
   },
   "$id": "https://cdisc.org/CORE-base.json",

--- a/resources/schema/Operations.json
+++ b/resources/schema/Operations.json
@@ -471,13 +471,13 @@
     },
     "group": {
       "items": {
-        "$ref": "CORE-base.json#/$defs/VariableName"
+        "$ref": "CORE-base.json#/$defs/VariableReference"
       },
       "type": "array"
     },
     "group_aliases": {
       "items": {
-        "$ref": "CORE-base.json#/$defs/VariableName"
+        "$ref": "CORE-base.json#/$defs/VariableReference"
       },
       "type": "array"
     },


### PR DESCRIPTION
this PR does a few things:
- updates schema so grouping can be an operation result $TIMING_VARIABLES
- update record count to process TIMING VARIABLES as the grouping:
  -  this involves IDing an operation result as the grouping (done via checking if it is a column name and if it starts with '$')
  -  we then parse the column to get the list of columns from it that we want to use for the grouping; we also keep track of blank ('' or None for all columns) as pd will replace these with NaN.
  -  group on this list of columns
  -  restore the '' / None values to the columns that became NaN when grouped
-   when the grouping is restored, engine tries to merge on the target which is $TIMING_VARIABLES.  Logic is added to ID if it is an operation result (done via checking if it is a column name and if it starts with '$');  We then parse the operation result and return the columns to replace the grouping ID so that the merge can be performed between the original dataset and the grouped result

to test: 
[Rule_underscores.json](https://github.com/user-attachments/files/20954374/Rule_underscores.json)

(I believe the rule may need to be altered, my logic: 
[Rule_underscores.json](https://github.com/user-attachments/files/20955726/Rule_underscores.json)

 negative:
[DatasetsN.json](https://github.com/user-attachments/files/20954382/DatasetsN.json)
[DatasetsN2.json](https://github.com/user-attachments/files/20955741/DatasetsN2.json)

positive
[DatasetsP.json](https://github.com/user-attachments/files/20955742/DatasetsP.json)
[DatasetsP2.json](https://github.com/user-attachments/files/20955743/DatasetsP2.json)
