### PR TITLE
Autoupdate

### DIFF
--- a/.github/workflows/automated-ci.yml
+++ b/.github/workflows/automated-ci.yml
@@ -19,3 +19,5 @@ jobs:
     needs: rule_tester
     uses: ./.github/workflows/test_rule_editor_preview.yml
     secrets: inherit
+    with:
+      pr_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test_rule_editor_preview.yml
+++ b/.github/workflows/test_rule_editor_preview.yml
@@ -2,7 +2,21 @@ name: Run Tests on Preview Deployment
 
 on:
   workflow_call:
+    inputs:
+      pr_ref:
+        description: "Git reference to checkout (for PRs)"
+        required: false
+        type: string
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to test (leave empty for current branch)"
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-dev-slot
+  cancel-in-progress: false
 
 jobs:
   end_to_end_test:
@@ -11,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_ref || (inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number)) || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
- this PR resolves the e2e testing concurrency issue when multiple branches try to deploy to the same dev slot.

- https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git   When using pull_request_target, the workflow runs with access to secrets but in the base repository's context, which allows it to clone your private CORE_Test_Suite repository.  This does create a security risk but our security settings require approval to run the CI for external PRs so I believe the warnings from codeQL would not be relevant as we would screen/manually review the PR code for malicious code before running the action
