### PR TITLE
Pympler fallback

### DIFF
--- a/cdisc_rules_engine/services/cache/in_memory_cache_service.py
+++ b/cdisc_rules_engine/services/cache/in_memory_cache_service.py
@@ -15,11 +15,7 @@ from cdisc_rules_engine.services import logger
 def cust_asizeof(obj):
     try:
         return asizeof.asizeof(obj)
-    except (ValueError, TypeError, AttributeError) as e:
-        logger.warning(
-            f"asizeof failed for object type {type(obj).__name__}: {e}. "
-            "Using sys.getsizeof fallback."
-        )
+    except (ValueError, TypeError, AttributeError):
         return sys.getsizeof(obj)
 
 

--- a/cdisc_rules_engine/services/cache/in_memory_cache_service.py
+++ b/cdisc_rules_engine/services/cache/in_memory_cache_service.py
@@ -1,6 +1,7 @@
 import re
 from typing import List
 from pympler import asizeof
+import sys
 from cdisc_rules_engine.interfaces import (
     CacheServiceInterface,
 )
@@ -11,11 +12,22 @@ from multiprocessing import Lock
 from cdisc_rules_engine.services import logger
 
 
+def cust_asizeof(obj):
+    try:
+        return asizeof.asizeof(obj)
+    except (ValueError, TypeError, AttributeError) as e:
+        logger.warning(
+            f"asizeof failed for object type {type(obj).__name__}: {e}. "
+            "Using sys.getsizeof fallback."
+        )
+        return sys.getsizeof(obj)
+
+
 def get_data_size(dataset):
     if isinstance(dataset, DatasetInterface):
         return dataset.size
     else:
-        return asizeof.asizeof(dataset)
+        return cust_asizeof(dataset)
 
 
 class InMemoryCacheService(CacheServiceInterface):
@@ -30,7 +42,7 @@ class InMemoryCacheService(CacheServiceInterface):
     def __init__(self, max_size=None, **kwargs):
         self.max_size = max_size or psutil.virtual_memory().available * 0.25
         self.cache_lock = Lock()
-        self.cache = LRUCache(maxsize=self.max_size, getsizeof=asizeof.asizeof)
+        self.cache = LRUCache(maxsize=self.max_size, getsizeof=cust_asizeof)
         self.max_dataset_cache_size = psutil.virtual_memory().available * 0.5
         self.dataset_cache_lock = Lock()
         self.dataset_cache = LRUCache(


### PR DESCRIPTION
This PR adds a fallback for the asizeof() pympler which estimates negative memory by falling back onto sys.getsizeof 

This pull request improves the robustness of the in-memory cache service by introducing a safer way to calculate object sizes, preventing potential errors when estimating memory usage. The main change is the addition of a custom size calculation function that gracefully falls back to a default method if the preferred one fails.

**Improvements to object size calculation:**

* Added a new `cust_asizeof` function that tries to use `asizeof.asizeof` for object size estimation, but falls back to `sys.getsizeof` and logs a warning if an exception occurs. This prevents crashes when `asizeof` cannot handle certain object types.
* Updated the cache initialization in the `InMemoryCacheService` class to use `cust_asizeof` instead of `asizeof.asizeof` for the LRU cache's `getsizeof` parameter, improving reliability.
* Modified the `get_data_size` function to use `cust_asizeof` instead of `asizeof.asizeof` for non-`DatasetInterface` objects, ensuring consistent error handling.

to test: run cg0006 with test data I sent to @RamilCDISC via slack