### PR TITLE
Issue 1233: Performance improvements using native Python traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# Custom Local
+*.xlsx
+cProfile.txt
+compare_cprofile.py
+output*.txt
+pilot_usdm.json
+usdm2xl.py
+usdm2xl_jsonata.py
+cProfile_results/
+
 # Editors
 .vscode/
 .idea/


### PR DESCRIPTION
[I forked cdisc-org/cdisc-rules-engine:main into my repo and created the branch pendingintent/cdisc-rules-engine:issue_1233.  Here I made the changes to usdm_data_service.py and ran my profiling.  In the interest of not recreating my branch in cdisc-org/cdisc-rules-engine, I have created the Pull request from my repo branch.  If you would like me to change this, just let me know.]

A native Python traversal function _traverse_path has been added to USDMDataService, and the __get_dataset method now uses it instead of jsonpath-ng.

The methods __get_record_metadata, __get_parent, and __get_closest_non_list_ancestor have been refactored to work with the new native node objects, removing any dependency on .context or DatumInContext.

New summary cProfile results are:

12718877 function calls (12282698 primitive calls) in 3.233 seconds

This is a significant improvement over the previous version of issue1233/usdm_data_service.py as well as the jsonata implementation.

Investigated removing the jsonpath-ng dependency altogether, but dove down a rabbit hole that seems quite deep.  I attempted to use copilot to help resolve the errors generated but, in the end, received:

> This is a data issue, not a code bug. Your code is correctly reporting the missing key and showing the available keys for debugging.
> 
> How to resolve:
> 
> Check your input JSON and the logic that builds dataset_content_index and content_paths.
> Make sure the path 'lines[0]' is valid for your data. If not, update your metadata or fix the logic that generates these paths.

I am using the file pilot_usdm.json file for my code and did not want to change to another version with which I am unfamiliar.  I did not dive any further into the issue and decided to leave the remaining jsonpath-ng dependencies in place.

[pilot_usdm.json](https://github.com/user-attachments/files/21475821/pilot_usdm.json)
 
[cProfile_branch_issue1233_20250728_1331.txt](https://github.com/user-attachments/files/21475674/cProfile_branch_issue1233_20250728_1331.txt)

[output_20250728_151134.txt](https://github.com/user-attachments/files/21475866/output_20250728_151134.txt)

