### PR TITLE
fix fstring

### DIFF
--- a/cdisc_rules_engine/utilities/jsonata_processor.py
+++ b/cdisc_rules_engine/utilities/jsonata_processor.py
@@ -35,14 +35,14 @@ class JSONataProcessor:
             expr = Jsonata(full_string)
         except Exception as e:
             raise RuleFormatError(
-                f"\n  Error parsing JSONata Rule for Core Id: {rule.get("core_id")}"
+                f"\n  Error parsing JSONata Rule for Core Id: {rule.get('core_id')}"
                 f"\n  {type(e).__name__}: {e}"
             )
         try:
             results = expr.evaluate(dataset)
         except Exception as e:
             raise RuleExecutionError(
-                f"\n  Error evaluating JSONata Rule with Core Id: {rule.get("core_id")}"
+                f"\n  Error evaluating JSONata Rule with Core Id: {rule.get('core_id')}"
                 f"\n  {type(e).__name__}: {e}"
             )
         errors = defaultdict(list)


### PR DESCRIPTION
This pull request makes a minor update to error message formatting in the `execute_jsonata_rule` function. The change replaces double quotes with single quotes inside the f-string expressions to avoid syntax errors when accessing dictionary keys.

- Updated error messages in `execute_jsonata_rule` to use single quotes around dictionary keys in f-strings, improving code correctness and readability.