### PR TITLE
Fix value-level greater_than comparator (used < instead of >)

### DIFF
--- a/cdisc_rules_engine/models/define/value_level_metadata.py
+++ b/cdisc_rules_engine/models/define/value_level_metadata.py
@@ -69,7 +69,7 @@ class ValueLevelMetadata:
 
     def greater_than(self):
         def gt(dataframe):
-            return dataframe[self.item.Name] < self._convert_to_datatype(
+            return dataframe[self.item.Name] > self._convert_to_datatype(
                 self.check_values[0], dataframe[self.item.Name]
             )
 

--- a/tests/unit/test_value_level_metadata.py
+++ b/tests/unit/test_value_level_metadata.py
@@ -111,3 +111,20 @@ def test_is_not_in(data, check_values, expected_result):
     ]
     partial_function = vlm.is_not_in()
     assert partial_function(df.iloc[0]) == expected_result
+
+
+@pytest.mark.parametrize(
+    "data, check_value, expected_result",
+    [
+        ({"TEST": [3]}, "2", True),
+        ({"TEST": [2]}, "2", False),
+        ({"TEST": [1]}, "2", False),
+    ],
+)
+def test_greater_than(data, check_value, expected_result):
+    df = pandas.DataFrame.from_dict(data)
+    vlm = ValueLevelMetadata()
+    vlm.item = Mock(Name="TEST")
+    vlm.check_values = [CheckValue(_content=check_value)]
+    partial_function = vlm.greater_than()
+    assert partial_function(df.iloc[0]) == expected_result


### PR DESCRIPTION
`ValueLevelMetadata.greater_than()` returns `value < check_value` — an exact copy of `less_than()` — so Define-XML value-level where-clauses with `Comparator="GT"` select the inverse set of rows. `greater_than_or_equal_to()` already uses `>=`, so the intended direction is clear.

Repro on `main`:

```python
from unittest.mock import Mock
import pandas
from odmlib.define_2_1.model import CheckValue
from cdisc_rules_engine.models.define import ValueLevelMetadata

vlm = ValueLevelMetadata()
vlm.item = Mock(Name="TEST")
vlm.check_values = [CheckValue(_content="2")]
df = pandas.DataFrame.from_dict({"TEST": [3]})
print(vlm.greater_than()(df.iloc[0]))   # 3 > 2 -> should be True; on main prints False
```

Fix: change `<` to `>` in `greater_than()`. Added a test covering values above, at, and below the check value. One-line change plus test; no other comparator is affected.
