### PR TITLE
Dockerbuild

### DIFF
--- a/.github/workflows/build_version.yml
+++ b/.github/workflows/build_version.yml
@@ -1,0 +1,52 @@
+name: Build Custom Executable
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+  #   - cron: '0 2 * * *'  # Daily at 2 AM UTC
+jobs:
+  custom-executable-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: cdisc-org/cdisc-rules-engine
+          ref: main
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          pip install --no-deps -r requirements.txt
+          pip install -r requirements.txt --no-cache-dir
+      - name: Update CDISC standards cache
+        env:
+          CDISC_LIBRARY_API_KEY: ${{ secrets.CDISC_LIBRARY_API_KEY }}
+        run: |
+          python core.py update-cache
+      - name: Build Binary
+        run: |
+          pyinstaller --onedir \
+            --contents-directory "." \
+            core.py \
+            --dist ./dist/output/core-ubuntu-22.04 \
+            --collect-submodules pyreadstat \
+            --add-data="resources/cache:resources/cache" \
+            --add-data="resources/templates:resources/templates" \
+            --add-data="resources/schema:resources/schema" \
+            --add-data="tests/resources/datasets:tests/resources/datasets"
+      - name: Prepare executable
+        run: |
+          cd dist/output/core-ubuntu-22.04/core
+          chmod +x core
+          file core  # Verify x86_64 architecture
+          mv core cdisc-core-$(date +%Y%m%d)
+          echo "Executable ready: $(ls cdisc-core-*)"
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdisc-core-ubuntu-22.04
+          path: dist/output/core-ubuntu-22.04/core/cdisc-core-*

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,8 @@ resources/cache/custom_rules.pkl
 *.swp
 
 Organization_Custom.json
+
+#ignore custom build artifacts
+/build-output
+.github/workflows/build_version.yml
+dockerfile.build

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,11 +1,9 @@
-#!/bin/bash
-
-cat > Dockerfile.simple << 'EOF'
 FROM --platform=linux/amd64 ubuntu:22.04
 
 ENV TZ=America/New_York
 ENV DEBIAN_FRONTEND=noninteractive
-# Install Python 3.12 exactly like GitHub Actions
+
+# Install Python 3.12
 RUN apt-get update && \
     apt-get install -y software-properties-common curl && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
@@ -19,13 +17,13 @@ WORKDIR /app
 # Copy everything
 COPY . .
 
-# Install dependencies exactly like GitHub Actions
+# Install dependencies exactly
 RUN python3.12 -m pip install --upgrade pip && \
     pip install setuptools wheel twine && \
     pip install --no-deps -r requirements.txt && \
     pip install -r requirements.txt --no-cache-dir
 
-# Build binary with EXACT same command from GitHub Actions
+# Build binary
 RUN pyinstaller --onedir \
     --contents-directory "." \
     core.py \
@@ -36,18 +34,7 @@ RUN pyinstaller --onedir \
     --add-data="resources/schema:resources/schema" \
     --add-data="tests/resources/datasets:tests/resources/datasets"
 
-# Set permissions
-RUN chmod +x /app/dist/output/core-ubuntu-22.04/core/core
-
-CMD ["bash"]
-EOF
-
-# Build and extract
-docker build -f Dockerfile.simple -t cdisc-simple .
-mkdir -p build-output
-CONTAINER_ID=$(docker create cdisc-simple)
-docker cp $CONTAINER_ID:/app/dist/output/core-ubuntu-22.04 ./build-output/
-docker rm $CONTAINER_ID
-
-echo "Created: ./build-output/cdisc-core-ubuntu-22.04 executable"
-
+# Set permissions and verify
+RUN chmod +x /app/dist/output/core-ubuntu-22.04/core/core && \
+    file /app/dist/output/core-ubuntu-22.04/core/core && \
+    echo "Executable built successfully"

--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ For implementation instructions, see [PYPI.md](PYPI.md).
 
 ### **Creating an executable version**
 
+**Note:** Further directions to create your own executable are contained in [README_Build_Executable.md](README_Build_Executable.md) if you wish to build an unofficial release executable for your own use.
+
 **Linux**
 
 `pyinstaller core.py --add-data=venv/lib/python3.12/site-packages/xmlschema/schemas:xmlschema/schemas --add-data=resources/cache:resources/cache --add-data=resources/templates:resources/templates`
