### PR TITLE
min max date

### DIFF
--- a/cdisc_rules_engine/check_operators/helpers.py
+++ b/cdisc_rules_engine/check_operators/helpers.py
@@ -334,6 +334,26 @@ def _truncate_by_precision(
     )
 
 
+def format_date_preserving_precision(original_str: str) -> str:
+    precision = detect_datetime_precision(original_str)
+    if precision is None:
+        return ""
+    dt = truncate_datetime_to_precision(original_str, precision)
+
+    if precision >= DatePrecision.second:
+        return dt.strftime("%Y-%m-%dT%H:%M:%S")
+    elif precision == DatePrecision.minute:
+        return dt.strftime("%Y-%m-%dT%H:%M")
+    elif precision == DatePrecision.hour:
+        return dt.strftime("%Y-%m-%dT%H")
+    elif precision == DatePrecision.day:
+        return dt.strftime("%Y-%m-%d")
+    elif precision == DatePrecision.month:
+        return dt.strftime("%Y-%m")
+    else:  # year
+        return dt.strftime("%Y")
+
+
 def _compare_with_inferred_precision(
     operator_func,
     target: str,

--- a/cdisc_rules_engine/operations/max_date.py
+++ b/cdisc_rules_engine/operations/max_date.py
@@ -23,9 +23,12 @@ class MaxDate(BaseOperation):
         group_keys = [self.params.dataframe[col] for col in grouping_cols]
         idx_of_max = data.groupby(group_keys).idxmax()
         max_dates = idx_of_max.apply(
-            lambda idx: format_date_preserving_precision(original.loc[idx])
+            lambda idx: (
+                ""
+                if pd.isna(idx)
+                else format_date_preserving_precision(original.loc[idx])
+            )
         )
-
         if len(grouping_cols) == 1:
             lookup_keys = self.evaluation_dataset[grouping_cols[0]]
         else:

--- a/cdisc_rules_engine/operations/max_date.py
+++ b/cdisc_rules_engine/operations/max_date.py
@@ -21,7 +21,9 @@ class MaxDate(BaseOperation):
             grouping_cols = [grouping_cols]
 
         group_keys = [self.params.dataframe[col] for col in grouping_cols]
-        idx_of_max = data.groupby(group_keys).idxmax()
+        idx_of_max = data.groupby(group_keys).apply(
+            lambda s: s.idxmax() if s.notna().any() else pd.NA
+        )
         max_dates = idx_of_max.apply(
             lambda idx: (
                 ""

--- a/cdisc_rules_engine/operations/max_date.py
+++ b/cdisc_rules_engine/operations/max_date.py
@@ -14,11 +14,23 @@ class MaxDate(BaseOperation):
                 result = ""
             else:
                 result = format_date(max_date)
+            return pd.Series(result, index=self.evaluation_dataset.index)
+        grouping_cols = self.params.grouping
+        if isinstance(grouping_cols, str):
+            grouping_cols = [grouping_cols]
+
+        group_keys = [self.params.dataframe[col] for col in grouping_cols]
+        max_dates = data.groupby(group_keys).max().apply(format_date)
+
+        # Build lookup: single key -> scalar dict, multi-key -> tuple-keyed dict
+        if len(grouping_cols) == 1:
+            lookup_keys = self.evaluation_dataset[grouping_cols[0]]
         else:
-            grouping_cols = self.params.grouping
-            if isinstance(grouping_cols, str):
-                grouping_cols = [grouping_cols]
-            group_keys = [self.params.dataframe[col] for col in grouping_cols]
-            max_dates = data.groupby(group_keys).transform("max")
-            result = max_dates.apply(format_date)
+            lookup_keys = pd.Series(
+                list(zip(*[self.evaluation_dataset[c] for c in grouping_cols])),
+                index=self.evaluation_dataset.index,
+            )
+
+        result = lookup_keys.map(max_dates).fillna("")
+        result.index = self.evaluation_dataset.index
         return result

--- a/cdisc_rules_engine/operations/max_date.py
+++ b/cdisc_rules_engine/operations/max_date.py
@@ -1,26 +1,24 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
+from cdisc_rules_engine.utilities.utils import format_date
 
 
 class MaxDate(BaseOperation):
     def _execute_operation(self):
+        data = pd.to_datetime(
+            self.params.dataframe[self.params.target], format="ISO8601"
+        )
         if not self.params.grouping:
-            data = pd.to_datetime(self.params.dataframe[self.params.target])
             max_date = data.max()
             if isinstance(max_date, pd._libs.tslibs.nattype.NaTType):
                 result = ""
             else:
-                result = max_date.isoformat()
+                result = format_date(max_date)
         else:
-            result = self.params.dataframe.groupby(
-                self.params.grouping, as_index=False, group_keys=False
-            ).max()
-        if isinstance(result, pd.Series):
-            result = result.apply(lambda x: x.isoformat() if pd.notna(x) else "")
-        elif isinstance(result, pd.DataFrame):
-            for col in result.columns:
-                if pd.api.types.is_datetime64_any_dtype(result[col]):
-                    result[col] = result[col].apply(
-                        lambda x: x.isoformat() if pd.notna(x) else ""
-                    )
+            grouping_cols = self.params.grouping
+            if isinstance(grouping_cols, str):
+                grouping_cols = [grouping_cols]
+            group_keys = [self.params.dataframe[col] for col in grouping_cols]
+            max_dates = data.groupby(group_keys).transform("max")
+            result = max_dates.apply(format_date)
         return result

--- a/cdisc_rules_engine/operations/max_date.py
+++ b/cdisc_rules_engine/operations/max_date.py
@@ -1,28 +1,31 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
-from cdisc_rules_engine.utilities.utils import format_date
+from cdisc_rules_engine.check_operators.helpers import format_date_preserving_precision
 
 
 class MaxDate(BaseOperation):
     def _execute_operation(self):
-        data = pd.to_datetime(
-            self.params.dataframe[self.params.target], format="ISO8601"
-        )
+        original = self.params.dataframe[self.params.target]
+        data = pd.to_datetime(original, format="ISO8601")
+
         if not self.params.grouping:
-            max_date = data.max()
-            if isinstance(max_date, pd._libs.tslibs.nattype.NaTType):
+            if data.isna().all():
                 result = ""
             else:
-                result = format_date(max_date)
+                max_idx = data.idxmax()
+                result = format_date_preserving_precision(original.loc[max_idx])
             return pd.Series(result, index=self.evaluation_dataset.index)
+
         grouping_cols = self.params.grouping
         if isinstance(grouping_cols, str):
             grouping_cols = [grouping_cols]
 
         group_keys = [self.params.dataframe[col] for col in grouping_cols]
-        max_dates = data.groupby(group_keys).max().apply(format_date)
+        idx_of_max = data.groupby(group_keys).idxmax()
+        max_dates = idx_of_max.apply(
+            lambda idx: format_date_preserving_precision(original.loc[idx])
+        )
 
-        # Build lookup: single key -> scalar dict, multi-key -> tuple-keyed dict
         if len(grouping_cols) == 1:
             lookup_keys = self.evaluation_dataset[grouping_cols[0]]
         else:

--- a/cdisc_rules_engine/operations/min_date.py
+++ b/cdisc_rules_engine/operations/min_date.py
@@ -1,18 +1,24 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
+from cdisc_rules_engine.utilities.utils import format_date
 
 
 class MinDate(BaseOperation):
     def _execute_operation(self):
+        data = pd.to_datetime(
+            self.params.dataframe[self.params.target], format="ISO8601"
+        )
         if not self.params.grouping:
-            data = pd.to_datetime(self.params.dataframe[self.params.target])
             min_date = data.min()
             if isinstance(min_date, pd._libs.tslibs.nattype.NaTType):
                 result = ""
             else:
-                result = min_date.isoformat()
+                result = format_date(min_date)
         else:
-            result = self.params.dataframe.groupby(
-                self.params.grouping, as_index=False
-            ).min()
+            grouping_cols = self.params.grouping
+            if isinstance(grouping_cols, str):
+                grouping_cols = [grouping_cols]
+            group_keys = [self.params.dataframe[col] for col in grouping_cols]
+            min_dates = data.groupby(group_keys).transform("min")
+            result = min_dates.apply(format_date)
         return result

--- a/cdisc_rules_engine/operations/min_date.py
+++ b/cdisc_rules_engine/operations/min_date.py
@@ -23,7 +23,11 @@ class MinDate(BaseOperation):
         group_keys = [self.params.dataframe[col] for col in grouping_cols]
         idx_of_min = data.groupby(group_keys).idxmin()
         min_dates = idx_of_min.apply(
-            lambda idx: format_date_preserving_precision(original.loc[idx])
+            lambda idx: (
+                ""
+                if pd.isna(idx)
+                else format_date_preserving_precision(original.loc[idx])
+            )
         )
 
         if len(grouping_cols) == 1:

--- a/cdisc_rules_engine/operations/min_date.py
+++ b/cdisc_rules_engine/operations/min_date.py
@@ -21,7 +21,9 @@ class MinDate(BaseOperation):
             grouping_cols = [grouping_cols]
 
         group_keys = [self.params.dataframe[col] for col in grouping_cols]
-        idx_of_min = data.groupby(group_keys).idxmin()
+        idx_of_min = data.groupby(group_keys).apply(
+            lambda s: s.idxmin() if s.notna().any() else pd.NA
+        )
         min_dates = idx_of_min.apply(
             lambda idx: (
                 ""

--- a/cdisc_rules_engine/operations/min_date.py
+++ b/cdisc_rules_engine/operations/min_date.py
@@ -1,19 +1,19 @@
 import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
-from cdisc_rules_engine.utilities.utils import format_date
+from cdisc_rules_engine.check_operators.helpers import format_date_preserving_precision
 
 
 class MinDate(BaseOperation):
     def _execute_operation(self):
-        data = pd.to_datetime(
-            self.params.dataframe[self.params.target], format="ISO8601"
-        )
+        original = self.params.dataframe[self.params.target]
+        data = pd.to_datetime(original, format="ISO8601")
+
         if not self.params.grouping:
-            min_date = data.min()
-            if isinstance(min_date, pd._libs.tslibs.nattype.NaTType):
+            if data.isna().all():
                 result = ""
             else:
-                result = format_date(min_date)
+                min_idx = data.idxmin()
+                result = format_date_preserving_precision(original.loc[min_idx])
             return pd.Series(result, index=self.evaluation_dataset.index)
 
         grouping_cols = self.params.grouping
@@ -21,7 +21,10 @@ class MinDate(BaseOperation):
             grouping_cols = [grouping_cols]
 
         group_keys = [self.params.dataframe[col] for col in grouping_cols]
-        min_dates = data.groupby(group_keys).min().apply(format_date)
+        idx_of_min = data.groupby(group_keys).idxmin()
+        min_dates = idx_of_min.apply(
+            lambda idx: format_date_preserving_precision(original.loc[idx])
+        )
 
         if len(grouping_cols) == 1:
             lookup_keys = self.evaluation_dataset[grouping_cols[0]]

--- a/cdisc_rules_engine/operations/min_date.py
+++ b/cdisc_rules_engine/operations/min_date.py
@@ -14,11 +14,23 @@ class MinDate(BaseOperation):
                 result = ""
             else:
                 result = format_date(min_date)
+            return pd.Series(result, index=self.evaluation_dataset.index)
+
+        grouping_cols = self.params.grouping
+        if isinstance(grouping_cols, str):
+            grouping_cols = [grouping_cols]
+
+        group_keys = [self.params.dataframe[col] for col in grouping_cols]
+        min_dates = data.groupby(group_keys).min().apply(format_date)
+
+        if len(grouping_cols) == 1:
+            lookup_keys = self.evaluation_dataset[grouping_cols[0]]
         else:
-            grouping_cols = self.params.grouping
-            if isinstance(grouping_cols, str):
-                grouping_cols = [grouping_cols]
-            group_keys = [self.params.dataframe[col] for col in grouping_cols]
-            min_dates = data.groupby(group_keys).transform("min")
-            result = min_dates.apply(format_date)
+            lookup_keys = pd.Series(
+                list(zip(*[self.evaluation_dataset[c] for c in grouping_cols])),
+                index=self.evaluation_dataset.index,
+            )
+
+        result = lookup_keys.map(min_dates).fillna("")
+        result.index = self.evaluation_dataset.index
         return result

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -414,3 +414,11 @@ def custom_str_conversion(x):
         elif isinstance(x, float):
             return f"{x:.0f}" if x.is_integer() else str(x).strip()
     return x
+
+
+def format_date(d):
+    if pd.isna(d):
+        return ""
+    if d.hour == 0 and d.minute == 0 and d.second == 0 and d.microsecond == 0:
+        return d.strftime("%Y-%m-%d")
+    return d.isoformat()

--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -414,11 +414,3 @@ def custom_str_conversion(x):
         elif isinstance(x, float):
             return f"{x:.0f}" if x.is_integer() else str(x).strip()
     return x
-
-
-def format_date(d):
-    if pd.isna(d):
-        return ""
-    if d.hour == 0 and d.minute == 0 and d.second == 0 and d.microsecond == 0:
-        return d.strftime("%Y-%m-%d")
-    return d.isoformat()

--- a/tests/unit/test_operations/test_max_date.py
+++ b/tests/unit/test_operations/test_max_date.py
@@ -93,6 +93,88 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
             DaskDataset,
             ["USUBJID"],
         ),
+        (
+            {
+                "dates": [
+                    "2025-10-10",
+                    "2025-10-15",
+                    "2025-12-02",
+                    "2025-12-11",
+                    "",
+                    "",
+                ],
+                "USUBJID": ["00002", "00002", "00003", "00003", "00004", "00004"],
+            },
+            PandasDataset.from_records(
+                [
+                    {
+                        "dates": "2025-10-10",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-15",
+                    },
+                    {
+                        "dates": "2025-10-15",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-15",
+                    },
+                    {
+                        "dates": "2025-12-02",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-11",
+                    },
+                    {
+                        "dates": "2025-12-11",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-11",
+                    },
+                    {"dates": "", "USUBJID": "00004", "operation_id": ""},
+                    {"dates": "", "USUBJID": "00004", "operation_id": ""},
+                ]
+            ),
+            PandasDataset,
+            ["USUBJID"],
+        ),
+        (
+            {
+                "dates": [
+                    "2025-10-10",
+                    "2025-10-15",
+                    "2025-12-02",
+                    "2025-12-11",
+                    "",
+                    "",
+                ],
+                "USUBJID": ["00002", "00002", "00003", "00003", "00004", "00004"],
+            },
+            DaskDataset.from_records(
+                [
+                    {
+                        "dates": "2025-10-10",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-15",
+                    },
+                    {
+                        "dates": "2025-10-15",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-15",
+                    },
+                    {
+                        "dates": "2025-12-02",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-11",
+                    },
+                    {
+                        "dates": "2025-12-11",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-11",
+                    },
+                    {"dates": "", "USUBJID": "00004", "operation_id": ""},
+                    {"dates": "", "USUBJID": "00004", "operation_id": ""},
+                ]
+            ),
+            DaskDataset,
+            ["USUBJID"],
+        ),
     ],
 )
 def test_max_date(

--- a/tests/unit/test_operations/test_max_date.py
+++ b/tests/unit/test_operations/test_max_date.py
@@ -3,8 +3,7 @@ from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.max_date import MaxDate
 from cdisc_rules_engine.models.operation_params import OperationParams
-from cdisc_rules_engine.utilities.utils import format_date
-import pandas as pd
+from cdisc_rules_engine.check_operators.helpers import format_date_preserving_precision
 import pytest
 
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
@@ -18,14 +17,14 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
     [
         (
             {"dates": ["2001-01-01", "", "2022-01-05"]},
-            format_date(pd.to_datetime("2022-01-05")),
+            format_date_preserving_precision("2022-01-05"),
             PandasDataset,
             None,
         ),
         ({"dates": [None, None]}, "", PandasDataset, None),
         (
             {"dates": ["2001-01-01", "", "2022-01-05"]},
-            format_date(pd.to_datetime("2022-01-05")),
+            format_date_preserving_precision("2022-01-05"),
             DaskDataset,
             None,
         ),

--- a/tests/unit/test_operations/test_max_date.py
+++ b/tests/unit/test_operations/test_max_date.py
@@ -3,6 +3,7 @@ from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.max_date import MaxDate
 from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.utilities.utils import format_date
 import pandas as pd
 import pytest
 
@@ -17,14 +18,14 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
     [
         (
             {"dates": ["2001-01-01", "", "2022-01-05"]},
-            pd.to_datetime("2022-01-05").isoformat(),
+            format_date(pd.to_datetime("2022-01-05")),
             PandasDataset,
             None,
         ),
         ({"dates": [None, None]}, "", PandasDataset, None),
         (
             {"dates": ["2001-01-01", "", "2022-01-05"]},
-            pd.to_datetime("2022-01-05").isoformat(),
+            format_date(pd.to_datetime("2022-01-05")),
             DaskDataset,
             None,
         ),

--- a/tests/unit/test_operations/test_min_date.py
+++ b/tests/unit/test_operations/test_min_date.py
@@ -3,6 +3,7 @@ from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.min_date import MinDate
 from cdisc_rules_engine.models.operation_params import OperationParams
+from cdisc_rules_engine.utilities.utils import format_date
 import pandas as pd
 import pytest
 
@@ -13,31 +14,110 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
 
 
 @pytest.mark.parametrize(
-    "data, expected, dataset_type",
+    "data, expected, dataset_type, grouping",
     [
         (
             {"dates": ["2001-01-01", "", "2022-01-01"]},
-            pd.to_datetime("2001-01-01").isoformat(),
+            format_date(pd.to_datetime("2001-01-01")),
             DaskDataset,
+            None,
         ),
-        ({"dates": [None, None]}, "", DaskDataset),
+        ({"dates": [None, None]}, "", DaskDataset, None),
         (
             {"dates": ["2001-01-01", "", "2022-01-01"]},
-            pd.to_datetime("2001-01-01").isoformat(),
+            format_date(pd.to_datetime("2001-01-01")),
             PandasDataset,
+            None,
         ),
-        ({"dates": [None, None]}, "", PandasDataset),
+        ({"dates": [None, None]}, "", PandasDataset, None),
+        (
+            {
+                "dates": ["2025-10-10", "2025-10-15", "2025-12-02", "2025-12-11"],
+                "USUBJID": ["00002", "00002", "00003", "00003"],
+            },
+            PandasDataset.from_records(
+                [
+                    {
+                        "dates": "2025-10-10",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-10",
+                    },
+                    {
+                        "dates": "2025-10-15",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-10",
+                    },
+                    {
+                        "dates": "2025-12-02",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-02",
+                    },
+                    {
+                        "dates": "2025-12-11",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-02",
+                    },
+                ]
+            ),
+            PandasDataset,
+            ["USUBJID"],
+        ),
+        (
+            {
+                "dates": ["2025-10-10", "2025-10-15", "2025-12-02", "2025-12-11"],
+                "USUBJID": ["00002", "00002", "00003", "00003"],
+            },
+            DaskDataset.from_records(
+                [
+                    {
+                        "dates": "2025-10-10",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-10",
+                    },
+                    {
+                        "dates": "2025-10-15",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-10",
+                    },
+                    {
+                        "dates": "2025-12-02",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-02",
+                    },
+                    {
+                        "dates": "2025-12-11",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-02",
+                    },
+                ]
+            ),
+            DaskDataset,
+            ["USUBJID"],
+        ),
     ],
 )
-def test_minimum(data, expected, operation_params: OperationParams, dataset_type):
+def test_minimum(
+    data,
+    expected,
+    dataset_type,
+    grouping: str | None,
+    operation_params: OperationParams,
+):
     config = ConfigService()
     cache = CacheServiceFactory(config).get_cache_service()
     data_service = DataServiceFactory(config, cache).get_data_service()
     operation_params.dataframe = dataset_type.from_dict(data)
     operation_params.target = "dates"
+    operation_params.grouping = grouping
     result = MinDate(
         operation_params, dataset_type.from_dict(data), cache, data_service
     ).execute()
     assert operation_params.operation_id in result
-    for val in result[operation_params.operation_id]:
-        assert val == expected
+
+    if isinstance(expected, PandasDataset) and dataset_type is PandasDataset:
+        assert result.data.equals(expected.data)
+    elif isinstance(expected, DaskDataset) and dataset_type is DaskDataset:
+        assert expected.equals(result)
+    else:
+        for val in result[operation_params.operation_id]:
+            assert val == expected

--- a/tests/unit/test_operations/test_min_date.py
+++ b/tests/unit/test_operations/test_min_date.py
@@ -3,8 +3,7 @@ from cdisc_rules_engine.models.dataset.dask_dataset import DaskDataset
 from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.min_date import MinDate
 from cdisc_rules_engine.models.operation_params import OperationParams
-from cdisc_rules_engine.utilities.utils import format_date
-import pandas as pd
+from cdisc_rules_engine.check_operators.helpers import format_date_preserving_precision
 import pytest
 
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
@@ -18,14 +17,14 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
     [
         (
             {"dates": ["2001-01-01", "", "2022-01-01"]},
-            format_date(pd.to_datetime("2001-01-01")),
+            format_date_preserving_precision("2001-01-01"),
             DaskDataset,
             None,
         ),
         ({"dates": [None, None]}, "", DaskDataset, None),
         (
             {"dates": ["2001-01-01", "", "2022-01-01"]},
-            format_date(pd.to_datetime("2001-01-01")),
+            format_date_preserving_precision("2001-01-01"),
             PandasDataset,
             None,
         ),

--- a/tests/unit/test_operations/test_min_date.py
+++ b/tests/unit/test_operations/test_min_date.py
@@ -93,6 +93,88 @@ from cdisc_rules_engine.services.data_services.data_service_factory import (
             DaskDataset,
             ["USUBJID"],
         ),
+        (
+            {
+                "dates": [
+                    "2025-10-10",
+                    "2025-10-15",
+                    "2025-12-02",
+                    "2025-12-11",
+                    "",
+                    "",
+                ],
+                "USUBJID": ["00002", "00002", "00003", "00003", "00004", "00004"],
+            },
+            PandasDataset.from_records(
+                [
+                    {
+                        "dates": "2025-10-10",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-10",
+                    },
+                    {
+                        "dates": "2025-10-15",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-10",
+                    },
+                    {
+                        "dates": "2025-12-02",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-02",
+                    },
+                    {
+                        "dates": "2025-12-11",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-02",
+                    },
+                    {"dates": "", "USUBJID": "00004", "operation_id": ""},
+                    {"dates": "", "USUBJID": "00004", "operation_id": ""},
+                ]
+            ),
+            PandasDataset,
+            ["USUBJID"],
+        ),
+        (
+            {
+                "dates": [
+                    "2025-10-10",
+                    "2025-10-15",
+                    "2025-12-02",
+                    "2025-12-11",
+                    "",
+                    "",
+                ],
+                "USUBJID": ["00002", "00002", "00003", "00003", "00004", "00004"],
+            },
+            DaskDataset.from_records(
+                [
+                    {
+                        "dates": "2025-10-10",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-10",
+                    },
+                    {
+                        "dates": "2025-10-15",
+                        "USUBJID": "00002",
+                        "operation_id": "2025-10-10",
+                    },
+                    {
+                        "dates": "2025-12-02",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-02",
+                    },
+                    {
+                        "dates": "2025-12-11",
+                        "USUBJID": "00003",
+                        "operation_id": "2025-12-02",
+                    },
+                    {"dates": "", "USUBJID": "00004", "operation_id": ""},
+                    {"dates": "", "USUBJID": "00004", "operation_id": ""},
+                ]
+            ),
+            DaskDataset,
+            ["USUBJID"],
+        ),
     ],
 )
 def test_minimum(


### PR DESCRIPTION
this PR works to fix the issues encountered in open rules with CORE-000238 and CORE-000370 (note 238 has bad data for negative 02 which I resolved in another PR as well as negative 1 having incorrect results).  CORE-000178 in deprecated also checks these operators.

this PR does a few things: 
- Fixes min_date/max_date grouped aggregation — previously .groupby(grouping).min()/.max() was called directly on the raw dataframe, which aggregated across all columns instead of just the target column, and would crash on mixed-type groups (e.g., blank cells parsed as float('nan') alongside string dates). The new logic now converts the target column to datetime first, groups only that column, and uses .transform() instead of just .min()/.max() so the per-subject result broadcasts back to every row with the correct index alignment (previously produced all NaT).

- Fixed date parsing for mixed-precision and malformed values — added format="ISO8601" to correctly parse date/time values with varying precision

- Fixes output formatting to preserve date precision — added format_date utility used by both date operations, which only appends a time component when one actually exists. Timestamp.isoformat() always added T00:00:00 even for date-only values, causing detect_datetime_precision mismatches that made date_not_equal_to/equal_to comparisons return incorrect results regardless of the actual dates.

- adds logic to match on grouping--so when the max_date is grouped on USUBJID for a target dataset, it will then attach the value to corresponding USUBJID in the dataframe the operation is being added to.

fixed stale tests, added a grouping case to the min_date test