### PR TITLE
fix: reset LocalDataService singleton between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,12 @@ def run_regression_tests(request):
     return request.config.getoption("-m") == "regression"
 
 
+@pytest.fixture(autouse=True)
+def _reset_data_service_singleton():
+    yield
+    LocalDataService._instance = None
+
+
 def mock_get_dataset(dataset_name):
     dataframe_map = {
         "ae.xpt": PandasDataset.from_dict(


### PR DESCRIPTION
Several tests mutate the LocalDataService singleton (overwriting get_datasets, get_dataset, dataset_implementation, etc.) without restoring the original state. With pytest <8 the default collection order happened to run test_rules_engine.py before the mutating tests, masking the issue. Pytest 9 changed the collection order, exposing 29 test failures from stale singleton state.

This adds an autouse fixture in conftest.py that resets `LocalDataService._instance = None` after each test. This doesn't change the pytest version constraint — it just makes the test suite order-independent so pytest can be upgraded when ready.

Tested scenarios:
- Full pytest suite with pytest 7.4: 1746 passed, 11 skipped, 0 failed
- Full pytest suite with pytest 9.1.1: 1746 passed, 11 skipped, 0 failed