@@ -501,4 +503,4 @@ Then run normally: `core.exe validate -rest -of -config -commands
 
 ---
 
-**Note:** Setting `DATASET_SIZE_THRESHOLD=0` tells the engine to use Dask processing for all datasets regardless of size, size threshold defaults to 1/4 of available RAM so datasets larger than this will use Dask
+**Note:** Setting `DATASET_SIZE_THRESHOLD=0` tells the engine to use Dask processing for all datasets regardless of size, size threshold defaults to 1/4 of available RAM so datasets larger than this will use Dask. See env.example to see what the CLI .env file should look like

--- a/README_Build_Executable.md
+++ b/README_Build_Executable.md
@@ -130,9 +130,13 @@ The default Dockerfile builds for Ubuntu 22.04 on AMD64 architecture. To customi
 
 ### Change Target Operating System
 
+To change what underlying OS the executable is built on to match your implementation needs, you will need to edit the dockerfile
+
 - https://docs.docker.com/reference/dockerfile/#from
 - **Windows**: https://hub.docker.com/r/microsoft/windows
 - **macOS**: https://hub.docker.com/search - you can explore DockerHub to find a macOS image to utilize
+
+You will need to edit these areas of the dockerfile:
 
 ```dockerfile
 # Change the base image (line 2)
@@ -143,7 +147,7 @@ FROM --platform=linux/amd64 ubuntu:22.04
 
 ### Update PyInstaller Output Path
 
-If you change the base OS, update the PyInstaller dist path to match:
+If you change the base OS, update the PyInstaller dist path. this is for clarity and organization, but it's not technically required for functionality:
 
 ```dockerfile
 # Change the --dist path in the pyinstaller command (around line 20)
@@ -182,6 +186,14 @@ REM docker cp %CONTAINER_ID%:/app/dist/output/core-windows/core ./build-output/
 docker cp "${CONTAINER_ID}:/app/dist/output/core-ubuntu-22.04/core" ./build-output/
 # Example for Windows build:
 # docker cp "${CONTAINER_ID}:/app/dist/output/core-windows/core" ./build-output/
+```
+
+### Executability
+
+Currently the Dockerfile.build is ubuntu and we give the file executable permissions. This may not be required depending on your OS.
+
+```bash
+RUN chmod +x /app/dist/output/core-ubuntu-22.04/core/core && \
 ```
 
 ## Platform-Specific Notes

--- a/README_Build_Executable.md
+++ b/README_Build_Executable.md
@@ -1,124 +1,224 @@
-# CDISC Rules Engine Docker Build Guide
+# Building CDISC Rules Engine Executable
 
-This guide walks you through building the CDISC Rules Engine executable from scratch.
+## Option 1: Using GitHub Actions (Recommended)
 
-## Prerequisites
+### Step 1: Fork and Setup
 
-This guide presumes you have 2 things:
+1. Fork the repository: https://github.com/cdisc-org/cdisc-rules-engine
+2. The workflow file `.github/workflows/build-version.yml` is already included in the main repository. It is contained within our .gitignore so you can customize it as you see fit.
 
-- an installation of git
-- an installation of docker/ docker desktop as well as an account
-- a current compatible version of python installed (currently 3.12)
+### Step 2: Run the Build
 
-## Setup Steps
+1. Go to the top bar of the fork, click Settings > Security > Secrets and Variables > Actions
+2. Click **New Repository Secret** and set an action secret named CDISC_LIBRARY_API_KEY and secret as your API key
+3. Go to **Actions** tab in your forked repository
+4. Click "Build Custom Executable"
+5. Click **Run workflow**
+6. Download the artifact when complete
 
