### PR TITLE
fix codelist operations type inference for empty dataframes

### DIFF
--- a/cdisc_rules_engine/operations/codelist_extensible.py
+++ b/cdisc_rules_engine/operations/codelist_extensible.py
@@ -26,6 +26,12 @@ class CodelistExtensible(BaseOperation):
             self.params.ct_package_type, unique_ct_versions
         )
         ct_df = self.evaluation_dataset.__class__.from_dict(ct_data)
+        ct_df = ct_df.astype(
+            {
+                "version": str,
+                "codelist_code": str,
+            }
+        )
         if self.params.codelist_code in self.evaluation_dataset.columns:
             is_extensible = self.evaluation_dataset.merge(
                 ct_df.data,

--- a/cdisc_rules_engine/operations/codelist_extensible.py
+++ b/cdisc_rules_engine/operations/codelist_extensible.py
@@ -28,8 +28,8 @@ class CodelistExtensible(BaseOperation):
         ct_df = self.evaluation_dataset.__class__.from_dict(ct_data)
         ct_df = ct_df.astype(
             {
-                "version": str,
-                "codelist_code": str,
+                "version": "string",
+                "codelist_code": "string",
             }
         )
         if self.params.codelist_code in self.evaluation_dataset.columns:

--- a/cdisc_rules_engine/operations/codelist_terms.py
+++ b/cdisc_rules_engine/operations/codelist_terms.py
@@ -60,8 +60,8 @@ class CodelistTerms(BaseOperation):
         ct_df = self.evaluation_dataset.__class__.from_dict(ct_data)
         ct_df = ct_df.astype(
             {
-                "version": str,
-                "codelist_code": str,
+                "version": "string",
+                "codelist_code": "string",
             }
         )
         if self.params.codelist_code in self.evaluation_dataset.columns:

--- a/cdisc_rules_engine/operations/codelist_terms.py
+++ b/cdisc_rules_engine/operations/codelist_terms.py
@@ -58,6 +58,12 @@ class CodelistTerms(BaseOperation):
             self.params.ct_package_type, unique_ct_versions
         )
         ct_df = self.evaluation_dataset.__class__.from_dict(ct_data)
