### PR TITLE
changes

### DIFF
--- a/cdisc_rules_engine/operations/base_operation.py
+++ b/cdisc_rules_engine/operations/base_operation.py
@@ -212,6 +212,9 @@ class BaseOperation:
         for item in grouping_list:
             if item in self.evaluation_dataset.columns:
                 operation_col = self.evaluation_dataset[item]
+                if operation_col.empty:
+                    expanded.append(item)
+                    continue
                 first_val = operation_col.iloc[0]
                 if (
                     isinstance(first_val, (list, tuple))

--- a/cdisc_rules_engine/operations/distinct.py
+++ b/cdisc_rules_engine/operations/distinct.py
@@ -2,9 +2,11 @@ import pandas as pd
 from cdisc_rules_engine.operations.base_operation import BaseOperation
 
 
-def _check_column_exists_in_dataset(row, target_col_name, referenced_datasets):
+def _check_column_exists_in_dataset(
+    row, target_col_name, referenced_domain_col, referenced_datasets
+):
     col_name = row[target_col_name]
-    referenced_domain = row.get("RDOMAIN")
+    referenced_domain = row.get(referenced_domain_col)
     if referenced_domain not in referenced_datasets:
         return None
     referenced_dataset = referenced_datasets[referenced_domain]
@@ -24,13 +26,16 @@ class Distinct(BaseOperation):
         if self.params.filter:
             result = self._filter_data(result)
         value_is_reference = getattr(self.params, "value_is_reference", False)
+        referenced_domain_col = getattr(
+            self.params, "referenced_domain_variable", "RDOMAIN"
+        )
         if not self.params.grouping:
             if value_is_reference:
                 target = self.params.target
                 referenced_datasets = self._get_referenced_datasets()
                 data = result.apply(
                     lambda row: _check_column_exists_in_dataset(
-                        row, target, referenced_datasets
+                        row, target, referenced_domain_col, referenced_datasets
                     ),
                     axis=1,
                 )
@@ -41,37 +46,56 @@ class Distinct(BaseOperation):
                 data = data.astype(str)
             result = list(data)
         else:
-            grouped = result.groupby(
-                self.params.grouping, as_index=False, group_keys=False
-            )
             if value_is_reference:
                 target = self.params.target
                 operation_id = self.params.operation_id
                 referenced_datasets = self._get_referenced_datasets()
 
-                def get_existing_column_names(group):
-                    values = group.apply(
-                        lambda row: _check_column_exists_in_dataset(
-                            row, target, referenced_datasets
-                        ),
-                        axis=1,
-                    )
-                    return pd.Series(
-                        {operation_id: list(values.dropna().sort_index().unique())}
+                if len(result.data) == 0:
+                    result = self._build_empty_grouped_result(result, operation_id)
+                else:
+                    grouped = result.groupby(
+                        self.params.grouping, as_index=False, group_keys=False
                     )
 
-                result = grouped.apply(get_existing_column_names).reset_index()
+                    def get_existing_column_names(group):
+                        values = group.apply(
+                            lambda row: _check_column_exists_in_dataset(
+                                row,
+                                target,
+                                referenced_domain_col,
+                                referenced_datasets,
+                            ),
+                            axis=1,
+                        )
+                        return pd.Series(
+                            {operation_id: list(values.dropna().sort_index().unique())}
+                        )
+
+                    result = grouped.apply(get_existing_column_names).reset_index()
             else:
-                result = (
-                    result.drop_duplicates(
-                        subset=self.params.grouping + [self.params.target]
+                if len(result.data) == 0:
+                    result = self._build_empty_grouped_result(
+                        result, self.params.target
                     )
-                    .groupby(self.params.grouping, as_index=False, group_keys=False)
-                    .data[self.params.target]
-                    .apply(_apply_dropna_list)
-                    .reset_index()
-                )
+                else:
+                    result = (
+                        result.drop_duplicates(
+                            subset=self.params.grouping + [self.params.target]
+                        )
+                        .groupby(self.params.grouping, as_index=False, group_keys=False)
+                        .data[self.params.target]
+                        .apply(_apply_dropna_list)
+                        .reset_index()
+                    )
         return result
+
+    def _build_empty_grouped_result(self, result, value_column_name):
+        empty_df = (
+            result.data[self.params.grouping].drop_duplicates().reset_index(drop=True)
+        )
+        empty_df[value_column_name] = pd.Series(dtype=object)
+        return empty_df
 
     def _get_referenced_datasets(self):
         referenced_datasets = {}

--- a/tests/unit/test_operations/test_distinct.py
+++ b/tests/unit/test_operations/test_distinct.py
@@ -4,6 +4,7 @@ from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
 from cdisc_rules_engine.operations.distinct import Distinct
 from cdisc_rules_engine.models.operation_params import OperationParams
 
+import pandas as pd
 import pytest
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
 from cdisc_rules_engine.services.data_services.data_service_factory import (
@@ -334,4 +335,66 @@ def test_grouped_distinct_value_is_reference(
             sorted(actual_val) == sorted(expected_val)
             if expected_val is not None
             else actual_val == expected_val
+        )
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        PandasDataset.from_dict({"values": [], "patient": []}),
+        DaskDataset.from_dict({"values": [], "patient": []}),
+    ],
+)
+def test_grouped_distinct_empty_dataset(data, operation_params: OperationParams):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    operation_params.dataframe = data
+    operation_params.target = "values"
+    operation_params.grouping = ["patient"]
+    operation_params.grouping_aliases = None
+    result = Distinct(operation_params, data, cache, data_service).execute()
+    assert operation_params.operation_id in result
+    assert "patient" in result
+    assert len(result) == 0
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        PandasDataset.from_dict(
+            {
+                "values": [11, 12, 12, 5, 18, 9],
+                "patient": [1, 2, 2, 1, 2, 1],
+                "cat": [1, 1, 1, 1, 1, 1],
+            }
+        ),
+        DaskDataset.from_dict(
+            {
+                "values": [11, 12, 12, 5, 18, 9],
+                "patient": [1, 2, 2, 1, 2, 1],
+                "cat": [1, 1, 1, 1, 1, 1],
+            }
+        ),
+    ],
+)
+def test_filtered_grouped_distinct_zero_row_result(
+    data, operation_params: OperationParams
+):
+    config = ConfigService()
+    cache = CacheServiceFactory(config).get_cache_service()
+    data_service = DataServiceFactory(config, cache).get_data_service()
+    operation_params.dataframe = data
+    operation_params.target = "values"
+    operation_params.filter = {"cat": 999}
+    operation_params.grouping = ["patient"]
+    operation_params.grouping_aliases = None
+    result = Distinct(operation_params, data, cache, data_service).execute()
+    assert operation_params.operation_id in result
+    assert "patient" in result
+    assert len(result) == len(data)
+    for _, val in result.iterrows():
+        assert val[operation_params.operation_id] is None or (
+            isinstance(val[operation_params.operation_id], float)
+            and pd.isna(val[operation_params.operation_id])
         )


