### PR TITLE
None/NaN handling

### DIFF
--- a/cdisc_rules_engine/check_operators/helpers.py
+++ b/cdisc_rules_engine/check_operators/helpers.py
@@ -173,6 +173,8 @@ def get_dict_key_val(dict_to_get: dict, key):
 def is_in(value, values):
     if values is None:
         return False
+    if value is None or np.isnan(value):
+        return False
     return value in values
 
 


### PR DESCRIPTION
this PR adds NaN/None handling to the vectorized is_in function to resolve the RuntimeWarnings encountered when a function running vectorized is_in() encounters a none/NaN value in the dataset.
```
20%numpy\lib\function_base.py:2455: RuntimeWarning: invalid value encountered in is_in (vectorized)
```