### PR TITLE
Update docs for referenced_variable_metadata

### DIFF
--- a/resources/schema/Operations.md
+++ b/resources/schema/Operations.md
@@ -699,6 +699,102 @@ Operations:
     operator: get_column_order_from_dataset
 ```
 
+### label_referenced_variable_metadata
+
+Generates a dataframe where each record in the dataframe is the library ig variable metadata corresponding with the variable label found in the column provided in name. The metadata column names are prefixed with the string provided in `id`.
+
+Input
+
+Target Dataset: SUPPLB
+
+Product: sdtmig
+
+Version: 3-4
+
+Dataset:
+
+```
+{
+  "STUDYID": ["STUDY1", "STUDY1", "STUDY1"],
+  "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ1"],
+  "QLABEL": ["Toxicity", "Viscosity", "Analysis Method"]
+}
+```
+
+Rule:
+
+```yaml
+- operator: label_referenced_variable_metadata
+  id: $qlabel_referenced_variable_metadata
+  name: "QLABEL"
+```
+
+Output
+
+```
+{
+  "STUDYID": ["STUDY1", "STUDY1", "STUDY1"],
+  "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ1"],
+  "QLABEL": ["Toxicity", "Viscosity", "Analysis Method"],
+  "$qlabel_referenced_variable_metadata_name": ["LBTOX", null, "LBANMETH"],
+  "$qlabel_referenced_variable_metadata_role": [
+    "Variable Qualifier",
+    null,
+    "Record Qualifier"
+  ],
+  "$qlabel_referenced_variable_metadata_ordinal": [44, null, 38],
+  "$qlabel_referenced_variable_metadata_label": ["Toxicity", null, "Analysis Method"]
+}
+```
+
+### name_referenced_variable_metadata
+
+Generates a dataframe where each record in the dataframe is the library ig variable metadata corresponding with the variable name found in the column provided in name. The metadata column names are prefixed with the string provided in `id`.
+
+Input
+
+Target Dataset: SUPPLB
+
+Product: sdtmig
+
+Version: 3-4
+
+Dataset:
+
+```
+{
+  "STUDYID": ["STUDY1", "STUDY1", "STUDY1"],
+  "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ1"],
+  "QNAM": ["Toxicity", "LBVISCOS", "Analysis Method"]
+}
+```
+
+Rule:
+
+```yaml
+- operator: name_referenced_variable_metadata
+  id: $qnam_referenced_variable_metadata
+  name: "QNAM"
+```
+
+Output
+
+```
+{
+  "STUDYID": ["STUDY1", "STUDY1", "STUDY1"],
+  "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ1"],
+  "QNAM": ["LBTOX", "LBVISCOS", "LBANMETH"],
+  "$qnam_referenced_variable_metadata_name": ["LBTOX", null, "LBANMETH"],
+  "$qnam_referenced_variable_metadata_role": [
+    "Variable Qualifier",
+    null,
+    "Record Qualifier"
+  ],
+  "$qnam_referenced_variable_metadata_ordinal": [44, null, 38],
+  "$qnam_referenced_variable_metadata_label": ["Toxicity", null, "Analysis Method"]
+}
+```
+
 ## Define.XML Metadata Operations
 
 Operations for working with Define.XML metadata and variable references.
@@ -740,102 +836,6 @@ Output
   "USUBJID": "Unique Subject Identifier",
   "LBTESTCD": "Laboratory Test Code",
   "...": "..."
-}
-```
-
-### label_referenced_variable_metadata
-
-Generates a dataframe where each record in the dataframe is the library ig variable metadata corresponding with the variable label found in the column provided in name
-
-Input
-
-Target Dataset: SUPPLB
-
-Product: sdtmig
-
-Version: 3-4
-
-Dataset:
-
-```
-{
-  "STUDYID": ["STUDY1", "STUDY1", "STUDY1"],
-  "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ1"],
-  "QLABEL": ["Toxicity", "Viscosity", "Analysis Method"]
-}
-```
-
-Rule:
-
-```yaml
-- operator: label_referenced_variable_metadata
-  id: $label_referenced_variable_metadata
-  name: "QLABEL"
-```
-
-Output
-
-```
-{
-  "STUDYID": ["STUDY1", "STUDY1", "STUDY1"],
-  "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ1"],
-  "QLABEL": ["Toxicity", "Viscosity", "Analysis Method"],
-  "$label_referenced_variable_name": ["LBTOX", null, "LBANMETH"],
-  "$label_referenced_variable_role": [
-    "Variable Qualifier",
-    null,
-    "Record Qualifier"
-  ],
-  "$label_referenced_variable_ordinal": [44, null, 38],
-  "$label_referenced_variable_label": ["Toxicity", null, "Analysis Method"]
-}
-```
-
-### name_referenced_variable_metadata
-
-Generates a dataframe where each record in the dataframe is the library ig variable metadata corresponding with the variable name found in the column provided in name
-
-Input
-
-Target Dataset: SUPPLB
-
-Product: sdtmig
-
-Version: 3-4
-
-Dataset:
-
-```
-{
-  "STUDYID": ["STUDY1", "STUDY1", "STUDY1"],
-  "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ1"],
-  "QNAM": ["Toxicity", "LBVISCOS", "Analysis Method"]
-}
-```
-
-Rule:
-
-```yaml
-- operator: name_referenced_variable_metadata
-  id: $name_referenced_variable_metadata
-  name: "QNAM"
-```
-
-Output
-
-```
-{
-  "STUDYID": ["STUDY1", "STUDY1", "STUDY1"],
-  "USUBJID": ["SUBJ1", "SUBJ1", "SUBJ1"],
-  "QNAM": ["LBTOX", "LBVISCOS", "LBANMETH"],
-  "$label_referenced_variable_name": ["LBTOX", null, "LBANMETH"],
-  "$label_referenced_variable_role": [
-    "Variable Qualifier",
-    null,
-    "Record Qualifier"
-  ],
-  "$label_referenced_variable_ordinal": [44, null, 38],
-  "$label_referenced_variable_label": ["Toxicity", null, "Analysis Method"]
 }
 ```
 


### PR DESCRIPTION
**Documentation consistency and clarity:**

* Updated output column prefixes for `label_referenced_variable_metadata` and `name_referenced_variable_metadata` to use the `id` value, ensuring outputs like `$qlabel_referenced_variable_metadata_*` and `$qnam_referenced_variable_metadata_*` match the provided `id` parameter. [[1]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL783-R752) [[2]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL831-R838)
* Renamed example rule `id` values for these operators to `$qlabel_referenced_variable_metadata` and `$qnam_referenced_variable_metadata` for consistency. [[1]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL772-R728) [[2]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL820-R776)
* Clarified that metadata column names in outputs are prefixed by the string provided in `id`, and updated descriptions for both operators. [[1]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL783-R752) [[2]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL831-R838)

**Documentation organization:**

* Moved the referenced_variable_metadata sections to be under IG and Model Var operations instead of the miscategorized Define XML ops. [[1]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL702-R704) [[2]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL831-R838)
* No changes to code logic—these are documentation-only improvements for clarity and maintainability. [[1]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL702-R704) [[2]](diffhunk://#diff-942595cdbf814b4ebf4a943e94a3ae1d7ea0a195bc257a58fdb819e8e591795fL831-R838)