### PR TITLE
version

### DIFF
--- a/cdisc_rules_engine/models/operation_params.py
+++ b/cdisc_rules_engine/models/operation_params.py
@@ -58,4 +58,3 @@ class OperationParams:
     target: str = None
     value_is_reference: bool = False
     namespace: str = None
-    version: str = None

--- a/cdisc_rules_engine/operations/get_codelist_attributes.py
+++ b/cdisc_rules_engine/operations/get_codelist_attributes.py
@@ -65,7 +65,7 @@ class CodeListAttributes(BaseOperation):
         # Get controlled term attribute column name specified in rule
         ct_attribute = self.params.ct_attribute
         ct_target = self.params.target
-        ct_version = self.params.version
+        ct_version = self.params.ct_version
         ct_packages = self.params.ct_packages
         df = self.params.dataframe
         # 2.0 build codelist from cache
@@ -167,7 +167,7 @@ class CodeListAttributes(BaseOperation):
         ct_attribute = self.params.ct_attribute
 
         ct_target = self.params.target  # target variable specified in rule
-        ct_version = self.params.version  # controlled term version
+        ct_version = self.params.ct_version  # controlled term version
         if ct_attribute == "Term CCODE":
             ct_attribute = "TSVALCD"
         sel_cols = [ct_target, ct_version, ct_attribute, ct_key]

--- a/tests/unit/test_operations/test_get_codelist_attributes.py
+++ b/tests/unit/test_operations/test_get_codelist_attributes.py
@@ -467,7 +467,7 @@ def test_get_codelist_attributes(
     operation_params.standard = "sdtmig"
     operation_params.standard_version = "3-4"
     operation_params.ct_attribute = "Term CCODE"  # Changed from TSVALCD
-    operation_params.version = "TSVCDVER"
+    operation_params.ct_version = "TSVCDVER"
     operation_params.target = "TSVCDREF"
     operation_params.ct_packages = ct_packages
 


### PR DESCRIPTION
cg0288 PR broke all DDF Codelist term rules-- the issue is due to ct_version getting grabbed and not version.  I have ported get_codelist_attributes to using version instead of ct_version and restored the old attribute grab. 

this PR restores functionality while continuing to have cg0288 work.  
cg0288 report: [CORE-Report-2025-11-11T12-17-08.xlsx](https://github.com/user-attachments/files/23483270/CORE-Report-2025-11-11T12-17-08.xlsx)
ddf00142 - [CORE-Report-2025-11-11T12-19-09.xlsx](https://github.com/user-attachments/files/23483271/CORE-Report-2025-11-11T12-19-09.xlsx)


to test: run ddf rules with codelist_term / codelist_extensible operators
run cg0288 with the below updated logic:
[Rule_underscores.json](https://github.com/user-attachments/files/23483304/Rule_underscores.json)
