### PR TITLE
dask readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ $env:DATASET_SIZE_THRESHOLD=0; core.exe validate -rest -of -config -commands
 ### Linux/Mac (Bash)
 
 ```bash
-DATASET_SIZE_THRESHOLD=0 ./core.exe -rest -of -config -commands
+DATASET_SIZE_THRESHOLD=0 ./core -rest -of -config -commands
 ```
 
 ## .env File (Alternative)


### PR DESCRIPTION
I added an update to our docset outlining setting the dataset size limit for dask as it came up in emails.  I have tested both windows commands as well as the .env strategy for implementation coercion to dask.  @RamilCDISC I was hoping you could test the linux/max bash command which should work.  
.env
<img width="1796" height="121" alt="image" src="https://github.com/user-attachments/assets/61e9032f-efc6-4601-9c82-ed976330bc83" />
powershell command
<img width="1798" height="117" alt="image" src="https://github.com/user-attachments/assets/fa6aa373-65f7-4d2e-b7d8-aeef6925a21b" />
windows command prompt
<img width="1715" height="160" alt="image" src="https://github.com/user-attachments/assets/2fb49027-9b85-486d-b343-8a00b34fcb01" />