-### 1. Clone the Repository
+### Step 3: Automated Builds (Optional)
+
+To run builds automatically, uncomment the schedule section in the workflow:
+
+```yaml
+schedule:
+  - cron: "0 2 * * 0" # Weekly on Sunday at 2 AM UTC
+  # OR
+  - cron: "0 2 * * *" # Daily at 2 AM UTC
+```
+
+## Troubleshooting
+
+### Architecture Issues
+
+You can build executables for different operating systems using GitHub's hosted runners. This creates platform-specific executables that work on different environments. See:
+
+- https://docs.github.com/en/actions/concepts/runners/github-hosted-runners
+- https://github.com/actions/runner-images
+
+The runner in our workflow currently builds for ubuntu-22.04 but this can be changed to your particular OS, as well as CPU architectures (This will be different for Apple M chips that use ARM architecture versus Intel chips)
+
+## Option 2: Using Docker Locally
+
+### Prerequisites
+
+- Docker Desktop installed and running
+- Git
+- **Note**: There is no official support for a macOS docker runner; Windows also requires some additional setup
+
+### Step 1: Clone Repository
+
+#### Linux/macOS/WSL/Windows Command Prompt/Powershell:
 
 ```bash
-# Clone the CDISC Rules Engine repository
 git clone https://github.com/cdisc-org/cdisc-rules-engine.git
 cd cdisc-rules-engine
 ```
 
-### 2. Set up Python Virtual Environment (Optional but Recommended)
+### Step 1.5: Update cache and code
+
+When you clone the repo initially, it will come with an updated cache and main branch. Before subsequent local docker builds, you will want to follow the README to install the compatible python version of engine, create the virtual environment, and then update the cache as well as pulling down changes from main in cdisc-rules-engine root directory.
+
+#### Linux/macOS/WSL/Git Bash/Windows Command Prompt & PowerShell:
 
 ```bash
-# Create virtual environment
-python3.12 -m venv venv
+# Set up upstream remote (only done once)
+git remote add upstream https://github.com/cdisc-org/cdisc-rules-engine.git
 
-# Activate virtual environment
-# On Windows:
-venv\Scripts\activate
-# On Mac/Linux:
-source venv/bin/activate
-
-# Install dependencies (for local testing)
-pip install -r requirements.txt
+# Pull latest changes from upstream main branch
+git pull upstream main
 ```
 
-### 3. Update CDISC Library Cache
+### Step 2: Build with Docker
 
-The CDISC Rules Engine uses cached CDISC standards. Update the cache before building:
+#### Linux/macOS/WSL/Git Bash:
 
 ```bash
-python core.py update-cache
+# Build the executable
+docker build -f Dockerfile.build -t cdisc-builder .
+
+# Extract the executable and remove container
+CONTAINER_ID=$(docker create cdisc-builder)
+docker cp $CONTAINER_ID:/app/dist/output/core-ubuntu-22.04/core ./build-output/
+docker rm $CONTAINER_ID
+
+# Make executable (Linux/macOS only)
+chmod +x ./build-output/core
+
+echo "Executable ready: ./build-output/core"
 ```
 
-### 4. Run the Build Script
+#### Windows Command Prompt:
+
+```cmd
+REM Build the executable
+docker build -f Dockerfile.build -t cdisc-builder .
+
+REM Create container and get ID
+docker create cdisc-builder > temp_id.txt
+set /p CONTAINER_ID=<temp_id.txt
+
+REM Extract the executable
+docker cp %CONTAINER_ID%:/app/dist/output/core-ubuntu-22.04/core ./build-output/
+
+REM Clean up
+docker rm %CONTAINER_ID%
+del temp_id.txt
+
+echo Executable ready: ./build-output/core
+```
+
+#### Windows PowerShell:
+
+```powershell
+# Build the executable
+docker build -f Dockerfile.build -t cdisc-builder .
+
+# Extract the executable and remove container
+$CONTAINER_ID = docker create cdisc-builder
+docker cp "${CONTAINER_ID}:/app/dist/output/core-ubuntu-22.04/core" ./build-output/
+docker rm $CONTAINER_ID
+
+# Note: chmod is not needed on Windows
+Write-Host "Executable ready: ./build-output/core"
+```
+
+### Alternative: Create build-output directory first
+
+If you encounter issues with the docker cp command, create the output directory first:
+
+#### Linux/macOS/WSL/Git Bash:
 
 ```bash
-# Execute the build script
-./build_for_colab.sh
+mkdir -p ./build-output
 ```
 
-The build process will:
+#### Windows Command Prompt:
 
