### PR TITLE
update null handling

### DIFF
--- a/cdisc_rules_engine/constants/__init__.py
+++ b/cdisc_rules_engine/constants/__init__.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 # a message like: [INFO 2021-12-29 17:10:26,575 - module.py:44] - Log Message
 LOG_FORMAT: str = "[%(levelname)s %(asctime)s - %(filename)s:%(lineno)s] - %(message)s"
 XPT_LABEL_PATTERN: str = (
@@ -14,4 +16,4 @@ XPT_MODIFIED_DATE_PATTERN: str = (
 
 REPORT_TEMPLATE_PATH = "/templates/report-template.xlsx"
 
-NULL_FLAVORS = ["", None, {None}, [], {}]
+NULL_FLAVORS = ["", None, {None}, [], {}, np.nan]

--- a/cdisc_rules_engine/models/actions.py
+++ b/cdisc_rules_engine/models/actions.py
@@ -1,5 +1,4 @@
 from typing import List, Optional, Set, Hashable
-
 from os import path
 import pandas as pd
 from business_rules.actions import BaseActions, rule_action
@@ -137,9 +136,21 @@ class COREActions(BaseActions):
             }
 
             # Create the initial error
-            error_value = (
-                dict(errors_df.iloc[0].to_dict()) if not all_targets_missing else {}
-            )
+            if not all_targets_missing:
+                raw_error_dict = errors_df.iloc[0].to_dict()
+                error_value = {}
+                for key, value in raw_error_dict.items():
+                    if isinstance(value, list):
+                        error_value[key] = [
+                            None if (val in NULL_FLAVORS or pd.isna(val)) else val
+                            for val in value
+                        ]
+                    else:
+                        error_value[key] = (
+                            None if (value in NULL_FLAVORS or pd.isna(value)) else value
+                        )
+            else:
+                error_value = {}
 
             # Add missing variables to the error value
             if missing_vars:


### PR DESCRIPTION
this PR makes null handling consistent across reporting- FB 3205 avoids getting into our current null handling given its sensitivity.  This resulted in a 500 error when executing the negative data with the rule.  This PR makes the NaN handling consistent so as to prevent these errors.

use FB3205 and negative data to test