### PR TITLE
resolve double testing with CI

### DIFF
--- a/.github/workflows/automated-ci.yml
+++ b/.github/workflows/automated-ci.yml
@@ -1,16 +1,13 @@
 name: CI
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   lint_format:
     uses: ./.github/workflows/lint_format.yml
   test_unit:
     uses: ./.github/workflows/test_unit.yml
-  test_suite:
-    uses: ./.github/workflows/test_suite.yml
-    secrets: inherit
-    with:
-      pr_ref: ${{ github.event.pull_request.head.sha }}
   rule_tester:
     if: github.event.action == 'opened'
     uses: ./.github/workflows/rule-tester.yml


### PR DESCRIPTION
this PR does 2 things:
- resolve the double trigger of test suite on a PR.
- remove the test suite from the CI as I was able to get the test suite to run on external PRs the current way it is triggered outside of the CI action, but when it passes the PR head from CI to test suite, it does not have the token to get the test suite repo when it is an outside PR.