### PR TITLE
fix: replace inplace=True mutation (pandas 3.0 CoW)

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -1497,7 +1497,7 @@ class DataframeType(BaseType):
         return df.apply(check_inconsistency, axis=1)
 
     def next_column_exists_and_previous_is_null(self, row) -> bool:
-        row.reset_index(drop=True, inplace=True)
+        row = row.reset_index(drop=True)
         for index in row[
             row.isin(NULL_FLAVORS) | pd.isna(row)
         ].index:  # leaving null values only


### PR DESCRIPTION
Replaces `row.reset_index(drop=True, inplace=True)` with `row = row.reset_index(drop=True)` in `next_column_exists_and_previous_is_null`. Pandas 3.0 enforces Copy-on-Write, which makes `inplace=True` on a row (a view of the DataFrame) silently fail instead of modifying the data. This doesn't produce warnings on pandas <3.0 but will break at runtime on pandas 3.0.

Tested scenarios:
- Full pytest suite: 1746 passed, 11 skipped, 0 failed (pandas 2.3.3, dask 2025.12.0)
- Ran validation on [CDISC_Pilot_Study_v4_FIXED.json](https://github.com/cdisc-org/cdisc-jsonata-rules/blob/main/testdata/CDISC_Pilot_Study_v4_FIXED.json): 201 SUCCESS, 6 SKIPPED, 0 errors