### PR TITLE
update test_utils

### DIFF
--- a/tests/QARegressionTests/test_core/test_utils.py
+++ b/tests/QARegressionTests/test_core/test_utils.py
@@ -1,9 +1,13 @@
 import subprocess
 from platform import system
-from os import listdir, remove
+from os import environ, listdir, remove
 
 
 def run_command(args, shell):
+    env = environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    env["PYTHONUTF8"] = "1"
+
     try:
         completed_process = subprocess.run(
             args,
@@ -12,9 +16,8 @@ def run_command(args, shell):
             universal_newlines=True,
             check=True,
             encoding="utf8",
-            # test_test_command and windows seem to be happy with shell=True
-            # test_validate on linux needs shell=False
             shell=shell or system() == "Windows",
+            env=env,
         )
         return (
             completed_process.returncode,


### PR DESCRIPTION
Fixed Windows-specific subprocess failures in test_utils.py by setting PYTHONUNBUFFERED=1 and PYTHONUTF8=1 in the child process environment. 
- PYTHONUNBUFFERED=1 prevents the child process from holding stderr in memory and ensures it gets written out before the process ends
- PYTHONUTF8=1 ensures output is written in UTF-8 rather than the Windows system codepage (CP1252). 

Environment changes are applied to a copy of the parent environment to avoid mutation.