### PR TITLE
1335: Fixing CT version in JSON report

### DIFF
--- a/cdisc_rules_engine/services/reporting/json_report.py
+++ b/cdisc_rules_engine/services/reporting/json_report.py
@@ -104,9 +104,7 @@ class JsonReport(BaseReport):
         if define_xml_path:
             define_version = get_define_version([define_xml_path])
         else:
-            define_version: str = self._args.define_version or get_define_version(
-                self._args.dataset_paths
-            )
+            define_version: str = self._args.define_version
         controlled_terminology = self._args.controlled_terminology_package
         if not controlled_terminology and define_version:
             if define_xml_path and define_version:


### PR DESCRIPTION
This PR addresses #1335. In JSON reporter, when there was no define/define version specified, the define version was detected from the dataset folder. If there is a define in that folder, a CT from that define would be shown in the report, although it was not used for the validation. 
After the update XLSX and JSON reports have the same blank CT in this case.