### PR TITLE
updated inconsistent_across_dataset

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -1049,10 +1049,19 @@ class DataframeType(BaseType):
                     grouping_cols.append(col_name)
         df_check = self.value[grouping_cols + [target]].copy()
         df_check = df_check.fillna("_NaN_")
-        results = pd.Series(True, index=df_check.index)
-        for name, group in df_check.groupby(grouping_cols):
-            if group[target].nunique() == 1:
-                results[group.index] = False
+        results = pd.Series(False, index=df_check.index)
+        for name, group in df_check.groupby(grouping_cols, dropna=False):
+            if group[target].nunique() > 1:
+                value_counts = group[target].value_counts()
+                max_count = value_counts.max()
+                # if same amount of inconsistency values, flag all
+                most_common_values = value_counts[value_counts == max_count]
+                if len(most_common_values) > 1:
+                    results[group.index] = True
+                else:
+                    most_common_value = most_common_values.index[0]
+                    minority_rows = group[group[target] != most_common_value]
+                    results[minority_rows.index] = True
         return results
 
     @log_operator_execution


### PR DESCRIPTION
this PR updates the inconsistent across dataset operator.  The PR checks if there is a clear majority and flags the minority grouping if there are 2 groupings.  This was a problem with the test suite as there was 1 --ELTM value that differed from the other 238 values.  
The logic now checks how many groupings there are, if there is one that is the majority-it flags the minorities.  If there is a tie, it flags all.

to test: 
 run CG0241 against cert data

copilot summary:  
This pull request refines the logic for detecting inconsistencies in datasets and enhances test coverage to validate edge cases. The main changes include updating the `is_inconsistent_across_dataset` method to handle ties and clear majorities more effectively, adjusting existing tests to align with the updated logic, and adding new test cases to ensure robustness.

### Changes to inconsistency detection logic:
* Updated `is_inconsistent_across_dataset` in `dataframe_operators.py` to handle cases with ties (e.g., equal counts of inconsistent values) and clear majorities. The method now flags all rows in case of a tie and only the minority rows when a clear majority exists.

### Adjustments to existing tests:
* Modified expected results in `test_is_not_ordered_set` and `test_is_inconsistent_across_dataset` to reflect the updated logic for detecting inconsistencies. [[1]](diffhunk://#diff-1cb00509324ff8def78fdb76e2129bf17ab2702f0afdba72ab3dd217d64e482dL101-R101) [[2]](diffhunk://#diff-1cb00509324ff8def78fdb76e2129bf17ab2702f0afdba72ab3dd217d64e482dL127-R127)

### New test cases for edge scenarios:
* Added `test_is_inconsistent_clear_majority` to validate behavior when a clear majority exists in a group.
* Added `test_is_inconsistent_perfect_tie` to verify correct handling of perfect ties within groups.
* Added `test_is_inconsistent_three_way_tie` to test scenarios with three-way ties in group values.