### PR TITLE
cg0546

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -1550,7 +1550,7 @@ class DataframeType(BaseType):
         pandas = isinstance(self.value, PandasDataset)
         for col in columns:
             comparator: str = self.replace_prefix(col["name"])
-            ascending: bool = col["sort_order"].lower() != "desc"
+            ascending: bool = col["order"].lower() != "desc"
             na_pos: str = col["null_position"]
             sorted_df = self.value[[target, within, comparator]].sort_values(
                 by=[within, comparator], ascending=ascending, na_position=na_pos


### PR DESCRIPTION
current cg0546 fails if you try to use test data (the data in cg0545 works for this rule) because the argument is order and not sort_order (see reference guide and ).  This fixes the issue and allows the operator to execute