### PR TITLE
fix: handle pandas 3.0 default StringDtype

### DIFF
--- a/cdisc_rules_engine/check_operators/dataframe_operators.py
+++ b/cdisc_rules_engine/check_operators/dataframe_operators.py
@@ -228,8 +228,16 @@ class DataframeType(BaseType):
             target_val = custom_str_conversion(target_val)
             comparison_val = custom_str_conversion(comparison_val)
         if case_insensitive:
-            target_val = target_val.lower() if target_val else None
-            comparison_val = comparison_val.lower() if comparison_val else None
+            target_val = (
+                target_val.lower()
+                if isinstance(target_val, str) and target_val
+                else None
+            )
+            comparison_val = (
+                comparison_val.lower()
+                if isinstance(comparison_val, str) and comparison_val
+                else None
+            )
             return target_val == comparison_val
         return target_val == comparison_val
 
@@ -275,8 +283,16 @@ class DataframeType(BaseType):
             target_val = custom_str_conversion(target_val)
             comparison_val = custom_str_conversion(comparison_val)
         if case_insensitive:
-            target_val = target_val.lower() if target_val else None
-            comparison_val = comparison_val.lower() if comparison_val else None
+            target_val = (
+                target_val.lower()
+                if isinstance(target_val, str) and target_val
+                else None
+            )
+            comparison_val = (
+                comparison_val.lower()
+                if isinstance(comparison_val, str) and comparison_val
+                else None
+            )
             return target_val != comparison_val
         return target_val != comparison_val
 
@@ -696,6 +712,12 @@ class DataframeType(BaseType):
     def is_not_contained_by_case_insensitive(self, other_value):
         return ~self.is_contained_by_case_insensitive(other_value)
 
+    @staticmethod
+    def _map_regex(series, func):
+        # pandas 3 returns nullable BooleanDtype from .map(); normalize to numpy
+        # bool so ~ and & behave identically for both positive and negated callers.
+        return series.map(func, na_action="ignore").fillna(False).astype(bool)
+
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)
     def prefix_matches_regex(self, other_value):
@@ -705,10 +727,10 @@ class DataframeType(BaseType):
         converted_strings = self.value[target].map(
             lambda x: self._regex_str_conversion(x)
         )
-        results = converted_strings.notna() & converted_strings.astype(str).map(
-            lambda x: re.search(comparator, x[:prefix]) is not None
+        return converted_strings.notna() & self._map_regex(
+            converted_strings.astype(str),
+            lambda x: re.search(comparator, x[:prefix]) is not None,
         )
-        return results
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)
@@ -719,10 +741,10 @@ class DataframeType(BaseType):
         converted_strings = self.value[target].map(
             lambda x: self._regex_str_conversion(x)
         )
-        results = converted_strings.notna() & ~converted_strings.astype(str).map(
-            lambda x: re.search(comparator, x[:prefix]) is not None
+        return converted_strings.notna() & ~self._map_regex(
+            converted_strings.astype(str),
+            lambda x: re.search(comparator, x[:prefix]) is not None,
         )
-        return results
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)
@@ -733,10 +755,10 @@ class DataframeType(BaseType):
         converted_strings = self.value[target].map(
             lambda x: self._regex_str_conversion(x)
         )
-        results = converted_strings.notna() & converted_strings.astype(str).map(
-            lambda x: re.search(comparator, x[-suffix:]) is not None
+        return converted_strings.notna() & self._map_regex(
+            converted_strings.astype(str),
+            lambda x: re.search(comparator, x[-suffix:]) is not None,
         )
-        return results
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)
@@ -747,10 +769,10 @@ class DataframeType(BaseType):
         converted_strings = self.value[target].map(
             lambda x: self._regex_str_conversion(x)
         )
-        results = converted_strings.notna() & ~converted_strings.astype(str).map(
-            lambda x: re.search(comparator, x[-suffix:]) is not None
+        return converted_strings.notna() & ~self._map_regex(
+            converted_strings.astype(str),
+            lambda x: re.search(comparator, x[-suffix:]) is not None,
         )
-        return results
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)
@@ -760,10 +782,10 @@ class DataframeType(BaseType):
         converted_strings = self.value[target].map(
             lambda x: self._regex_str_conversion(x)
         )
-        results = converted_strings.notna() & converted_strings.astype(str).str.match(
-            comparator
+        return converted_strings.notna() & self._map_regex(
+            converted_strings.astype(str),
+            lambda x: re.match(comparator, x) is not None,
         )
-        return results
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)
@@ -773,10 +795,10 @@ class DataframeType(BaseType):
         converted_strings = self.value[target].map(
             lambda x: self._regex_str_conversion(x)
         )
-        results = converted_strings.notna() & ~converted_strings.astype(str).str.match(
-            comparator
+        return converted_strings.notna() & ~self._map_regex(
+            converted_strings.astype(str),
+            lambda x: re.match(comparator, x) is not None,
         )
-        return results
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)

--- a/cdisc_rules_engine/check_operators/helpers.py
+++ b/cdisc_rules_engine/check_operators/helpers.py
@@ -56,7 +56,7 @@ class DatePrecision(IntEnum):
 
 
 def is_valid_date(date_string: str) -> bool:
-    if date_string is None or not isinstance(date_string, str):
+    if not isinstance(date_string, str):
         return False
     try:
         isoparse(date_string)

--- a/cdisc_rules_engine/operations/record_count.py
+++ b/cdisc_rules_engine/operations/record_count.py
@@ -169,7 +169,7 @@ class RecordCount(BaseOperation):
                 if self.params.dataframe[col].isna().all():
                     all_na_cols[col] = None
                 elif (
-                    self.params.dataframe[col].dtype == "object"
+                    pd.api.types.is_string_dtype(self.params.dataframe[col])
                     and self.params.dataframe[col].fillna("").str.strip().eq("").all()
                 ):
                     all_na_cols[col] = ""


### PR DESCRIPTION
Pandas 3.0 changes the default string dtype from `object` to `StringDtype`, which requires these changes:

1. Regex operators: `.map()` now returns nullable `BooleanDtype`, where `pd.NA & True` raises instead of returning `False`. Adds a `_map_regex()` helper that normalizes to numpy bool via `.fillna(False).astype(bool)`, used by all prefix/suffix/matches regex operators.

2. Case-insensitive comparisons: `.lower()` on a non-string value (e.g. `pd.NA`) raises `AttributeError`. Guards with `isinstance(target_val, str)` before calling `.lower()`.

3. Empty-column detection in record_count: checks `dtype == "object"` to identify string columns, which misses `StringDtype`. Uses `pd.api.types.is_string_dtype()` instead.

4. Date validation: simplifies the `is_valid_date` guard to `not isinstance(date_string, str)`, which already handles `None`, `pd.NA`, and any other non-string type.

Tested scenarios:
- Full pytest suite: 1746 passed, 11 skipped, 0 failed (pandas 2.3.3, dask 2025.12.0)
- Ran validation on [CDISC_Pilot_Study_v4_FIXED.json](https://github.com/cdisc-org/cdisc-jsonata-rules/blob/main/testdata/CDISC_Pilot_Study_v4_FIXED.json): 201 SUCCESS, 6 SKIPPED, 0 errors