### PR TITLE
Performance 1233

### DIFF
--- a/cdisc_rules_engine/services/data_services/usdm_data_service.py
+++ b/cdisc_rules_engine/services/data_services/usdm_data_service.py
@@ -287,12 +287,13 @@ class USDMDataService(BaseDataService):
         rel_type = getattr(node, "type", "")
         # 'Wrapper' for all top-level Study attributes (any path starting with '`this`' or with no dot)
         if path.startswith("`this`") or "." not in path:
-            parent_entity = self.entity_dict["`this`"]
+            # parent_entity = self.entity_dict["`this`"]
+            parent_entity = self.entity_dict.get("`this`")
         # If still not set, use schema mapping for node type or key
         if not parent_entity:
             node_type = getattr(node, "type", None)
             if node_type and node_type in self.entity_dict:
-                parent_entity = self.entity_dict[node_type]
+                parent_entity = self.entity_dict.get(node_type)
             elif path:
                 key = path.split(".")[-1] if "." in path else path
                 parent_entity = self.entity_dict.get(key, key)


### PR DESCRIPTION
These changes address the parent_entity value missing for the top-level attributes:

1. In the Study dataset, parent_entity should be populated with "Wrapper"
2. In the string dataset, parent_entity should be:
- "Wrapper" where parent_rel is "usdmVersion", "systemName" or "systemVersion"
- "Study" where:
- - parent_rel is "name" and value is "Study_CDISC PILOT - LZZT"
- - parent_rel is "instanceType" and value is "Study"
- In the StudyVersion dataset, parent_entity should be "Study" for any record where rel_type is "definition"
- In the StudyProtocolDocument (USDM v3) or StudyDefinitionDocument (USDM v4) dataset, parent_entity should be "Study" for any record where rel_type is "definition".