### PR TITLE
890: Column should consist of delimited codelists

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -1042,16 +1042,26 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def contains_all(self, other_value: dict):
         target = self.replace_prefix(other_value.get("target"))
+        value_is_literal: bool = other_value.get("value_is_literal", False)
         comparator = other_value.get("comparator")
-        if isinstance(comparator, list):
-            # get column as array of values
-            values = flatten_list(self.value, comparator)
+        if self.is_column_of_iterables(
+            self.value[target]
+        ) and self.is_column_of_iterables(self.value[comparator]):
+            comparison_data = self.get_comparator_data(comparator, value_is_literal)
+            results = []
+            for i in range(len(self.value[target])):
+                target_val = self.value[target].iloc[i]
+                comp_val = comparison_data.iloc[i]
+                results.append(all(is_in(item, comp_val) for item in target_val))
         else:
-            comparator = self.replace_prefix(comparator)
-            values = self.value[comparator].unique()
-        return self.value.convert_to_series(
-            set(values).issubset(set(self.value[target].unique()))
-        )
+            if isinstance(comparator, list):
+                # get column as array of values
+                values = flatten_list(self.value, comparator)
+            else:
+                comparator = self.replace_prefix(comparator)
+                values = self.value[comparator].unique()
+            results = set(values).issubset(set(self.value[target].unique()))
+        return self.value.convert_to_series(results)
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)

--- a/cdisc_rules_engine/models/operation_params.py
+++ b/cdisc_rules_engine/models/operation_params.py
@@ -59,3 +59,4 @@ class OperationParams:
     target: str = None
     value_is_reference: bool = False
     namespace: str = None
+    delimiter: str = None

--- a/cdisc_rules_engine/operations/operations_factory.py
+++ b/cdisc_rules_engine/operations/operations_factory.py
@@ -42,6 +42,7 @@ from cdisc_rules_engine.operations.meddra_term_references_validator import (
 from cdisc_rules_engine.operations.min_date import MinDate
 from cdisc_rules_engine.operations.minimum import Minimum
 from cdisc_rules_engine.operations.record_count import RecordCount
+from cdisc_rules_engine.operations.split_by import SplitBy
 from cdisc_rules_engine.operations.valid_external_dictionary_code import (
     ValidExternalDictionaryCode,
 )
@@ -121,6 +122,7 @@ class OperationsFactory(FactoryInterface):
         "domain_is_custom": DomainIsCustom,
         "domain_label": DomainLabel,
         "required_variables": RequiredVariables,
+        "split_by": SplitBy,
         "expected_variables": ExpectedVariables,
         "permissible_variables": PermissibleVariables,
         "study_domains": StudyDomains,

--- a/cdisc_rules_engine/operations/split_by.py
+++ b/cdisc_rules_engine/operations/split_by.py
@@ -1,0 +1,8 @@
+from cdisc_rules_engine.operations.base_operation import BaseOperation
+
+
+class SplitBy(BaseOperation):
+    def _execute_operation(self):
+        return self.params.dataframe[self.params.target].str.split(
+            self.params.delimiter
+        )

--- a/cdisc_rules_engine/utilities/rule_processor.py
+++ b/cdisc_rules_engine/utilities/rule_processor.py
@@ -423,6 +423,7 @@ class RuleProcessor:
                 term_pref_term=operation.get("term_pref_term"),
                 namespace=operation.get("namespace"),
                 value_is_reference=operation.get("value_is_reference", False),
+                delimiter=operation.get("delimiter"),
             )
 
             # execute operation


### PR DESCRIPTION
This PR adds support for https://github.com/cdisc-org/cdisc-rules-engine/issues/890.

Suggested rule:
```
Check:
  all:
    - name: $ppspec_value
      operator: not_contains_all
      value: $spec_codelist
Core:
  Id: CDISC.SENDIG.SEND282
  Status: Draft
  Version: "1"
Operations:
  - codelists:
      - SPEC
    level: term
    id: $spec_codelist
    operator: codelist_terms
    returntype: value
  - name: PPSPEC
    delimiter: ;
    id: $ppspec_value
    operator: split_by
Description: If multiple specimen types are used for a calculation (e.g., serum
  and urine for creatinine clearance), then this field should be populated with
  values from the (SPEC) Controlled Terminology codelist delimited by a
  semicolon.
Executability: Fully Executable
Outcome:
  Message: The multiple specimens are not correctly separated by a semicolon
  Output Variables:
    - $ppspec_value
    - $spec_codelist
```

core.py command:
```
validate
-s
send
-v
1-0
-l
info
-dp
unit-test-coreid-SENDIG282.json
-lr
Rule.yml
-ct
sendct-2025-09-26
```

The idea is:

1. Pull SPEC codelist values from the provided CT package (codelist_terms operation)
2. Split the target column (PPSPEC in this case) by the desired delimiter (split_by operation)
3. For every row, check that the result of step 1 contains all items from step 2. The `Check` section should be interpreted as "Find all rows where `$spec_codelist` doesn't contain all of `$ppspec_value`"