### PR TITLE
update release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,11 @@ jobs:
           - os: "ubuntu-latest"
             name: "core-ubuntu-latest"
           - os: "macos-latest"
-            name: "core-mac"
+            name: "core-mac-apple-silicon"
           - os: "windows-latest"
             name: "core-windows"
+          - os: "macos-13"
+            name: "core-mac-intel"
     uses: ./.github/workflows/build-binary.yml
     with:
       os: ${{ matrix.os }}
@@ -35,8 +37,12 @@ jobs:
           dest: core-ubuntu-latest.zip
       - uses: vimtor/action-zip@v1
         with:
-          files: artifacts/core-mac/
-          dest: core-mac.zip
+          files: artifacts/core-mac-intel/
+          dest: core-mac-intel.zip
+      - uses: vimtor/action-zip@v1
+        with:
+          files: artifacts/core-mac-apple-silicon/
+          dest: core-mac-apple-silicon.zip
       - uses: vimtor/action-zip@v1
         with:
           files: artifacts/core-windows/
@@ -51,14 +57,23 @@ jobs:
           asset_path: ./core-ubuntu-latest.zip
           asset_name: core-ubuntu-latest.zip
           asset_content_type: application/zip
-      - name: Upload Mac Release Asset
+      - name: Upload Mac Intel Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./core-mac.zip
-          asset_name: core-mac.zip
+          asset_path: ./core-mac-intel.zip
+          asset_name: core-mac-intel.zip
+          asset_content_type: application/zip
+      - name: Upload Mac Apple Silicon Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./core-mac-apple-silicon.zip
+          asset_name: core-mac-apple-silicon.zip
           asset_content_type: application/zip
       - name: Upload Windows Release Asset
         uses: actions/upload-release-asset@v1
@@ -77,7 +92,8 @@ jobs:
           name: release-artifacts
           path: |
             core-ubuntu-latest.zip
-            core-mac.zip
+            core-mac-intel.zip
+            core-mac-apple-silicon.zip
             core-windows.zip
   deploy-PyPi:
     needs: create-release-assets

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -11,7 +11,9 @@ jobs:
           - os: "ubuntu-latest"
             name: "core-ubuntu-latest"
           - os: "macos-latest"
-            name: "core-mac"
+            name: "core-mac-apple-silicon"
+          - os: "macos-13"
+            name: "core-mac-intel"
           - os: "windows-latest"
             name: "core-windows"
     uses: ./.github/workflows/build-binary.yml
@@ -34,8 +36,12 @@ jobs:
           dest: core-ubuntu-latest.zip
       - uses: vimtor/action-zip@v1
         with:
-          files: artifacts/core-mac/
-          dest: core-mac.zip
+          files: artifacts/core-mac-intel/
+          dest: core-mac-intel.zip
+      - uses: vimtor/action-zip@v1
+        with:
+          files: artifacts/core-mac-apple-silicon/
+          dest: core-mac-apple-silicon.zip
       - uses: vimtor/action-zip@v1
         with:
           files: artifacts/core-windows/
@@ -46,7 +52,8 @@ jobs:
           name: release-artifacts
           path: |
             core-ubuntu-latest.zip
-            core-mac.zip
+            core-mac-intel.zip
+            core-mac-apple-silicon.zip
             core-windows.zip
   deploy-PyPi:
     needs: create-release-assets


### PR DESCRIPTION
This PR updates the release and test release as mac-latest uses an M1 chip runner.

to test: run test release command, pass the intel-mac release to @mhungria to test as she is the user who brought this issue to attention (has an older generation mac with intel silicone) or potentially someone else withing scrum team?

see: https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/16911648198 