### PR TITLE
fix: remove method= and downcast= from fillna (removed in pandas 3.0)

### DIFF
--- a/cdisc_rules_engine/models/dataset/dask_dataset.py
+++ b/cdisc_rules_engine/models/dataset/dask_dataset.py
@@ -343,16 +343,14 @@ class DaskDataset(PandasDataset):
     def fillna(
         self,
         value=None,
-        method=None,
         axis=None,
         inplace=False,
         limit=None,
-        downcast=None,
     ):
         """
         Fill NA/NaN values using the specified method.
         """
-        result = self._data.fillna(value=value, method=method, axis=axis, limit=limit)
+        result = self._data.fillna(value=value, axis=axis, limit=limit)
         if inplace:
             self._data = result
             return None

--- a/cdisc_rules_engine/models/dataset/dataset_interface.py
+++ b/cdisc_rules_engine/models/dataset/dataset_interface.py
@@ -229,11 +229,9 @@ class DatasetInterface(ABC):
     def fillna(
         self,
         value=None,
-        method=None,
         axis=None,
         inplace=False,
         limit=None,
-        downcast=None,
     ):
         """
         Fill NA/NaN values using the specified method.

--- a/cdisc_rules_engine/models/dataset/pandas_dataset.py
+++ b/cdisc_rules_engine/models/dataset/pandas_dataset.py
@@ -260,22 +260,18 @@ class PandasDataset(DatasetInterface):
     def fillna(
         self,
         value=None,
-        method=None,
         axis=None,
         inplace=False,
         limit=None,
-        downcast=None,
     ):
         """
         Fill NA/NaN values using the specified method.
         """
         result = self._data.fillna(
             value=value,
-            method=method,
             axis=axis,
             inplace=inplace,
             limit=limit,
-            downcast=downcast,
         )
         if inplace:
             return None


### PR DESCRIPTION
Removes the `method=` and `downcast=` parameters from `fillna()` in `DatasetInterface`, `PandasDataset`, and `DaskDataset`. Both parameters were deprecated in pandas 2.2.0 and removed in pandas 3.0. No callers in the codebase pass these arguments — they were only present in the method signatures.

Tested scenarios:
- Full pytest suite: 1746 passed, 11 skipped, 0 failed (pandas 2.3.3, dask 2025.12.0)
- Ran validation on [CDISC_Pilot_Study_v4_FIXED.json](https://github.com/cdisc-org/cdisc-jsonata-rules/blob/main/testdata/CDISC_Pilot_Study_v4_FIXED.json): 201 SUCCESS, 6 SKIPPED, 0 errors