-- Create a Docker container with Ubuntu 22.04 (x86_64 architecture)
-- Install Python 3.12 and all dependencies
-- Build the executable using PyInstaller
-- Package everything into a tarball ready for Google Colab
+```cmd
+if not exist "build-output" mkdir build-output
+```
 
-### 6. Verify the Build
+#### Windows PowerShell:
 
-Check that the executable was built for the correct architecture:
+```powershell
+New-Item -ItemType Directory -Force -Path ./build-output
+```
+
+## Customizing the Build for Your Environment
+
+The default Dockerfile builds for Ubuntu 22.04 on AMD64 architecture. To customize for your specific environment, modify these sections in Dockerfile.build:
+
+### Change Target Operating System
+
+- https://docs.docker.com/reference/dockerfile/#from
+- **Windows**: https://hub.docker.com/r/microsoft/windows
+- **macOS**: https://hub.docker.com/search - you can explore DockerHub to find a macOS image to utilize
+
+```dockerfile
+# Change the base image (line 2)
+FROM --platform=linux/amd64 ubuntu:22.04
+# Example:
+# FROM mcr.microsoft.com/windows/servercore:ltsc2022  # Windows
+```
+
+### Update PyInstaller Output Path
+
+If you change the base OS, update the PyInstaller dist path to match:
+
+```dockerfile
+# Change the --dist path in the pyinstaller command (around line 20)
+--dist ./dist/output/core-ubuntu-22.04  # Current
+# Examples:
+# --dist ./dist/output/core-windows
+# --dist ./dist/output/core-mac
+```
+
+### Update Docker Copy Command
+
+Remember to update the corresponding path in your Docker copy command:
+
+**Linux/macOS/WSL/Git Bash:**
 
 ```bash
-# Extract and check the executable
-cd build-output/core-ubuntu-22.04/core
-file core
+# Update this path to match your PyInstaller dist path
+docker cp $CONTAINER_ID:/app/dist/output/core-ubuntu-22.04/core ./build-output/
+# Example for Windows build:
+# docker cp $CONTAINER_ID:/app/dist/output/core-windows/core ./build-output/
 ```
 
-You should see output like:
+**Windows Command Prompt:**
 
