### PR TITLE
update

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 120
 max_complexity = 10
-ignore = E203, W503
+ignore = E203, W503, E713
 
 exclude = .github,
     .pytest_cache,

--- a/core.py
+++ b/core.py
@@ -176,6 +176,7 @@ def cli():
     required=False,
     type=click.Path(exists=True, readable=True, resolve_path=True),
     help="path to directory containing local rules.",
+    multiple=True,
 )
 @click.option(
     "--custom_standard",

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -352,11 +352,12 @@ def load_rules_from_cache(args) -> List[dict]:
 
 def load_rules_from_local(args) -> List[dict]:
     rules = []
-    rule_files = (
-        [os.path.join(args.local_rules, file) for file in os.listdir(args.local_rules)]
-        if os.path.isdir(args.local_rules)
-        else [args.local_rules]
-    )
+    rule_files = []
+    for path in args.local_rules:
+        if os.path.isdir(path):
+            rule_files.extend([os.path.join(path, file) for file in os.listdir(path)])
+        else:
+            rule_files.append(path)
     rule_data = {}
 
     if args.rules:


### PR DESCRIPTION
This PR brings -lr in line with -r.  This allows the user to specify multiple -lr.  It parses them as they can be a mix of directories of local rules and file paths.  

This pull request introduces improvements to how local rule directories are handled and updates configuration for code linting. The main changes focus on supporting multiple local rule directories and ensuring correct rule file loading, along with a minor update to the `.flake8` configuration.

**Local rules handling:**

* The `--local_rules` CLI option in `core.py` now supports multiple directories, allowing users to specify more than one path for local rules.
* The `load_rules_from_local` function in `scripts/script_utils.py` was updated to iterate over all provided local rule paths, loading files from each directory or file path. This enables proper aggregation of rule files from multiple sources.

**Linting configuration:**

* The `.flake8` configuration was updated to ignore the `E713` error code, in addition to the previously ignored codes.

to test - try iterations of -lr