### PR TITLE
update

### DIFF
--- a/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/base_dataset_builder.py
@@ -101,7 +101,9 @@ class BaseDatasetBuilder:
             )
         else:
             # single dataset. the most common case
-            dataset: DatasetInterface = self.data_service.get_dataset(self.dataset_path)
+            dataset: DatasetInterface = self.data_service.get_dataset(
+                dataset_name=self.dataset_path
+            )
             dataset = tag_source(dataset, self.dataset_metadata)
         return dataset
 
@@ -211,17 +213,14 @@ class BaseDatasetBuilder:
                     href = first_codelist["href"]
                     codelist_code = href.split("/")[-1]
                     variable["ccode"] = codelist_code
-        # Rename columns:
-        column_name_mapping = {
-            "ordinal": "order_number",
-            "simpleDatatype": "data_type",
-        }
+            if "role" not in variable:
+                variable["role"] = ""
+            if "core" not in variable:
+                variable["core"] = ""
 
         for var in variables:
-            var["name"] = var["name"].replace("--", self.dataset_metadata.domain)
-            for key, new_key in column_name_mapping.items():
-                if key in var:
-                    var[new_key] = var.pop(key)
+            replacement_domain = self.dataset_metadata.domain or ""
+            var["name"] = var["name"].replace("--", replacement_domain)
 
         dataset = self.dataset_implementation.from_records(variables)
         dataset.data = dataset.data.add_prefix("library_variable_")

--- a/cdisc_rules_engine/dataset_builders/define_variables_with_library_metadata.py
+++ b/cdisc_rules_engine/dataset_builders/define_variables_with_library_metadata.py
@@ -37,9 +37,18 @@ class DefineVariablesWithLibraryMetadataDatasetBuilder(BaseDatasetBuilder):
             self.get_define_xml_variables_metadata()
         )
         library_variables_metadata = self.get_library_variables_metadata()
+        column_name_mapping = {
+            "library_variable_ordinal": "library_variable_order_number",
+            "library_variable_simpleDatatype": "library_variable_data_type",
+        }
+        if hasattr(library_variables_metadata, "data"):
+            library_data = library_variables_metadata.data
+        else:
+            library_data = library_variables_metadata._data
+        library_data = library_data.rename(columns=column_name_mapping)
 
         data = variable_metadata.merge(
-            library_variables_metadata.data,
+            library_data,
             how="left",
             left_on="define_variable_name",
             right_on="library_variable_name",

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_and_library_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_with_define_and_library_dataset_builder.py
@@ -29,6 +29,7 @@ class VariablesMetadataWithDefineAndLibraryDatasetBuilder(BaseDatasetBuilder):
         define_variable_codelist_coded_values,
         define_variable_codelist_coded_codes,
         define_variable_mandatory,
+        variable_has_empty_values
         library_variable_name,
         library_variable_label,
         library_variable_data_type,
@@ -45,6 +46,15 @@ class VariablesMetadataWithDefineAndLibraryDatasetBuilder(BaseDatasetBuilder):
             variable_metadata
         )
         library_metadata: DatasetInterface = self.get_library_variables_metadata()
+        column_name_mapping = {
+            "library_variable_ordinal": "library_variable_order_number",
+            "library_variable_simpleDatatype": "library_variable_data_type",
+        }
+        if hasattr(library_metadata, "data"):
+            library_data = library_metadata.data
+        else:
+            library_data = library_metadata._data
+        library_data = library_data.rename(columns=column_name_mapping)
         dataset_contents = self.get_dataset_contents()
 
         # First merge: content metadata with define metadata
@@ -52,12 +62,22 @@ class VariablesMetadataWithDefineAndLibraryDatasetBuilder(BaseDatasetBuilder):
             define_metadata.data,
             left_on="variable_name",
             right_on="define_variable_name",
-            how="outer",
+            how="left",
         )
         # Second merge: add library metadata
         final_dataframe = merged_data.merge(
-            library_metadata.data,
-            how="outer",
+            library_data[
+                [
+                    "library_variable_name",
+                    "library_variable_label",
+                    "library_variable_data_type",
+                    "library_variable_role",
+                    "library_variable_core",
+                    "library_variable_ccode",
+                    "library_variable_order_number",
+                ]
+            ],
+            how="left",
             left_on="variable_name",
             right_on="library_variable_name",
         ).fillna("")

