### PR TITLE
1211 fix na vs nan excel

### DIFF
--- a/cdisc_rules_engine/services/data_services/excel_data_service.py
+++ b/cdisc_rules_engine/services/data_services/excel_data_service.py
@@ -1,4 +1,3 @@
-# test
 import os
 from io import IOBase
 from typing import List, Sequence
@@ -188,7 +187,7 @@ class ExcelDataService(BaseDataService):
     def get_datasets(self) -> List[dict]:
         try:
             worksheet = pd.read_excel(self.dataset_path, sheet_name=DATASETS_SHEET_NAME,
-                                     na_values=[''], keep_default_na=False)
+                                      na_values=[''], keep_default_na=False)
         except TypeError as e:
             logger.error(
                 f"Failed to read datasets from the Excel file at {self.dataset_path}. "


### PR DESCRIPTION
Fixed issue #1211 where the string value 'NA' was incorrectly converted to NaN when reading Excel files. By adding `na_values=[''] `and` keep_default_na=False` parameters to all five pd.read_excel() calls in excel_data_service.py, the string 'NA' is now preserved as a valid data value instead of being treated as missing. This allows 'NA' to be used as a legitimate term while empty strings continue to be properly handled as missing values.