### PR TITLE
CG0235

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -1,7 +1,7 @@
 from business_rules.operators import BaseType, type_operator
 from typing import Union, Any, List, Tuple
 from business_rules.fields import FIELD_DATAFRAME
-from business_rules.utils import (
+from cdisc_rules_engine.check_operators.helpers import (
     flatten_list,
     is_valid_date,
     vectorized_is_valid,
@@ -11,8 +11,8 @@ from business_rules.utils import (
     vectorized_is_in,
     vectorized_case_insensitive_is_in,
     apply_regex,
+    vectorized_compare_dates,
 )
-from cdisc_rules_engine.check_operators.helpers import vectorized_compare_dates
 
 from cdisc_rules_engine.constants import NULL_FLAVORS
 from cdisc_rules_engine.utilities.utils import dates_overlap, parse_date
@@ -134,8 +134,7 @@ class DataframeType(BaseType):
         if column_exists:
             return self.value.convert_to_series([True] * len(self.value))
         else:
-            exists_in_nested = self.value.apply(check_row, axis=1).any()
-            return self.value.convert_to_series([exists_in_nested] * len(self.value))
+            return self.value.convert_to_series(self.value.apply(check_row, axis=1))
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)

--- a/cdisc_rules_engine/check_operators/helpers.py
+++ b/cdisc_rules_engine/check_operators/helpers.py
@@ -1,7 +1,84 @@
 from datetime import datetime
+import re
 import numpy as np
-from dateutil.parser import parse
+from dateutil.parser import parse, isoparse
 import pytz
+from cdisc_rules_engine.services import logger
+import traceback
+
+
+# Date regex pattern for validation
+date_regex = re.compile(
+    r"^((-?[0-9]{4}|-)(-(1[0-2]|0[1-9]|-)(-(3[01]|0[1-9]|[12][0-9]|-)"
+    r"(T(2[0-3]|[01][0-9]|-)(:([0-5][0-9]|-)((:([0-5][0-9]|-))?(\.[0-9]+)?"
+    r"((Z|[+-](:2[0-3]|[01][0-9]):[0-5][0-9]))?)?)?)?)?)?)(\/((-?[0-9]{4}|-)"
+    r"(-(1[0-2]|0[1-9]|-)(-(3[01]|0[1-9]|[12][0-9]|-)(T(2[0-3]|[01][0-9]|-)"
+    r"(:([0-5][0-9]|-)((:([0-5][0-9]|-))?(\.[0-9]+)?((Z|[+-](:2[0-3]|[01][0-9])"
+    r":[0-5][0-9]))?)?)?)?)?)?))?$"
+)
+
+
+def is_valid_date(date_string: str) -> bool:
+    if date_string is None:
+        return False
+    try:
+        isoparse(date_string)
+    except Exception as e:
+        uncertainty_substrings = ["/", "--", "-:"]
+        if any([substr in date_string for substr in uncertainty_substrings]):
+            # date_string contains uncertainty
+            # will not parse with isoparse
+            return date_regex.match(date_string) is not None
+        else:
+            logger.error(
+                f"Error with date parsing: {str(e)}, "
+                f"traceback: {traceback.format_exc()}"
+            )
+            return False
+    return date_regex.match(date_string) is not None
+
+
+def is_valid_duration(duration: str, negative) -> bool:
+    if not isinstance(duration, str):
+        duration = str(duration)
+    if negative:
+        pattern = (
+            r"^[-]?P(?!$)(?:(?:(\d+(?:[.,]\d*)?Y)?[,]?(\d+(?:[.,]\d*)?M)?[,]?"
+            r"(\d+(?:[.,]\d*)?D)?[,]?(T(?=\d)(?:(\d+(?:[.,]\d*)?H)?[,]?"
+            r"(\d+(?:[.,]\d*)?M)?[,]?(\d+(?:[.,]\d*)?S)?)?)?)|(\d+(?:[.,]\d*)?W))$"
+        )
+    else:
+        pattern = (
+            r"^P(?!$)(?:(?:(\d+(?:[.,]\d*)?Y)?[,]?(\d+(?:[.,]\d*)?M)?[,]?"
+            r"(\d+(?:[.,]\d*)?D)?[,]?(T(?=\d)(?:(\d+(?:[.,]\d*)?H)?[,]?"
+            r"(\d+(?:[.,]\d*)?M)?[,]?(\d+(?:[.,]\d*)?S)?)?)?)|(\d+(?:[.,]\d*)?W))$"
+        )
+    match = re.match(pattern, duration)
+    if not match:
+        return False
+
+    years, months, days, time_designator, hours, minutes, seconds, weeks = (
+        match.groups()
+    )
+
+    if time_designator and not any([hours, minutes, seconds]):
+        return False
+
+    components = [
+        c
+        for c in [years, months, weeks, days, hours, minutes, seconds]
+        if c is not None
+    ]
+
+    # Check if decimal is only in the smallest unit
+    decimal_found = False
+    for i, component in enumerate(components):
+        if "." in component or "," in component:
+            if decimal_found or i != len(components) - 1:
+                return False
+            decimal_found = True
+
+    return True
 
 
 def get_year(date_string: str):
@@ -69,6 +146,40 @@ def get_date(date_string: str):
         return utc.localize(date)
 
 
+def is_complete_date(date_string: str) -> bool:
+    try:
+        datetime.fromisoformat(date_string)
+    except Exception as e:
+        try:
+            datetime.fromisoformat(date_string.replace("Z", "+00:00"))
+        except Exception as e:
+            logger.error(
+                f"Error with date parsing: {str(e)}, "
+                f"traceback: {traceback.format_exc()}"
+            )
+            return False
+        logger.error(
+            f"Error with date parsing: {str(e)}, "
+            f"traceback: {traceback.format_exc()}"
+        )
+        return True
+    return True
+
+
+def get_dict_key_val(dict_to_get: dict, key):
+    return dict_to_get.get(key)
+
+
+def is_in(value, values):
+    if values is None:
+        return False
+    return value in values
+
+
+def case_insensitive_is_in(value, values):
+    return str(value).lower() in str(values).lower()
+
+
 def compare_dates(component, target, comparator, operator):
     if not target or not comparator:
         # Comparison should return false if either is empty or None
@@ -80,4 +191,31 @@ def compare_dates(component, target, comparator, operator):
         )
 
 
