### PR TITLE
numpy scrubber

### DIFF
--- a/TestRule/__init__.py
+++ b/TestRule/__init__.py
@@ -8,6 +8,7 @@ from scripts.run_validation import run_single_rule_validation
 import json
 import os
 import asyncio
+import numpy as np
 
 
 class BadRequestError(Exception):
@@ -55,6 +56,26 @@ def handle_exception(e: Exception):
         )
 
 
+def convert_numpy_types(obj):
+    """Recursively convert numpy types to native Python types"""
+    if isinstance(obj, dict):
+        return {key: convert_numpy_types(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        return [convert_numpy_types(item) for item in obj]
+    elif isinstance(obj, (np.integer, np.int64, np.int32, np.int16, np.int8)):
+        return int(obj)
+    elif isinstance(obj, (np.floating, np.float64, np.float32, np.float16)):
+        return float(obj)
+    elif isinstance(obj, np.bool_):
+        return bool(obj)
+    elif isinstance(obj, np.ndarray):
+        return obj.tolist()
+    elif hasattr(obj, "item"):
+        return obj.item()
+    else:
+        return obj
+
+
 def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:  # noqa
     try:
         json_data = req.get_json()
@@ -94,6 +115,7 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:  # 
             standard_substandard,
             codelists,
         )
+        result = convert_numpy_types(result)
         result_json = json.dumps(result)
         return func.HttpResponse(result_json)
     except Exception as e:


### PR DESCRIPTION
For CG0032 if you put the output of the operation $tv_visitnum into the output variables you get a 500 error.  This is due to the values in the operation column being of numpy type and not native python, which json.dump() does not handle and results in an error.  I added parsing logic to the testrule to handle numpy types and convert them back to native python.


