### PR TITLE
error

### DIFF
--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -254,7 +254,7 @@ def load_specified_rules(
         if rule in standard_rules:
             valid_rule_ids.add(rule)
         else:
-            engine_logger.error(
+            raise ValueError(
                 f"The rule specified '{rule}' is not in the standard {standard} and version {version}"
             )
     rules = []


### PR DESCRIPTION
It was brought up with the 2 rule ids which were unpublished and deleted--if a rule is specified and its not in the cache when being grabbed by the ID-- it should have an error thrown, not a log.