### PR TITLE
Add JSON Schema Check to Rule_Type.json

### DIFF
--- a/resources/schema/Rule_Type.json
+++ b/resources/schema/Rule_Type.json
@@ -35,6 +35,10 @@
       "title": "Content domain presence at study level"
     },
     {
+      "const": "JSON Schema Check",
+      "title": "Apply JSON schema validation to a JSON file"
+    },
+    {
       "const": "JSONata",
       "title": "Apply a JSONata query to a JSON file"
     },


### PR DESCRIPTION
This PR adds the "JSON Schema Check" rule type to Rule_Type.json so that the new rule type is not flagged as an error by the rule editor.