### PR TITLE
fix: replace Dask GroupBy path in Distinct (.apply(set) fails in pandas 3.0)

### DIFF
--- a/cdisc_rules_engine/operations/distinct.py
+++ b/cdisc_rules_engine/operations/distinct.py
@@ -20,7 +20,7 @@ class Distinct(BaseOperation):
         result = self.params.dataframe
         if self.params.filter:
             result = self._filter_data(result)
-        if hasattr(result.data, 'compute'):
+        if hasattr(result.data, "compute"):
             result = PandasDataset(result.data.compute())
         value_is_reference = getattr(self.params, "value_is_reference", False)
         if not self.params.grouping:

--- a/cdisc_rules_engine/operations/distinct.py
+++ b/cdisc_rules_engine/operations/distinct.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 
 
@@ -19,6 +20,8 @@ class Distinct(BaseOperation):
         result = self.params.dataframe
         if self.params.filter:
             result = self._filter_data(result)
+        if hasattr(result.data, 'compute'):
+            result = PandasDataset(result.data.compute())
         value_is_reference = getattr(self.params, "value_is_reference", False)
         if not self.params.grouping:
             if value_is_reference:
@@ -57,17 +60,10 @@ class Distinct(BaseOperation):
                     )
 
                 result = grouped.apply(get_existing_column_names).reset_index()
-            elif isinstance(result.data, pd.DataFrame):
+            else:
                 result = grouped.data[self.params.target].agg(
                     self._unique_values_for_column
                 )
-            else:
-                result = (
-                    grouped.data[self.params.target]
-                    .unique()
-                    .rename({self.params.target: self.params.operation_id})
-                )
-                result = result.apply(list).to_frame().reset_index()
         return result
 
     def _get_referenced_datasets(self):


### PR DESCRIPTION
Pandas 3.0 changes the behavior of `.apply(set)` / `.apply(list)` on a GroupBy, returning a DataFrame instead of a Series. This breaks the Dask `else` branch in `Distinct._execute_operation`.

Instead of adding a Dask-specific code path, this materializes dask DataFrames to pandas at the top of the method, letting the existing pandas groupby/agg logic handle everything. This eliminates the Dask-specific `else` branch entirely and also resolves 11 dask GroupBy `FutureWarning` instances (145 → 134 warnings).

Tested scenarios:
- Full pytest suite: 1746 passed, 11 skipped, 0 failed (pandas 2.3.3, dask 2025.12.0)
- Ran validation on [CDISC_Pilot_Study_v4_FIXED.json](https://github.com/cdisc-org/cdisc-jsonata-rules/blob/main/testdata/CDISC_Pilot_Study_v4_FIXED.json): 201 SUCCESS, 6 SKIPPED, 0 errors