### PR TITLE
Docker

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,11 +1,11 @@
 name: Build and Push Docker Image
 on:
-  workflow_run:
-    workflows: ["Release CORE Rules Engine"]
-    types:
-      - completed
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: "Version tag for the Docker image"
 jobs:
   check-if-latest:
     runs-on: ubuntu-latest
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.check-if-latest.outputs.version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,3 +108,10 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
+
+  build-and-push-docker:
+    needs: [create-release-assets, deploy-PyPi]
+    uses: ./.github/workflows/docker_release.yml
+    with:
+      version: ${{ github.event.release.tag_name }}
+    secrets: inherit

--- a/dockerfile
+++ b/dockerfile
@@ -1,24 +1,36 @@
 FROM ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app
-# Install dependencies
+
+# Install dependencies (keeping original tools)
 RUN apt-get update && apt-get install -y \
     software-properties-common \
     curl \
     unzip \
     jq \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get install -y \
     python3.12 \
-    python3.12-distutils \
+    python3.12-venv \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
-# Download the latest release
-RUN LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest | jq -r '.assets[] | select(.name == "core-ubuntu-latest.zip") | .browser_download_url') \
-    && curl -L -o core-ubuntu-latest.zip "$LATEST_RELEASE_URL" \
+
+# Download with better retry options but same structure
+RUN LATEST_RELEASE_URL=$(curl -s --fail --retry 3 https://api.github.com/repos/cdisc-org/cdisc-rules-engine/releases/latest | jq -r '.assets[] | select(.name == "core-ubuntu-latest.zip") | .browser_download_url') \
+    && echo "Downloading from: $LATEST_RELEASE_URL" \
+    && curl -L \
+        --fail \
+        --retry 10 \
+        --retry-delay 5 \
+        --retry-max-time 1800 \
+        --retry-connrefused \
+        --retry-all-errors \
+        --connect-timeout 30 \
+        -C - \
+        -o core-ubuntu-latest.zip \
+        "$LATEST_RELEASE_URL" \
     && unzip core-ubuntu-latest.zip -d cdisc-rules-engine \
     && rm core-ubuntu-latest.zip \
     && mv cdisc-rules-engine/* . \
     && rmdir cdisc-rules-engine \
     && chmod +x /app/core
+
 CMD ["/bin/sh"]


### PR DESCRIPTION
- updated gitaction docker image build and deploy trigger as it did not trigger with release action.
- updated dockerile to add http protocol/added reconnect logic to executable download as well as fixing python 3.12 dependancy issue with ubuntu latest

This pull request introduces changes to streamline the Docker image build and release process by transitioning to a reusable workflow, improving Dockerfile dependency management, and enhancing the download process. Key changes include modifying the workflow trigger mechanism, integrating the Docker build workflow into the release process, and updating the Dockerfile for better reliability and maintainability.

### Workflow Improvements
* [`.github/workflows/docker_release.yml`](diffhunk://#diff-7a9e7957be8c75423cf2952e32b3710390191525a45d41e256f337b3809675b8L3-R8): Changed the workflow trigger from `workflow_run` to `workflow_call` to allow reusability. Added an input parameter for the Docker image version.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R111-R117): Integrated the reusable Docker build workflow (`docker_release.yml`) into the release process, ensuring it runs after creating release assets and deploying to PyPI.

### Dockerfile Enhancements
* [`dockerfile`](diffhunk://#diff-254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacfL4-R35): Improved dependency installation by replacing `python3.12-distutils` with `python3.12-venv` and adding `python3-pip`. Enhanced the release download process with retry logic for better reliability.