### PR TITLE
update reporting

### DIFF
--- a/cdisc_rules_engine/services/reporting/base_report.py
+++ b/cdisc_rules_engine/services/reporting/base_report.py
@@ -124,10 +124,13 @@ class BaseReport(ABC):
                         "row": error.get("row", ""),
                         "SEQ": error.get("SEQ", ""),
                     }
-                    values = [
-                        str(error.get("value", {}).get(variable))
-                        for variable in variables
-                    ]
+                    values = []
+                    for variable in variables:
+                        raw_value = error.get("value", {}).get(variable)
+                        if raw_value is None:
+                            values.append(None)
+                        else:
+                            values.append(str(raw_value))
                     processed_values = self.process_values(values, excel)
                     if self._item_type == "list":
                         error_item["variables"] = ", ".join(variables)
@@ -144,8 +147,10 @@ class BaseReport(ABC):
             return "null" if excel else ["null"]
         processed_values = []
         for value in values:
+            if value is None:
+                processed_values.append("null")
             value = value.strip()
-            if value == "" or value.lower() == "none" or value.lower() == "nan":
+            if value == "" or value.lower() == "nan":
                 processed_values.append("null")
             else:
                 processed_values.append(value)


### PR DESCRIPTION
this PR updates None handling the rule report.  The issue encountered by Els is described:
For CG0265: First the rule filters only completed TSVAL, and then completed TSVALCD. And then it checks the 1-1 relationship. But still we have a study with a TS where TSVAL for TSPARMCD = TCNRTL is ‘NONE’ with TSVALCD = C411132 is flagged, while this is really the only combination. When looking at the output report, it reports TSVAL = NONE as 'null'. So maybe something is going wrong in the translation from NONE to accidentally 'null' and the filter for 'non_empty' is then not taken into account? Because if I remove the TSVAL/TSVALCD = non_empty filters, then there are different TSVALCDs for the same TSVAL.
<img width="945" height="50" alt="image" src="https://github.com/user-attachments/assets/b886107b-e0d8-4825-b1ad-85ed4495121b" />
<img width="945" height="52" alt="image" src="https://github.com/user-attachments/assets/fd4238f5-ef93-448b-afc8-dd71ba07d29b" />

i made test data with TSVAL of 'None'.
[Datasets.json](https://github.com/user-attachments/files/21514753/Datasets.json)
