### PR TITLE
Test

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -232,14 +232,17 @@ jobs:
         run: |
           PANDAS_DIFF="${{ env.pandas_diff }}"
           DASK_DIFF="${{ env.dask_diff }}"
+          USDM_NEG_DIFF="${{ env.usdm_neg_diff }}"
+          USDM_POS_DIFF="${{ env.usdm_pos_diff }}"
 
-          if [[ "$PANDAS_DIFF" == "1" || "$DASK_DIFF" == "1" ]]; then
-            echo "Differences found in either Pandas or Dask comparison"
+
+          if [[ "$PANDAS_DIFF" == "1" || "$DASK_DIFF" == "1" || "$USDM_NEG_DIFF" == "1" || "$USDM_POS_DIFF" == "1" ]]; then
+            echo "Differences found in one or more comparisons"
             exit 1
-          elif [[ "$PANDAS_DIFF" == "0" && "$DASK_DIFF" == "0" ]]; then
-            echo "No differences found in either comparison"
+          elif [[ "$PANDAS_DIFF" == "0" && "$DASK_DIFF" == "0" && "$USDM_NEG_DIFF" == "0" && "$USDM_POS_DIFF" == "0" ]]; then
+            echo "No differences found in any comparison"
             exit 0
           else
-            echo "Issue with comparison script"
+            echo "Issue with comparison scripts"
             exit 1
           fi

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -145,11 +145,25 @@ jobs:
             echo "usdm_neg_success=false" >> $GITHUB_OUTPUT
             echo "**Failed**: No results for negative test" >> $GITHUB_STEP_SUMMARY
           fi
+
       - name: Compare USDM negative result
         if: steps.usdm_neg.outputs.usdm_neg_success == 'true'
         continue-on-error: true
         run: |
           python CORE_Test_Suite/scripts/comparison.py CORE_Test_Suite/usdm_negative_report.json CORE_Test_Suite/USDM_Negative_Result.json CORE_Test_Suite/usdm_negative_comparison.xlsx --mode test --json-output CORE_Test_Suite/usdm_negative_comparison.json
+          USDM_NEG_EXIT_CODE=$?
+          echo "usdm_neg_diff=$USDM_NEG_EXIT_CODE" >> $GITHUB_ENV
+          if [ $USDM_NEG_EXIT_CODE -eq 0 ]; then
+            echo "USDM negative comparison completed successfully (no differences)"
+          else
+            echo "USDM negative comparison found differences"
+          fi
+
+      - name: Generate USDM negative comparison summary
+        if: steps.usdm_neg.outputs.usdm_neg_success == 'true'
+        continue-on-error: true
+        run: |
+          python CORE_Test_Suite/scripts/compare_implementations.py CORE_Test_Suite/usdm_negative_report.json CORE_Test_Suite/USDM_Negative_Result.json CORE_Test_Suite/usdm_negative_comparison.json --github-step-summary $GITHUB_STEP_SUMMARY --mode test
 
       - name: Run USDM validation (Positive)
         id: usdm_pos
@@ -172,6 +186,19 @@ jobs:
         continue-on-error: true
         run: |
           python CORE_Test_Suite/scripts/comparison.py CORE_Test_Suite/usdm_positive_report.json CORE_Test_Suite/USDM_Positive_Result.json CORE_Test_Suite/usdm_positive_comparison.xlsx --mode test --json-output CORE_Test_Suite/usdm_positive_comparison.json
+          USDM_POS_EXIT_CODE=$?
+          echo "usdm_pos_diff=$USDM_POS_EXIT_CODE" >> $GITHUB_ENV
+          if [ $USDM_POS_EXIT_CODE -eq 0 ]; then
+            echo "USDM positive comparison completed successfully (no differences)"
+          else
+            echo "USDM positive comparison found differences"
+          fi
+
+      - name: Generate USDM positive comparison summary
+        if: steps.usdm_pos.outputs.usdm_pos_success == 'true'
+        continue-on-error: true
+        run: |
+          python CORE_Test_Suite/scripts/compare_implementations.py CORE_Test_Suite/usdm_positive_report.json CORE_Test_Suite/USDM_Positive_Result.json CORE_Test_Suite/usdm_positive_comparison.json --github-step-summary $GITHUB_STEP_SUMMARY --mode test
 
       #######################
       # UPLOAD ALL RESULTS


### PR DESCRIPTION
- this PR adds exit code catching logic as Darren's branch was not failing but differences were found
- creates the markdown tables for the summary report for test suite

This pull request enhances the test suite workflow by improving the comparison and reporting steps for both USDM negative and positive test results. It introduces new summary steps, captures exit codes for USDM comparisons, and updates the final result evaluation logic to include USDM outcomes alongside Pandas and Dask comparisons.

**Enhanced comparison and reporting for USDM tests:**

* Added steps to capture the exit code from USDM negative and positive comparison scripts, storing results in environment variables (`usdm_neg_diff` and `usdm_pos_diff`). [[1]](diffhunk://#diff-bd07b6f2904b3965cc56060e7e8e29daa89d25bdf814911e3de55f5206eb2de6R148-R166) [[2]](diffhunk://#diff-bd07b6f2904b3965cc56060e7e8e29daa89d25bdf814911e3de55f5206eb2de6R189-R201)
* Introduced summary generation steps for both USDM negative and positive comparisons using `compare_implementations.py`, which outputs results to the GitHub step summary. [[1]](diffhunk://#diff-bd07b6f2904b3965cc56060e7e8e29daa89d25bdf814911e3de55f5206eb2de6R148-R166) [[2]](diffhunk://#diff-bd07b6f2904b3965cc56060e7e8e29daa89d25bdf814911e3de55f5206eb2de6R189-R201)

**Unified final result evaluation:**

* Updated the final comparison logic to consider USDM negative and positive comparison results along with Pandas and Dask, ensuring that differences in any of these will fail the workflow.
* Improved messaging in the final evaluation step to reflect checks across all comparison types.