+        ct_df = ct_df.astype(
+            {
+                "version": str,
+                "codelist_code": str,
+            }
+        )
         if self.params.codelist_code in self.evaluation_dataset.columns:
             result = self.evaluation_dataset.merge(
                 ct_df.data,

--- a/tests/unit/test_operations/test_codelist_extensible.py
+++ b/tests/unit/test_operations/test_codelist_extensible.py
@@ -124,32 +124,44 @@ def test_empty_metadata(operation_params):
 
 
 @mark.parametrize(
-    "package_type, codelist_code, expected",
+    "package_type, codelist_code, versions, codelist_codes, expected",
     [
         (
             "mock_package",
             "codelist_code",
+            ["v1", "v2", "v3"],
+            ["C1", "C2", "C3"],
             [True, False, None],
         ),
         (
             "mock_package",
             "C1",
+            ["v1", "v2", "v3"],
+            ["C1", "C2", "C3"],
             [True, True, True],
         ),
         (
             "missing_package",
             "codelist_code",
+            ["v1", "v2", "v3"],
+            ["C1", "C2", "C3"],
             [None, None, None],
         ),
+        ("mock_package", "codelist_code", [], [], []),
     ],
 )
 def test_multiple_versions(
-    operation_params, mock_metadata, package_type, codelist_code, expected
+    operation_params,
+    mock_metadata,
+    package_type,
+    codelist_code,
+    versions,
+    codelist_codes,
+    expected,
 ):
     operation_params.ct_package_type = package_type
     operation_params.ct_version = "version"
     operation_params.codelist_code = codelist_code
-    versions = ["v1", "v2", "v3"]
 
     library_metadata = LibraryMetadataContainer()
     for version in versions:
@@ -157,7 +169,13 @@ def test_multiple_versions(
     library_metadata._ct_package_metadata = mock_metadata
 
     evaluation_dataset = PandasDataset.from_dict(
-        {"version": versions, "codelist_code": ["C1", "C2", "C3"]}
+        {"version": versions, "codelist_code": codelist_codes}
+    )
+    evaluation_dataset = evaluation_dataset.astype(
+        {
+            "version": str,
+            "codelist_code": str,
+        }
     )
 
     operation = CodelistExtensible(

--- a/tests/unit/test_operations/test_codelist_extensible.py
+++ b/tests/unit/test_operations/test_codelist_extensible.py
@@ -173,8 +173,8 @@ def test_multiple_versions(
     )
     evaluation_dataset = evaluation_dataset.astype(
         {
-            "version": str,
-            "codelist_code": str,
+            "version": "string",
+            "codelist_code": "string",
         }
     )
 

--- a/tests/unit/test_operations/test_codelist_extensible.py
+++ b/tests/unit/test_operations/test_codelist_extensible.py
@@ -171,12 +171,6 @@ def test_multiple_versions(
     evaluation_dataset = PandasDataset.from_dict(
         {"version": versions, "codelist_code": codelist_codes}
     )
-    evaluation_dataset = evaluation_dataset.astype(
-        {
-            "version": "string",
-            "codelist_code": "string",
-        }
-    )
 
     operation = CodelistExtensible(
         operation_params,

--- a/tests/unit/test_operations/test_codelist_terms.py
+++ b/tests/unit/test_operations/test_codelist_terms.py
@@ -349,12 +349,6 @@ def test_empty_dataset_multiple_versions(
             "t_pref_term": [],
         }
     )
-    evaluation_dataset = evaluation_dataset.astype(
-        {
-            "version": "string",
-            "codelist_code": "string",
-        }
-    )
 
     operation = CodelistTerms(
         operation_params,

--- a/tests/unit/test_operations/test_codelist_terms.py
+++ b/tests/unit/test_operations/test_codelist_terms.py
@@ -323,3 +323,45 @@ def test_multiple_versions(
     except RuleExecutionError:
         result = pd.Series(RuleExecutionError)
     assert result.equals(pd.Series(expected))
+
+
+def test_empty_dataset_multiple_versions(
+    operation_params,
+    mock_metadata,
+):
+    operation_params.ct_package_type = "mock_package"
+    operation_params.ct_version = "version"
+    operation_params.codelist_code = "codelist_code"
+    operation_params.term_code = "t_code"
+    operation_params.term_value = None
+    operation_params.term_pref_term = None
+    operation_params.returntype = None
+
+    library_metadata = LibraryMetadataContainer()
+    library_metadata._ct_package_metadata = mock_metadata
+
+    evaluation_dataset = PandasDataset.from_dict(
+        {
+            "version": [],
+            "codelist_code": [],
+            "t_code": [],
+            "t_value": [],
+            "t_pref_term": [],
+        }
+    )
+    evaluation_dataset = evaluation_dataset.astype(
+        {
+            "version": str,
+            "codelist_code": str,
+        }
+    )
+
+    operation = CodelistTerms(
+        operation_params,
+        evaluation_dataset,
+        MagicMock(),
+        MagicMock(),
+        library_metadata,
+    )
+    result = operation._execute_operation()
+    assert result.tolist() == []

--- a/tests/unit/test_operations/test_codelist_terms.py
+++ b/tests/unit/test_operations/test_codelist_terms.py
@@ -351,8 +351,8 @@ def test_empty_dataset_multiple_versions(
     )
     evaluation_dataset = evaluation_dataset.astype(
         {
-            "version": str,
-            "codelist_code": str,
+            "version": "string",
+            "codelist_code": "string",
         }
     )
 


### PR DESCRIPTION
Fixes the issue for CORE-000857 with #1651. I cannot reproduce the issue for CORE-000873, CORE-000874 without the proper data.

Previously, we would get an Execution Error because the operations input dataframe is empty (after match datasets) and the column datatypes cannot be inferred.
[Broken.xlsx](https://github.com/user-attachments/files/27057714/Broken.xlsx)
Now we get a skip.
[Fixed.xlsx](https://github.com/user-attachments/files/27057713/Fixed.xlsx)


Ran with following data and launch config:
[pilot_LZZT_narrative_2026MAR10.json](https://github.com/user-attachments/files/27057835/pilot_LZZT_narrative_2026MAR10.json)
```json
{
  "name": "USDM Rule",
  "type": "debugpy",
  "request": "launch",
  "program": "${workspaceFolder}/core.py",
  "console": "integratedTerminal",
  "args": [
    "validate",
    "-s",
    "usdm",
    "-v",
    "4-0",
    "-dp",
    "pilot_LZZT_narrative_2026MAR10.json",
    "-r",
    "CORE-000857",
    "-of",
    "XLSX",
    "-of",
    "json",
    "-l",
    "debug"
  ]
}
```