### PR TITLE
sort csv results by column instead of by rule output variables

### DIFF
--- a/cdisc_rules_engine/services/reporting/base_report_data.py
+++ b/cdisc_rules_engine/services/reporting/base_report_data.py
@@ -56,10 +56,16 @@ class BaseReportData(ABC):
                 processed_values.append(value)
         return processed_values
 
-    @abstractmethod
     def get_csv_rows(self) -> tuple[list[str], list[list[str]]]:
         """
-        Return (header, rows) for the CSV output format.
+        Return (header, sorted_rows) for the CSV output format.
         Each row is a list of string values matching the header columns.
+        Sorting is applied lexicographically by full column order.
         """
+        header, rows = self._get_csv_rows()
+        return header, sorted(rows, key=lambda row: tuple(row))
+
+    @abstractmethod
+    def _get_csv_rows(self) -> tuple[list[str], list[list[str]]]:
+        """Return (header, rows) before base-class sorting is applied."""
         pass

--- a/cdisc_rules_engine/services/reporting/sdtm_report_data.py
+++ b/cdisc_rules_engine/services/reporting/sdtm_report_data.py
@@ -347,7 +347,7 @@ class SDTMReportData(BaseReportData):
             )
         return errors
 
-    def get_csv_rows(self) -> tuple[list[str], list[list[str]]]:
+    def _get_csv_rows(self) -> tuple[list[str], list[list[str]]]:
         header = ["Dataset", "Record", "Variable", "Value"]
         rows = []
         for issue in self.data_sheets.get("Issue Details", []):

--- a/cdisc_rules_engine/services/reporting/usdm_report_data.py
+++ b/cdisc_rules_engine/services/reporting/usdm_report_data.py
@@ -245,7 +245,7 @@ class USDMReportData(BaseReportData):
             )
         return errors
 
-    def get_csv_rows(self) -> tuple[list[str], list[list[str]]]:
+    def _get_csv_rows(self) -> tuple[list[str], list[list[str]]]:
         header = ["path", "attribute", "value"]
         rows = []
         for issue in self.data_sheets.get("Issue Details", []):


### PR DESCRIPTION
This update makes it possible to dumb-sort the results using only the information in the existing results.csv instead of needing to refer to the rule output variables. This also makes it simpler to use github diff comparison

Action using the two updated branches run here: https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/28878144073