### PR TITLE
don't strip results values

### DIFF
--- a/cdisc_rules_engine/services/reporting/base_report_data.py
+++ b/cdisc_rules_engine/services/reporting/base_report_data.py
@@ -49,8 +49,8 @@ class BaseReportData(ABC):
             if value is None:
                 processed_values.append(null_placeholder)
                 continue
-            value = value.strip()
-            if value == "" or value.lower() == "nan":
+            stripped = value.strip()
+            if stripped == "" or stripped.lower() == "nan":
                 processed_values.append(null_placeholder)
             else:
                 processed_values.append(value)


### PR DESCRIPTION
This fixes unnecessary stripping as seen in [CORE-000019](https://github.com/cdisc-org/cdisc-open-rules/pull/60/changes#diff-f7b8a4fc6936acc0f0a2e5c8b8087c540cd85a66c65bdcac35a1724f2a46cb6d)

Error count went down here: https://github.com/cdisc-org/cdisc-rules-engine/actions/runs/28888155574
(319->315)