### PR DESCRIPTION
This pull request improves the robustness and correctness of the `Distinct` operation, especially in handling empty datasets and grouped operations. It also adds comprehensive unit tests to cover these scenarios. The main changes are as follows:

### Enhanced Handling of Empty Datasets in Grouped Operations

* The `Distinct` operation now correctly returns an empty grouped result with the appropriate columns when the input dataset is empty or when a filter produces zero rows, instead of failing or returning incorrect results. This is achieved by adding the `_build_empty_grouped_result` helper method and updating the execution logic to use it as needed. [[1]](diffhunk://#diff-ce2092de5cc87f43f1f577740e3f54c800b01b134fd43de0511db192669a974fL44-R67) [[2]](diffhunk://#diff-ce2092de5cc87f43f1f577740e3f54c800b01b134fd43de0511db192669a974fR76-R80) [[3]](diffhunk://#diff-ce2092de5cc87f43f1f577740e3f54c800b01b134fd43de0511db192669a974fR93-R99)

### Improved Reference Column Handling

* The `_check_column_exists_in_dataset` function and its usage were updated to allow the referenced domain column name to be configurable (defaulting to `"RDOMAIN"`), increasing flexibility for different dataset schemas. [[1]](diffhunk://#diff-ce2092de5cc87f43f1f577740e3f54c800b01b134fd43de0511db192669a974fL5-R9) [[2]](diffhunk://#diff-ce2092de5cc87f43f1f577740e3f54c800b01b134fd43de0511db192669a974fR29-R38) [[3]](diffhunk://#diff-ce2092de5cc87f43f1f577740e3f54c800b01b134fd43de0511db192669a974fL44-R67)

### Bug Fix in Result Expansion

* Fixed a bug in `_expand_operation_results_in_grouping` to handle the case when an operation column is empty, preventing errors during result expansion.

### Testing Improvements

* Added new parameterized unit tests to verify correct behavior of the `Distinct` operation for both empty datasets and filtered grouped results that yield zero rows, for both Pandas and Dask backends.

### Test Infrastructure

* Added missing `pandas` import in the test file to support new test cases.

PR addresses attached issue.  I updated SCheduleDecisionInstance in the test data for core-000804 to test;
```
parent_entity,parent_id,parent_rel,rel_type,id,name,description,label,defaultConditionId,epochId,timelineId,timelineExitId,instanceType,conditionAssignments
ScheduleTimeline,ScheduleTimeline_4,instances,definition,ScheduledDecisionInstance_1,Meet requirements for WK6 or end,,,ScheduledActivityInstance_27,,,,ScheduledDecisionInstance,true
ScheduleTimeline,ScheduleTimeline_4,entryId,reference,ScheduledDecisionInstance_1,Meet requirements for WK6 or end,,,ScheduledActivityInstance_27,,,,ScheduledDecisionInstance,true
```
this produces a scheduledesicioninstance with no timing instance

worth noting: conditionAssignments is cast as a bool and the current data in the repo is not able to be cast as such since it is a string

I also tested CORE-000712 given it's distinct-specific operation logic