### PR TITLE
update builder

### DIFF
--- a/cdisc_rules_engine/dataset_builders/variables_metadata_values_dataset_builder.py
+++ b/cdisc_rules_engine/dataset_builders/variables_metadata_values_dataset_builder.py
@@ -25,7 +25,7 @@ class ValueCheckVariableMetadataDatasetBuilder(ValuesDatasetBuilder):
             dataset_name=self.dataset_path, datasets=self.datasets, drop_duplicates=True
         )
         merged_df = data_contents_long_df.merge(
-            variable_metadata, how="left", on="variable_name"
+            variable_metadata._data, how="left", on="variable_name"
         )
         merged_df["variable_value_length"] = merged_df.apply(
             lambda row: ValuesDatasetBuilder.calculate_variable_value_length(

--- a/tests/unit/test_dataset_builders/test_values_variables_metadata_builder.py
+++ b/tests/unit/test_dataset_builders/test_values_variables_metadata_builder.py
@@ -138,19 +138,19 @@ def test_concat_with_split_datasets():
             ae1_data if dataset_name == "ae1.xpt" else ae2_data
         )
     )
-    data_service.get_variables_metadata = MagicMock(
-        return_value=pd.DataFrame.from_dict(
-            {
-                "variable_name": ["STUDYID", "USUBJID", "AETERM"],
-                "variable_label": ["Study ID", "Subject ID", "AE Term"],
-                "variable_size": [16, 20, 200],
-                "variable_order_number": [1, 2, 9],
-                "variable_data_type": ["text", "text", "text"],
-                "variable_format": ["$16.", "$20.", "$200."],
-            }
-        )
+    metadata_df = pd.DataFrame.from_dict(
+        {
+            "variable_name": ["STUDYID", "USUBJID", "AETERM"],
+            "variable_label": ["Study ID", "Subject ID", "AE Term"],
+            "variable_size": [16, 20, 200],
+            "variable_order_number": [1, 2, 9],
+            "variable_data_type": ["text", "text", "text"],
+            "variable_format": ["$16.", "$20.", "$200."],
+        }
     )
-
+    data_service.get_variables_metadata = MagicMock(
+        return_value=PandasDataset(metadata_df)
+    )
     builder = ValueCheckVariableMetadataDatasetBuilder(
         rule=MagicMock(),
         data_service=data_service,

--- a/tests/unit/test_dataset_builders/test_values_variables_metadata_builder.py
+++ b/tests/unit/test_dataset_builders/test_values_variables_metadata_builder.py
@@ -38,19 +38,19 @@ def test_build_with_variable_metadata(mock_build):
     mock_build.return_value = long_df
     data_service = LocalDataService(MagicMock(), MagicMock(), MagicMock())
     original_get_vars_metadata = data_service.get_variables_metadata
-    data_service.get_variables_metadata = MagicMock(
-        return_value=pd.DataFrame.from_dict(
-            {
-                "variable_name": ["STUDYID", "USUBJID", "AETERM"],
-                "variable_label": ["Study ID", "Subject ID", "AE Term"],
-                "variable_size": [16, 20, 200],
-                "variable_order_number": [1, 2, 9],
-                "variable_data_type": ["text", "text", "text"],
-                "variable_format": ["$16.", "$20.", "$200."],
-            }
-        )
+    metadata_df = pd.DataFrame.from_dict(
+        {
+            "variable_name": ["STUDYID", "USUBJID", "AETERM"],
+            "variable_label": ["Study ID", "Subject ID", "AE Term"],
+            "variable_size": [16, 20, 200],
+            "variable_order_number": [1, 2, 9],
+            "variable_data_type": ["text", "text", "text"],
+            "variable_format": ["$16.", "$20.", "$200."],
+        }
     )
-
+    data_service.get_variables_metadata = MagicMock(
+        return_value=PandasDataset(metadata_df)
+    )
     rule_mock = MagicMock()
     try:
         builder = ValueCheckVariableMetadataDatasetBuilder(


### PR DESCRIPTION
This PR resolves the error reported by @eljanssens -- the builder was trying to merge 2 PandasDatasetwrappers but merge() expects one to be a raw dataframe/series.


This pull request makes a minor update to how variable metadata is handled in both the dataset builder and its corresponding unit test. The most important change is that the code now consistently uses the `_data` attribute of the `variable_metadata` object when merging dataframes, and the unit test has been updated to use the `PandasDataset` wrapper for metadata.

Dataset merging and metadata handling:

* [`cdisc_rules_engine/dataset_builders/variables_metadata_values_dataset_builder.py`](diffhunk://#diff-dd0a9e4c1cf23e1820c8c2fe6b56c88727fd04f64ad096c957766300309830b4L28-R28): Updated the merge operation to use `variable_metadata._data` instead of `variable_metadata` directly, ensuring compatibility with the expected dataframe structure.

Unit test adjustments:

* [`tests/unit/test_dataset_builders/test_values_variables_metadata_builder.py`](diffhunk://#diff-74032a4c7cdcddcbc422b6dd1792a87303b2672512769029daa9be9e6c4331c0L141-R141): Modified the test setup to wrap the metadata dataframe in a `PandasDataset` before mocking `get_variables_metadata`, aligning the test with the updated builder logic. [[1]](diffhunk://#diff-74032a4c7cdcddcbc422b6dd1792a87303b2672512769029daa9be9e6c4331c0L141-R141) [[2]](diffhunk://#diff-74032a4c7cdcddcbc422b6dd1792a87303b2672512769029daa9be9e6c4331c0R151-L153)