### PR TITLE
hotfix

### DIFF
--- a/cdisc_rules_engine/utilities/dataset_preprocessor.py
+++ b/cdisc_rules_engine/utilities/dataset_preprocessor.py
@@ -162,7 +162,9 @@ class DatasetPreprocessor:
                         right_dataset_domain_details=domain_details,
                         datasets=datasets,
                     )
-                    merged_domains.add(file_info.domain)
+                    merged_domains.add(
+                        file_info.domain if file_info.domain else file_info.name
+                    )
         return result
 
     def _find_parent_dataset(


### PR DESCRIPTION
this PR fixes the error from #1445 where merged_domains was kept track of without accounting for USDM.  We now do a check for domain and if it is not there, we use name.  As USDM does not have domain, this prevents issues with merging datasets in preprocessor
to test: 
Any of these:
   DDF00103
   DDF00093
   DDF00092
   DDF00181
   DDF00127
   DDF00094
   DDF00048
   DDF00095
<img width="2399" height="719" alt="image" src="https://github.com/user-attachments/assets/1f634ae9-a2f0-4e7a-b5db-f2911540c63d" />
<img width="1372" height="92" alt="image" src="https://github.com/user-attachments/assets/eef920cf-ce6a-4c7b-a968-2032a82fe271" />

you can see the type.decode.GeographicScope for DDF00093 on the right which is this branch now correctly merges and we get the 4 results that are expected from the rule and the test data.  Right is the current engine and does not merge properly