### PR TITLE
Replace deprecated DataFrame.applymap() with map()

### DIFF
--- a/cdisc_rules_engine/services/data_readers/dataset_json_reader.py
+++ b/cdisc_rules_engine/services/data_readers/dataset_json_reader.py
@@ -36,7 +36,7 @@ class DatasetJSONReader(DataReaderInterface):
             [item for item in datasetjson.get("rows", [])],
             columns=[item["name"] for item in datasetjson.get("columns", [])],
         )
-        return df.applymap(lambda x: round(x, 15) if isinstance(x, float) else x)
+        return df.map(lambda x: round(x, 15) if isinstance(x, float) else x)
 
     def from_file(self, file_path):
         try:

--- a/cdisc_rules_engine/services/data_readers/dataset_ndjson_reader.py
+++ b/cdisc_rules_engine/services/data_readers/dataset_ndjson_reader.py
@@ -45,7 +45,7 @@ class DatasetNDJSONReader(DataReaderInterface):
             [item for item in datandjson],
             columns=[item["name"] for item in metadatandjson.get("columns", [])],
         )
-        return df.applymap(lambda x: round(x, 15) if isinstance(x, float) else x)
+        return df.map(lambda x: round(x, 15) if isinstance(x, float) else x)
 
     def from_file(self, file_path):
         try:

--- a/cdisc_rules_engine/services/data_readers/parquet_reader.py
+++ b/cdisc_rules_engine/services/data_readers/parquet_reader.py
@@ -32,7 +32,7 @@ class ParquetReader(DataReaderInterface):
     def _format_floats(
         self, dataframe: Union[pd.DataFrame, dd.DataFrame]
     ) -> Union[pd.DataFrame, dd.DataFrame]:
-        return dataframe.applymap(lambda x: round(x, 15) if isinstance(x, float) else x)
+        return dataframe.map(lambda x: round(x, 15) if isinstance(x, float) else x)
 
     def _read_dask(self, file_path):
         data = dd.read_parquet(file_path)

--- a/cdisc_rules_engine/services/data_readers/xpt_reader.py
+++ b/cdisc_rules_engine/services/data_readers/xpt_reader.py
@@ -50,4 +50,4 @@ class XPTReader(DataReaderInterface):
         return self._read_pandas(file_path)
 
     def _format_floats(self, dataframe: pd.DataFrame) -> pd.DataFrame:
-        return dataframe.applymap(lambda x: round(x, 15) if isinstance(x, float) else x)
+        return dataframe.map(lambda x: round(x, 15) if isinstance(x, float) else x)

--- a/cdisc_rules_engine/services/data_services/dummy_data_service.py
+++ b/cdisc_rules_engine/services/data_services/dummy_data_service.py
@@ -62,7 +62,7 @@ class DummyDataService(BaseDataService):
         dataset: Optional[DummyDataset] = self.get_dataset_data(dataset_name)
         if dataset is not None:
             df: pd.DataFrame = dataset.data
-            df = df.applymap(lambda x: x.decode("utf-8") if isinstance(x, bytes) else x)
+            df = df.map(lambda x: x.decode("utf-8") if isinstance(x, bytes) else x)
             result = PandasDataset(df)
             return result
         else:


### PR DESCRIPTION
Replaces `DataFrame.applymap()` with `DataFrame.map()` across all data readers and the dummy data service. `applymap()` was deprecated in pandas 2.1.0 and removed in pandas 3.0; this change resolves 12 `FutureWarning` instances on a full run of unit tests runs (157 → 145 warnings).

Tested scenarios:
- Full pytest suite: 1745 passed, 11 skipped, 0 failed (pandas 2.3.3, dask 2025.12.0)
- Ran validation on [CDISC_Pilot_Study_v4_FIXED.json](https://github.com/cdisc-org/cdisc-jsonata-rules/blob/main/testdata/CDISC_Pilot_Study_v4_FIXED.json): 201 SUCCESS, 6 SKIPPED, 0 errors