-```
-core: ELF 64-bit LSB executable, x86-64, version 1 (SYSV)...
-```
-
-If you see "ARM aarch64" instead of "x86-64", the build used the wrong architecture.
-
-## Troubleshooting
-
-## Alternative: GitHub Actions Build
-
-If Docker setup is problematic, you can use GitHub Actions instead:
-
-1. Fork the CDISC Rules Engine repository
-2. Add this workflow file as `.github/workflows/build-colab.yml`:
-
-```yaml
-name: Build for Colab
-on: workflow_dispatch
-
-jobs:
-  build:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Cache standards
-        run: python core.py cache-standards
-      - name: Build executable
-        run: |
-          pip install --upgrade pip setuptools wheel twine
-          pip install --no-deps -r requirements.txt
-          pip install -r requirements.txt --no-cache-dir
-          pyinstaller --onedir --contents-directory "." core.py \
-            --dist ./dist/output/core-ubuntu-22.04 \
-            --collect-submodules pyreadstat \
-            --add-data="resources/cache:resources/cache" \
-            --add-data="resources/templates:resources/templates" \
-            --add-data="resources/schema:resources/schema" \
-            --add-data="tests/resources/datasets:tests/resources/datasets"
-          cd dist/output && tar -czf cdisc-core-colab.tar.gz core-ubuntu-22.04/
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cdisc-core-colab
-          path: dist/output/cdisc-core-colab.tar.gz
+```cmd
+REM Update this path to match your PyInstaller dist path
+docker cp %CONTAINER_ID%:/app/dist/output/core-ubuntu-22.04/core ./build-output/
+REM Example for Windows build:
+REM docker cp %CONTAINER_ID%:/app/dist/output/core-windows/core ./build-output/
 ```
 
-3. Go to Actions tab in your fork and manually trigger the workflow
-4. Download the artifact when complete
+**Windows PowerShell:**
 
-This approach builds on GitHub's x86_64 runners and provides the same result.
+```powershell
+# Update this path to match your PyInstaller dist path
+docker cp "${CONTAINER_ID}:/app/dist/output/core-ubuntu-22.04/core" ./build-output/
+# Example for Windows build:
+# docker cp "${CONTAINER_ID}:/app/dist/output/core-windows/core" ./build-output/
+```
+
+## Platform-Specific Notes
+
+### Windows Users
+
+- **Recommended**: Use WSL (Windows Subsystem for Linux) or Git Bash for the best experience with the bash commands
+- The `chmod +x` command is not needed on Windows as executable permissions work differently
+- If using Command Prompt, some syntax differs from bash (variable assignment, echo commands)
+
+### Linux/macOS Users
+
+- The bash commands should work directly in your terminal
+- Make sure Docker Desktop is running before executing the commands
+- The `chmod +x` step is required to make the executable runnable
+
+### Cross-Platform Alternative
+
+For the most consistent experience across all platforms, consider using the **GitHub Actions approach (Option 1)**, which handles platform differences automatically and doesn't require local Docker setup.

--- a/README_Build_Executable.md
+++ b/README_Build_Executable.md
@@ -45,6 +45,7 @@ The runner in our workflow currently builds for ubuntu-22.04 but this can be cha
 - Docker Desktop installed and running
 - Git
 - **Note**: There is no official support for a macOS docker runner; Windows also requires some additional setup
+- **Note**: You will need to run Windows Command Prompt / Windows Powershell as administrator. This can be done by right clicking and the application and selecting 'Run as Administrator'
 
 ### Step 1: Clone Repository
 

--- a/README_Build_Executable.md
+++ b/README_Build_Executable.md
@@ -1,0 +1,124 @@
+# CDISC Rules Engine Docker Build Guide
+
+This guide walks you through building the CDISC Rules Engine executable from scratch.
+
+## Prerequisites
+
+This guide presumes you have 2 things:
+
+- an installation of git
+- an installation of docker/ docker desktop as well as an account
+- a current compatible version of python installed (currently 3.12)
+
+## Setup Steps
+
+### 1. Clone the Repository
+
+```bash
+# Clone the CDISC Rules Engine repository
+git clone https://github.com/cdisc-org/cdisc-rules-engine.git
+cd cdisc-rules-engine
+```
+
+### 2. Set up Python Virtual Environment (Optional but Recommended)
+
+```bash
+# Create virtual environment
+python3.12 -m venv venv
+
+# Activate virtual environment
+# On Windows:
+venv\Scripts\activate
+# On Mac/Linux:
+source venv/bin/activate
+
+# Install dependencies (for local testing)
+pip install -r requirements.txt
+```
+
+### 3. Update CDISC Library Cache
+
+The CDISC Rules Engine uses cached CDISC standards. Update the cache before building:
+
+```bash
+python core.py update-cache
+```
+
+### 4. Run the Build Script
+
+```bash
+# Execute the build script
+./build_for_colab.sh
+```
+
+The build process will:
+
+- Create a Docker container with Ubuntu 22.04 (x86_64 architecture)
+- Install Python 3.12 and all dependencies
+- Build the executable using PyInstaller
+- Package everything into a tarball ready for Google Colab
+
+### 6. Verify the Build
+
+Check that the executable was built for the correct architecture:
+
+```bash
+# Extract and check the executable
+cd build-output/core-ubuntu-22.04/core
+file core
+```
+
+You should see output like:
+
+```
+core: ELF 64-bit LSB executable, x86-64, version 1 (SYSV)...
+```
+
+If you see "ARM aarch64" instead of "x86-64", the build used the wrong architecture.
+
+## Troubleshooting
+
+## Alternative: GitHub Actions Build
+
+If Docker setup is problematic, you can use GitHub Actions instead:
+
+1. Fork the CDISC Rules Engine repository
+2. Add this workflow file as `.github/workflows/build-colab.yml`:
+
+```yaml
+name: Build for Colab
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Cache standards
+        run: python core.py cache-standards
+      - name: Build executable
+        run: |
+          pip install --upgrade pip setuptools wheel twine
+          pip install --no-deps -r requirements.txt
+          pip install -r requirements.txt --no-cache-dir
+          pyinstaller --onedir --contents-directory "." core.py \
+            --dist ./dist/output/core-ubuntu-22.04 \
+            --collect-submodules pyreadstat \
+            --add-data="resources/cache:resources/cache" \
+            --add-data="resources/templates:resources/templates" \
+            --add-data="resources/schema:resources/schema" \
+            --add-data="tests/resources/datasets:tests/resources/datasets"
+          cd dist/output && tar -czf cdisc-core-colab.tar.gz core-ubuntu-22.04/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cdisc-core-colab
+          path: dist/output/cdisc-core-colab.tar.gz
+```
+
+3. Go to Actions tab in your fork and manually trigger the workflow
+4. Download the artifact when complete
+
+This approach builds on GitHub's x86_64 runners and provides the same result.

--- a/README_Build_Executable.md
+++ b/README_Build_Executable.md
@@ -78,6 +78,7 @@ git pull upstream main
 docker build -f Dockerfile.build -t cdisc-builder .
 
 # Extract the executable and remove container
+mkdir -p ./build-output
 CONTAINER_ID=$(docker create cdisc-builder)
 docker cp $CONTAINER_ID:/app/dist/output/core-ubuntu-22.04/core ./build-output/
 docker rm $CONTAINER_ID
@@ -99,6 +100,7 @@ docker create cdisc-builder > temp_id.txt
 set /p CONTAINER_ID=<temp_id.txt
 
 REM Extract the executable
+if not exist "build-output" mkdir build-output
 docker cp %CONTAINER_ID%:/app/dist/output/core-ubuntu-22.04/core ./build-output/
 
 REM Clean up
@@ -115,34 +117,10 @@ echo Executable ready: ./build-output/core
 docker build -f Dockerfile.build -t cdisc-builder .
 
 # Extract the executable and remove container
+New-Item -ItemType Directory -Force -Path ./build-output
 $CONTAINER_ID = docker create cdisc-builder
 docker cp "${CONTAINER_ID}:/app/dist/output/core-ubuntu-22.04/core" ./build-output/
 docker rm $CONTAINER_ID
-
-# Note: chmod is not needed on Windows
-Write-Host "Executable ready: ./build-output/core"
-```
-
-### Alternative: Create build-output directory first
-
-If you encounter issues with the docker cp command, create the output directory first:
-
-#### Linux/macOS/WSL/Git Bash:
-
-```bash
-mkdir -p ./build-output
-```
-
-#### Windows Command Prompt:
-
-```cmd
-if not exist "build-output" mkdir build-output
-```
-
-#### Windows PowerShell:
-
-```powershell
-New-Item -ItemType Directory -Force -Path ./build-output
 ```
 
 ## Customizing the Build for Your Environment

