### PR TITLE
dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -29,8 +29,6 @@ RUN LATEST_RELEASE_URL=$(curl -s --fail --retry 3 https://api.github.com/repos/c
         "$LATEST_RELEASE_URL" \
     && unzip core-ubuntu-latest.zip -d cdisc-rules-engine \
     && rm core-ubuntu-latest.zip \
-    && ls -la cdisc-rules-engine/ \
-    && ls -la cdisc-rules-engine/core/ \
     && mv cdisc-rules-engine/core/* . \
     && rm -rf cdisc-rules-engine \
     && chmod +x /app/core

--- a/dockerfile
+++ b/dockerfile
@@ -29,8 +29,10 @@ RUN LATEST_RELEASE_URL=$(curl -s --fail --retry 3 https://api.github.com/repos/c
         "$LATEST_RELEASE_URL" \
     && unzip core-ubuntu-latest.zip -d cdisc-rules-engine \
     && rm core-ubuntu-latest.zip \
-    && mv cdisc-rules-engine/* . \
-    && rmdir cdisc-rules-engine \
+    && ls -la cdisc-rules-engine/ \
+    && ls -la cdisc-rules-engine/core/ \
+    && mv cdisc-rules-engine/core/* . \
+    && rm -rf cdisc-rules-engine \
     && chmod +x /app/core
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
<img width="1422" height="457" alt="image" src="https://github.com/user-attachments/assets/5beacf23-45ae-454d-9307-e287071778e2" />
with the update to 3.12, the build now nests the executable in a ./core directory. Because of this the dockerfile needs to be updated to get all the executables, python dependencies and resources in the root.  This PR does this.  If you see above you can run ./core from root now as the docker readme states.

This pull request updates the Dockerfile to improve the extraction and organization of files from the downloaded release archive. The changes focus on ensuring the correct files are moved and providing more visibility into the contents of the extracted directories.

This pull request updates the Dockerfile to improve the extraction and organization of files from the downloaded release archive. The main change is to move files from the nested `core` directory, rather than the top-level directory, and to add directory listings for debugging.

I have updated 0.12.0 and latest on dockerhub--to test: get docker image, spin up container, run docker command inside

Improvements to file extraction and organization:

* The `mv` command now moves files from `cdisc-rules-engine/core/` instead of `cdisc-rules-engine/`, ensuring only the intended files are placed in the working directory.
* The cleanup step now uses `rm -rf cdisc-rules-engine` instead of `rmdir`, allowing removal of the directory even if it contains files.