### PR TITLE
Raise MissingDataError on malformed LOINC row instead of returning it

### DIFF
--- a/cdisc_rules_engine/models/dictionaries/loinc/loinc_terms_factory.py
+++ b/cdisc_rules_engine/models/dictionaries/loinc/loinc_terms_factory.py
@@ -44,7 +44,7 @@ class LoincTermsFactory(TermsFactoryInterface):
                     text_line = decode_line(bytes_line)
                     values = next(csv.reader(StringIO(text_line)))
                     if len(values) < 9:
-                        return MissingDataError(
+                        raise MissingDataError(
                             message="Loinc term found without required fields provided"
                         )
                     term = LoincTerm(

--- a/tests/unit/test_dictionaries/test_loinc/test_loinc_terms_factory.py
+++ b/tests/unit/test_dictionaries/test_loinc/test_loinc_terms_factory.py
@@ -1,6 +1,10 @@
+import io
 import os
 from unittest.mock import MagicMock
 
+import pytest
+
+from cdisc_rules_engine.exceptions.custom_exceptions import MissingDataError
 from cdisc_rules_engine.models.dictionaries import DictionaryTypes, AbstractTermsFactory
 from cdisc_rules_engine.services.data_services.local_data_service import (
     LocalDataService,
@@ -21,3 +25,18 @@ def test_install():
     expected = ["100000-9", "100001-7", "100002-5"]
     for i, code in enumerate(dictionary):
         assert code == expected[i]
+
+
+def test_install_raises_on_row_with_missing_fields():
+    """A Loinc.csv data row with fewer than 9 fields must raise MissingDataError,
+    not return the exception object (which callers store as the dictionary)."""
+    data_service = MagicMock()
+    data_service.has_all_files.return_value = True
+    data_service.read_data.return_value = io.BytesIO(
+        b"NUM,COMP,PROP,TIME,SYS,SCALE,METHOD,CLASS,VER\n100000-9,short\n"
+    )
+    factory = AbstractTermsFactory(data_service).get_service(
+        DictionaryTypes.LOINC.value
+    )
+    with pytest.raises(MissingDataError):
+        factory.install_terms("some/path")


### PR DESCRIPTION
`LoincTermsFactory.install_terms` **returns** a `MissingDataError` when a `Loinc.csv` data row has fewer than 9 fields, instead of **raising** it:

```python
if len(values) < 9:
    return MissingDataError(message="Loinc term found without required fields provided")
```

So the caller (`get_term_dictionary`) stores the exception *instance* in place of the `ExternalDictionary` and caches it; a later `code in term_dictionary` check then fails with an opaque `TypeError: argument of type 'MissingDataError' is not iterable`, far from the actual cause (a malformed dictionary file — e.g. a truncated row or a trailing blank line).

Fix: `raise` it instead of returning it — consistent with the missing-file branch a few lines above in the same method, which already `raise`s the same exception. Added a test (the short-row path had no coverage).
