### PR TITLE
column_prefix bug

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -101,7 +101,7 @@ class DataframeType(BaseType):
     def replace_prefix(self, value: str) -> Union[str, Any]:
         if isinstance(value, str):
             for prefix, replacement in self.column_prefix_map.items():
-                if value.startswith(prefix):
+                if value.startswith(prefix) and replacement is not None:
                     return value.replace(prefix, replacement, 1)
         return value
 


### PR DESCRIPTION
rule: cg0028
[Datasets.json](https://github.com/user-attachments/files/21036973/Datasets.json)
[Rule_underscores.json](https://github.com/user-attachments/files/21036974/Rule_underscores.json)

the rule for SUPPEC thows an error 
![image](https://github.com/user-attachments/assets/7e172f0e-f0be-4616-a0bd-a97a469bf77b)

this occurs because 
```
def replace_prefix(self, value: str) -> Union[str, Any]:
        if isinstance(value, str):
            for prefix, replacement in self.column_prefix_map.items():
                if value.startswith(prefix):
                    return value.replace(prefix, replacement, 1)
        return value
```
the column prefix map for supp is called during dataframe operation.  The column prefix is created using dataset_metadata.domain and there is no domain property for Supps.  I added a None check for this and to otherwise return the value (no column in SUPPQUAL should need a prefix change).