--- a/env.example
+++ b/env.example
@@ -1,0 +1,2 @@
+CDISC_LIBRARY_API_KEY = 012345
+DATASET_SIZE_THRESHOLD = size_in_bytes to force dask implementation


### PR DESCRIPTION
I have tested this in windows command prompt (not i was not in administrator mode so could not copy the created executable, readme was adjusted following this) as well as WLS and Powershell
<img width="1045" height="1002" alt="image" src="https://github.com/user-attachments/assets/eeda7e43-6544-4ec5-9828-77de77f94854" />


This pull request introduces new documentation and automation to streamline the process of building custom executables for the CDISC Rules Engine. It adds a GitHub Actions workflow and a dedicated Dockerfile for building platform-specific binaries, along with clear step-by-step instructions for both approaches. The documentation has been updated to reference these new resources and clarify environment variable usage.

**Build automation and tooling:**

* Added `.github/workflows/build_version.yml` to automate building custom executables using GitHub Actions, including support for scheduled builds and artifact upload.
* Added `Dockerfile.build` to provide a reproducible Docker-based build environment for creating platform-specific binaries.

**Documentation improvements:**

* Added `README_Build_Executable.md` with detailed instructions for building executables via GitHub Actions or Docker, including troubleshooting and customization guidance.
* Updated `README.md` to reference the new build instructions and clarify the use of environment variables and the `.env.example` file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R411-R412) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L504-R506)

**Environment configuration:**

* Added `env.example` to illustrate required environment variables for the CLI, including `CDISC_LIBRARY_API_KEY` and `DATASET_SIZE_THRESHOLD`.