### PR TITLE
Meddra bug

### DIFF
--- a/cdisc_rules_engine/models/dictionaries/meddra/meddra_validator.py
+++ b/cdisc_rules_engine/models/dictionaries/meddra/meddra_validator.py
@@ -119,8 +119,6 @@ class MedDRAValidator(BaseDictionaryValidator):
         """
         if isinstance(code, float):
             code_str = str(int(code))
-        elif isinstance(code, int):
-            code_str = str(code)
         else:
             code_str = str(code)
         term_dictionary = self.get_term_dictionary()

--- a/cdisc_rules_engine/models/dictionaries/meddra/meddra_validator.py
+++ b/cdisc_rules_engine/models/dictionaries/meddra/meddra_validator.py
@@ -117,6 +117,12 @@ class MedDRAValidator(BaseDictionaryValidator):
             True: The term is valid
             False: The term is not valid
         """
+        if isinstance(code, float):
+            code_str = str(int(code))
+        elif isinstance(code, int):
+            code_str = str(code)
+        else:
+            code_str = str(code)
         term_dictionary = self.get_term_dictionary()
         term_type = term_type.lower()
         if term_type not in TermTypes.values():
@@ -124,4 +130,4 @@ class MedDRAValidator(BaseDictionaryValidator):
                 f"{term_type} does not correspond to a MedDRA term type"
             )
 
-        return code in term_dictionary.get(term_type, {})
+        return code_str in term_dictionary.get(term_type, {})


### PR DESCRIPTION
There is an issue with the meddra logic specifically--since the CD is not alphanumeric as with other external dictionary codes, some sample data was made designating the AEBDSYCD as a number.  The cache is populated using string logic and thus the keys are strings.  I have added logic to check the type to allow for both character or number typing for the code so that an error does not occur when the cache lookup occurs.
![image](https://github.com/user-attachments/assets/70800752-4213-4c09-a074-f8012d6892f4)

to test: 
I have the test data I can send as I cannot paste XPT/asc files in github.  ae is the file with numeric code and should be positive data (no errors).  ae2 is negative data and should return issues as below.
![image](https://github.com/user-attachments/assets/d767d27c-b5eb-4f69-8fb1-e7f57668b8cb)
