### PR TITLE
reorganize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Once downloaded, simply unzip the file and run the following command based on yo
 
 ## Command-line Interface
 
+**Note**: the following examples are applicable to the source code and have references to "`python core.py`". When using the executable version as described in the [Quick Start](#quick-start) above, instances of "`python cored.py`" should be replaced with "`.\core.exe`" (Windows) or "`./core`" (Linux/Mac). You can also run directly on the source code by following the [Cloning](#cloning) instructions.
+
 ### Running a validation (`validate`)
 
 Clone the repository and run `python core.py --help` to see the full list of commands.


### PR DESCRIPTION
I didn't change much documentation. I mostly moved things around, changed some formatting, and added some badges.
To preview, see here: https://github.com/cdisc-org/cdisc-rules-engine/tree/reorganize_readme

There are now 4 main sections:
- Quick start
- Command-line Interface
- Development
- Contributing

The TOC is now coherent compared to the existing:
<img width="925" height="1276" alt="image" src="https://github.com/user-attachments/assets/b0b030c6-c062-47b5-98ef-d25c935b962b" />
