### PR TITLE
fix: normalize null types in QNAM columns after supp merge

### DIFF
--- a/cdisc_rules_engine/utilities/data_processor.py
+++ b/cdisc_rules_engine/utilities/data_processor.py
@@ -269,6 +269,9 @@ class DataProcessor:
                     )
                 )
                 DataProcessor._validate_qnam(left_dataset.data, qnam_list, common_keys)
+                for qnam in qnam_list:
+                    if qnam in left_dataset.columns:
+                        left_dataset.data[qnam] = left_dataset.data[qnam].fillna(pd.NA)
             if not is_blank:
                 left_dataset[dynamic_key] = left_dataset[temp_key]
                 left_dataset = left_dataset.drop(columns=[temp_key])


### PR DESCRIPTION
The supp pivot (`process_supp`) initializes QNAM columns with `pd.NA`, but the subsequent left join in `merge_pivot_supp_dataset` fills unmatched rows with `NaN`. This creates mixed null types (`NaN` vs `pd.NA`) in the same column. On pandas <3.0 this is invisible since both are treated identically, but on pandas 3.0 with nullable dtypes the inconsistency causes strict equality checks to fail. Adding `fillna(pd.NA)` after the merge normalizes null representation in the QNAM columns.

Tested scenarios:
- Full pytest suite: 1746 passed, 11 skipped, 0 failed (pandas 2.3.3, dask 2025.12.0)
- Full pytest suite on pandas 3.0.3: 1746 passed, 11 skipped, 0 failed (with pending PRs #1777 and #1781 applied locally)
- Ran validation on [CDISC_Pilot_Study_v4_FIXED.json](https://github.com/cdisc-org/cdisc-jsonata-rules/blob/main/testdata/CDISC_Pilot_Study_v4_FIXED.json): 201 SUCCESS, 6 SKIPPED, 0 errors