### PR TITLE
add supp logic

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -162,10 +162,8 @@ class DataframeType(BaseType):
         equal_to       Populated   Populated   A == B
         """
         if value_is_reference:
-            dynamic_column_name = row[comparator] if comparator in row else None
-            comparison_data = (
-                row[dynamic_column_name] if dynamic_column_name in row else None
-            )
+            dynamic_column_name = row[comparator]
+            comparison_data = row[dynamic_column_name]
         else:
             comparison_data = (
                 comparator
@@ -209,10 +207,8 @@ class DataframeType(BaseType):
         not_equal_to   Populated   Populated   A != B
         """
         if value_is_reference:
-            dynamic_column_name = row[comparator] if comparator in row else None
-            comparison_data = (
-                row[dynamic_column_name] if dynamic_column_name in row else None
-            )
+            dynamic_column_name = row[comparator]
+            comparison_data = row[dynamic_column_name]
         else:
             comparison_data = (
                 comparator

--- a/cdisc_rules_engine/utilities/dataset_preprocessor.py
+++ b/cdisc_rules_engine/utilities/dataset_preprocessor.py
@@ -45,7 +45,7 @@ class DatasetPreprocessor:
         self._data_service = data_service
         self._rule_processor = RuleProcessor(self._data_service, cache_service)
 
-    def preprocess(
+    def preprocess(  # noqa
         self, rule: dict, datasets: Iterable[SDTMDatasetMetadata]
     ) -> DatasetInterface:
         """
@@ -72,11 +72,15 @@ class DatasetPreprocessor:
                     and self._dataset_metadata.is_supp
                     and self._dataset_metadata.rdomain
                 ):
-                    file_infos: list[SDTMDatasetMetadata] = [
-                        item
-                        for item in datasets
-                        if (item.domain == self._dataset_metadata.rdomain)
-                    ]
+                    if (
+                        domain_name == "SUPP--"
+                        or domain_name == self._dataset_metadata.name
+                    ):
+                        file_infos: list[SDTMDatasetMetadata] = [
+                            item
+                            for item in datasets
+                            if (item.domain == self._dataset_metadata.rdomain)
+                        ]
                 # find parent of other datasets
                 elif (
                     domain_name == self._dataset_metadata.domain


### PR DESCRIPTION
This PR allows for SUPP-- to be used as the match when the child property is given.
[Rule_underscores.json](https://github.com/user-attachments/files/21046075/Rule_underscores.json)
see above rule.
It also resolves an issues with is_reference where None was added instead of raising an error.

to test: run above rule against cg0371 data.
[Rule_underscores2.json](https://github.com/user-attachments/files/21046089/Rule_underscores2.json)
this rule can also be used as it only specifies SUPPDM, not SUPPLB so a result is removed from report.  This will flag an error with the dataset and skip it.  (see logs)