### PR TITLE
fix: remove unsupported dd.DataFrame type hint in parquet_reader

### DIFF
--- a/cdisc_rules_engine/services/data_readers/parquet_reader.py
+++ b/cdisc_rules_engine/services/data_readers/parquet_reader.py
@@ -1,5 +1,4 @@
 from io import BytesIO
-from typing import Union
 
 import pandas as pd
 import dask.dataframe as dd
@@ -29,9 +28,7 @@ class ParquetReader(DataReaderInterface):
             file_path
         )
 
-    def _format_floats(
-        self, dataframe: Union[pd.DataFrame, dd.DataFrame]
-    ) -> Union[pd.DataFrame, dd.DataFrame]:
+    def _format_floats(self, dataframe: pd.DataFrame) -> pd.DataFrame:
         return dataframe.map(lambda x: round(x, 15) if isinstance(x, float) else x)
 
     def _read_dask(self, file_path):


### PR DESCRIPTION
Removes the `Union[pd.DataFrame, dd.DataFrame]` type hint from `_format_floats` in parquet_reader. This method calls `.map()` which is only available on `pd.DataFrame` — it was never called with a dask DataFrame. The `Union` type hint pulls in `dd.DataFrame` which pandas 3.0 doesn't support in the same way, and the unused branch masks a type error.

Tested scenarios:
- Full pytest suite: 1746 passed, 11 skipped, 0 failed (pandas 2.3.3, dask 2025.12.0)
- Ran validation on [CDISC_Pilot_Study_v4_FIXED.json](https://github.com/cdisc-org/cdisc-jsonata-rules/blob/main/testdata/CDISC_Pilot_Study_v4_FIXED.json): 201 SUCCESS, 6 SKIPPED, 0 errors