--- a/cdisc_rules_engine/dataset_builders/variables_metadata_with_library_metadata.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_with_library_metadata.py
@@ -18,6 +18,7 @@ class VariablesMetadataWithLibraryMetadataDatasetBuilder(BaseDatasetBuilder):
         library_variable_data_type,
         library_variable_role,
         library_variable_core,
+        library_variable_ccode,
         library_variable_order_number
         """
         # get dataset metadata and execute the rule
@@ -30,9 +31,27 @@ class VariablesMetadataWithLibraryMetadataDatasetBuilder(BaseDatasetBuilder):
         )
         dataset_contents = self.get_dataset_contents()
         library_variables_metadata = self.get_library_variables_metadata()
-
+        column_name_mapping = {
+            "library_variable_ordinal": "library_variable_order_number",
+            "library_variable_simpleDatatype": "library_variable_data_type",
+        }
+        if hasattr(library_variables_metadata, "data"):
+            library_data = library_variables_metadata.data
+        else:
+            library_data = library_variables_metadata._data
+        library_data = library_data.rename(columns=column_name_mapping)
         data = content_variables_metadata.merge(
-            library_variables_metadata.data,
+            library_data[
+                [
+                    "library_variable_name",
+                    "library_variable_label",
+                    "library_variable_data_type",
+                    "library_variable_role",
+                    "library_variable_core",
+                    "library_variable_ccode",
+                    "library_variable_order_number",
+                ]
+            ],
             how="left",
             left_on="variable_name",
             right_on="library_variable_name",

--- a/resources/schema/Rule_Type.md
+++ b/resources/schema/Rule_Type.md
@@ -407,11 +407,11 @@ Attach define xml metadata at variable level
 - `variable_format`
 - `variable_has_empty_values`
 - `library_variable_name`
-- `library_variable_order_number`
-- `library_variable_label`
-- `library_variable_data_type`
 - `library_variable_role`
+- `library_variable_label`
 - `library_variable_core`
+- `library_variable_order_number`
+- `library_variable_data_type`
 - `library_variable_ccode`
 
 ## Variables Metadata Check against Define XML and Library Metadata

--- a/tests/unit/test_dataset_builders/test_variables_metadata_with_library_metadata_dataset_builder.py
+++ b/tests/unit/test_dataset_builders/test_variables_metadata_with_library_metadata_dataset_builder.py
@@ -54,6 +54,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder(
             "library_variable_core": ["Req", "Req", "Req", "Req"],
             "library_variable_order_number": ["1", "2", "9", "8"],
             "library_variable_data_type": ["Char", "Char", "Char", "Num"],
+            "library_variable_ccode": ["C49487", "C69256", "C41331", "C25364"],
         }
     )
     mock_get_library_variables_metadata.return_value = PandasDataset(library_vars_data)
@@ -158,11 +159,12 @@ def test_variable_metadata_with_library_metadata_dataset_builder(
         "variable_order_number",
         "variable_data_type",
         "library_variable_name",
-        "library_variable_role",
         "library_variable_label",
-        "library_variable_core",
-        "library_variable_order_number",
         "library_variable_data_type",
+        "library_variable_role",
+        "library_variable_core",
+        "library_variable_ccode",
+        "library_variable_order_number",
         "variable_has_empty_values",
     ]
     assert result["library_variable_name"].tolist() == [
@@ -212,6 +214,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder_variable_only_i
             "library_variable_core": ["Req", "Req", "Req", "Perm"],
             "library_variable_order_number": ["1", "2", "9", "2000"],
             "library_variable_data_type": ["Char", "Char", "Char", "Num"],
+            "library_variable_ccode": ["C49487", "C69256", "C41331", "C25364"],
         }
     )
     mock_get_library_variables_metadata.return_value = PandasDataset(library_vars_data)
@@ -382,6 +385,7 @@ def test_variable_metadata_with_library_metadata_dataset_builder_variable_only_i
             "library_variable_label",
             "library_variable_core",
             "library_variable_data_type",
+            "library_variable_ccode",
             "variable_has_empty_values",
         ]
     )


### PR DESCRIPTION
This PR resolves a few issues:
- it moves the ordinal sorting in the dataset builder.  There was in-place renaming occuring which caused issues with repeated calls in QS or datasets split >1 time.
- resolves the issue from the ticket with the dataset builders not working
- fixes a bug where supp/relrec looks for the domain to replace its domain prefix but they do not have domains, this is replaced with a '' to circumvent this (no domain prefixed variables exist in these datasets)

to test:
run test suite data with sdtmig 3-2,  CORE-000398 as this uses the dataset builder from the ticket