+def apply_regex(regex: str, val: str):
+    result = re.findall(regex, val)
+    if result:
+        return result[0]
+    else:
+        return None
+
+
+def flatten_list(data, list):
+    for item in list:
+        if isinstance(item, list):
+            yield from flatten_list(data, item)
+        elif item in data and isinstance(data[item].iloc[0], list):
+            for val in data[item].iloc[0]:
+                yield val
+        else:
+            yield item
+
+
+vectorized_apply_regex = np.vectorize(apply_regex)
+vectorized_is_complete_date = np.vectorize(is_complete_date)
 vectorized_compare_dates = np.vectorize(compare_dates)
+vectorized_is_valid = np.vectorize(is_valid_date)
+vectorized_is_valid_duration = np.vectorize(is_valid_duration)
+vectorized_get_dict_key = np.vectorize(get_dict_key_val)
+vectorized_is_in = np.vectorize(is_in)
+vectorized_case_insensitive_is_in = np.vectorize(case_insensitive_is_in)
+vectorized_len = np.vectorize(len)

--- a/cdisc_rules_engine/rules_engine.py
+++ b/cdisc_rules_engine/rules_engine.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from typing import Iterable, List, Union
-
+from dateutil.parser._parser import ParserError
 from business_rules import export_rule_data
 from business_rules.engine import run
 import os
@@ -389,7 +389,7 @@ class RulesEngine:
                 message="Rule contains invalid operator",
             )
             message = "rule execution error"
-        elif isinstance(exception, KeyError):
+        elif isinstance(exception, (KeyError, ParserError)):
             error_obj = FailedValidationEntity(
                 dataset=os.path.basename(dataset_path),
                 error="Column not found in data",


### PR DESCRIPTION
This PR addresses two issues:
- it moves the operator helpers and vectorized operations from business_rules into engine's helpers/operators file for easier management
- it corrects an error where isoparse is unable to parse a column when it doesnt exist--this was added to the missing column errors.
before:
<img width="2259" height="1229" alt="image" src="https://github.com/user-attachments/assets/599ab14b-6cc1-4f76-8e61-47b4539a0640" />
after:
<img width="2222" height="1274" alt="image" src="https://github.com/user-attachments/assets/e06e9140-0f47-4afe-ad14-ea455c0a4f64" />

To test: run editor locally and test cg0235 negative data
