### PR TITLE
Add missing documentation for define_dataset_variables (Issue #1045)

### DIFF
--- a/resources/schema/MetaVariables.json
+++ b/resources/schema/MetaVariables.json
@@ -30,6 +30,9 @@
       "const": "define_dataset_structure"
     },
     {
+      "const": "define_dataset_variables"
+    },
+    {
       "const": "define_variable_allowed_terms"
     },
     {

--- a/resources/schema/MetaVariables.md
+++ b/resources/schema/MetaVariables.md
@@ -42,6 +42,10 @@ ItemGroupDef.Domain
 
 ItemGroupDef.Structure
 
+## define_dataset_variables
+
+List of ItemGroupDef.ItemRef.ItemDef.Name, ordered by XML document order (implicit ordering, not OrderNumber)
+
 ## define_variable_allowed_terms
 
 ItemGroupDef.ItemDef.CodeList.CodeListItem.Decode.TranslatedText


### PR DESCRIPTION
This PR addresses Issue #1045 by adding missing documentation for `define_dataset_variables` in the Metadata Variables section.

**Changes:**
- Added `define_dataset_variables` constant to `MetaVariables.json` for schema validation
- Added documentation entry to `MetaVariables.md` describing the variable as a list of variable names from ItemGroupDef.ItemRef elements, ordered by XML document order

The variable was already listed in `Rule_Type.md` for applicable rule types but was missing from the Metadata Variables reference documentation. This PR completes the documentation so users can find the description of what `define_dataset_variables` returns.